### PR TITLE
[Feat] 뉴스기사,관심사연결,조회 Entity 설계

### DIFF
--- a/src/main/java/com/springboot/monew/newsarticles/entity/ArticleInterest.java
+++ b/src/main/java/com/springboot/monew/newsarticles/entity/ArticleInterest.java
@@ -1,0 +1,51 @@
+package com.springboot.monew.newsarticles.entity;
+
+import com.springboot.monew.base.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+//뉴스기사 - 관심사 연결 테이블
+//관심사에 해당하는 뉴스기사가 무엇인지 파악.
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(
+        name = "article_interests",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "UK_ARTICLE_INTERESTS_ARTICLE_INTEREST",
+                        columnNames = {"news_article_id", "interest_id"}
+                )
+        }
+)
+public class ArticleInterest extends BaseEntity {
+
+    // 관심사 N : 뉴스기사 1
+    // 지연로딩: 지금 당장 필요 없으니까 나중에 진짜 쓸때 가져옴.
+    // optional = false : 필수관계(NOT NULL)
+    @ManyToOne(fetch = FetchType.LAZY,  optional = false)   //뉴스기사 1 관심사 N
+    @JoinColumn(
+            name = "news_article_id",
+            nullable = false,
+            foreignKey = @ForeignKey(name = "FK_ARTICLE_INTERESTS_NEWS_ARTICLE")
+    )
+    private NewsArticle newsArticle;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(
+            name = "interest_id",
+            nullable = false,
+            foreignKey = @ForeignKey(name = "FK_ARTICLE_INTERESTS_INTEREST")
+    )
+    private Interests interest;
+
+    public ArticleInterest(NewsArticle newsArticles, Interests interest) {
+        this.newsArticle = newsArticles;
+        this.interest = interest;
+    }
+
+
+
+
+}

--- a/src/main/java/com/springboot/monew/newsarticles/entity/ArticleView.java
+++ b/src/main/java/com/springboot/monew/newsarticles/entity/ArticleView.java
@@ -1,0 +1,45 @@
+package com.springboot.monew.newsarticles.entity;
+
+import com.springboot.monew.base.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+//사용자:뉴스기사 연결 테이블
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(
+        name = "article_views",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "UK_ARTICLE_VIEWS_ARTICLE_USER",
+                        columnNames = {"news_article_id", "user_id"}
+                )
+        }
+)
+public class ArticleView extends BaseEntity {
+
+    // 사용자 N : 뉴스기사 1
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(
+            name = "news_article_id",
+            nullable = false,
+            foreignKey = @ForeignKey(name = "FK_ARTICLE_VIEWS_NEWS_ARTICLE")
+    )
+    private NewsArticle newsArticle;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(
+            name = "user_id",
+            nullable = false,
+            foreignKey = @ForeignKey(name = "FK_ARTICLE_VIEWS_USER")
+    )
+    private Users user;
+
+    public ArticleView(NewsArticle newsArticle, Users user) {
+        this.newsArticle = newsArticle;
+        this.user = user;
+    }
+
+}

--- a/src/main/java/com/springboot/monew/newsarticles/entity/NewsArticle.java
+++ b/src/main/java/com/springboot/monew/newsarticles/entity/NewsArticle.java
@@ -14,7 +14,7 @@ import java.util.UUID;
         uniqueConstraints = {
                 @UniqueConstraint(name = "UK_NEWS_ARTICLES_ORIGINAL_LINK", columnNames = "original_link")
         })
-public class NewsArticles {
+public class NewsArticle {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
@@ -41,7 +41,7 @@ public class NewsArticles {
     @Column(name = "is_deleted", nullable = false)
     private boolean isDeleted = false;
 
-    public NewsArticles(String source, String originalLink, String title, Instant publishedAt, String summary) {
+    public NewsArticle(String source, String originalLink, String title, Instant publishedAt, String summary) {
         this.source = source;
         this.originalLink = originalLink;
         this.title = title;

--- a/src/main/java/com/springboot/monew/newsarticles/entity/NewsArticle.java
+++ b/src/main/java/com/springboot/monew/newsarticles/entity/NewsArticle.java
@@ -13,7 +13,8 @@ import java.util.UUID;
 @Table(name = "news_articles",
         uniqueConstraints = {
                 @UniqueConstraint(name = "UK_NEWS_ARTICLES_ORIGINAL_LINK", columnNames = "original_link")
-        })
+        }
+)
 public class NewsArticle {
 
     @Id

--- a/src/main/java/com/springboot/monew/newsarticles/entity/NewsArticles.java
+++ b/src/main/java/com/springboot/monew/newsarticles/entity/NewsArticles.java
@@ -1,0 +1,64 @@
+package com.springboot.monew.newsarticles.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Getter
+@NoArgsConstructor //기본 생성자
+@Table(name = "news_articles",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "UK_NEWS_ARTICLES_ORIGINAL_LINK", columnNames = "original_link")
+        })
+public class NewsArticles {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false, length = 100)
+    private String source;
+
+    @Column(name = "original_link", nullable = false, length = 500)
+    private String originalLink;
+
+    @Column(nullable = false, length = 300)
+    private String title;
+
+    @Column(name = "published_at", nullable = false)
+    private Instant publishedAt;
+
+    @Column(nullable = false, columnDefinition = "TEXT")    //JPA가 테이블 생성할때 해당 컬럼을 DB의 TEXT 타입으로 지정하라.
+    private String summary;
+
+    @Column(name = "view_count", nullable = false)
+    private int viewCount = 0;
+
+    @Column(name = "is_deleted", nullable = false)
+    private boolean isDeleted = false;
+
+    public NewsArticles(String source, String originalLink, String title, Instant publishedAt, String summary) {
+        this.source = source;
+        this.originalLink = originalLink;
+        this.title = title;
+        this.publishedAt = publishedAt;
+        this.summary = summary;
+        this.viewCount = 0;
+        this.isDeleted = false;
+    }
+
+//    // ===== 비즈니스 로직 =====
+//    public void increaseViewCount() {
+//        this.viewCount++;
+//    }
+//
+//    public void delete() {
+//        this.isDeleted = true;
+//    }
+
+
+}


### PR DESCRIPTION
## 📌 해당 이슈카드
Closes #5, #157, #158

## 📌 작업 내용
- NewsArticle,ArticleView,ArticleInterest Entiy 설계

## 🔧 변경 사항
- NewsArticle 설계
- ArticleView 설계
- ArticleInterest 설계

## 반영 브랜치
`feature/#5/create-newsarticle-entity` -> `dev`

## 💬 기타 참고 사항
- 아직 Interest Entity와 User Entity가 없는 상태로 설계했습니다.
- Entity 내부 update() 메서드는 Entity 설계에 맞지않아 주석처리하였습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새로운 기능

* 사용자가 관심사(토픽)별로 뉴스 기사를 연결·관리할 수 있는 기능이 추가되었습니다.
* 각 기사에 대한 개별 조회(뷰) 기록이 생성되어 조회 이력과 중복 조회 방지가 지원됩니다.
* 뉴스 기사에 출처, 원문 링크, 제목, 발행일, 요약 등 상세 메타데이터 관리와 조회수·삭제 상태 초기값 지원이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->