### PR TITLE
[Feat] 관심사(Interest) 관련 엔티티 설계 및 관련 코드 구현

### DIFF
--- a/src/main/java/com/springboot/monew/interest/controller/InterestApiDocs.java
+++ b/src/main/java/com/springboot/monew/interest/controller/InterestApiDocs.java
@@ -1,0 +1,4 @@
+package com.springboot.monew.interest.controller;
+
+public interface InterestApiDocs {
+}

--- a/src/main/java/com/springboot/monew/interest/controller/InterestController.java
+++ b/src/main/java/com/springboot/monew/interest/controller/InterestController.java
@@ -1,0 +1,16 @@
+package com.springboot.monew.interest.controller;
+
+import com.springboot.monew.interest.service.InterestService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/interests")
+public class InterestController implements InterestApiDocs {
+
+    private final InterestService interestService;
+}

--- a/src/main/java/com/springboot/monew/interest/entity/Interest.java
+++ b/src/main/java/com/springboot/monew/interest/entity/Interest.java
@@ -1,0 +1,48 @@
+package com.springboot.monew.interest.entity;
+
+import com.springboot.monew.base.BaseUpdatableEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        name = "interests",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "UK_INTERESTS_NAME",
+                        columnNames = "name"
+                )
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Interest extends BaseUpdatableEntity {
+
+    @Column(name = "name", nullable = false, length = 50)
+    private String name;
+
+    @Column(name = "subscriber_count", nullable = false)
+    private long subscriberCount;
+
+    public Interest(String name) {
+        this.name = name;
+        this.subscriberCount = 0;
+    }
+
+    // 구독자 수 증가
+    public void increaseSubscriberCount() {
+        this.subscriberCount++;
+    }
+
+    // 구독자 수 감소
+    public void decreaseSubscriberCount() {
+        if (this.subscriberCount > 0) {
+            this.subscriberCount--;
+        }
+    }
+}

--- a/src/main/java/com/springboot/monew/interest/entity/InterestKeyword.java
+++ b/src/main/java/com/springboot/monew/interest/entity/InterestKeyword.java
@@ -1,0 +1,40 @@
+package com.springboot.monew.interest.entity;
+
+import com.springboot.monew.base.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        name = "interest_keywords",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "UK_INTEREST_KEYWORDS_INTEREST_ID_KEYWORD_ID",
+                        columnNames = {"interest_id", "keyword_id"}
+                )
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class InterestKeyword extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "interest_id", nullable = false)
+    private Interest interest;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "keyword_id", nullable = false)
+    private Keyword keyword;
+
+    public InterestKeyword(Interest interest, Keyword keyword) {
+        this.interest = interest;
+        this.keyword = keyword;
+    }
+}

--- a/src/main/java/com/springboot/monew/interest/entity/Keyword.java
+++ b/src/main/java/com/springboot/monew/interest/entity/Keyword.java
@@ -1,0 +1,32 @@
+package com.springboot.monew.interest.entity;
+
+import com.springboot.monew.base.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        name = "keywords",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "UK_KEYWORDS_NAME",
+                        columnNames = "name"
+                )
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Keyword extends BaseEntity {
+
+    @Column(name = "name", nullable = false, length = 100)
+    String name;
+
+    public Keyword(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/springboot/monew/interest/repository/InterestKeywordRepository.java
+++ b/src/main/java/com/springboot/monew/interest/repository/InterestKeywordRepository.java
@@ -1,0 +1,9 @@
+package com.springboot.monew.interest.repository;
+
+import com.springboot.monew.interest.entity.InterestKeyword;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface InterestKeywordRepository extends JpaRepository<InterestKeyword, UUID> {
+}

--- a/src/main/java/com/springboot/monew/interest/repository/InterestRepository.java
+++ b/src/main/java/com/springboot/monew/interest/repository/InterestRepository.java
@@ -1,0 +1,9 @@
+package com.springboot.monew.interest.repository;
+
+import com.springboot.monew.interest.entity.Interest;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface InterestRepository extends JpaRepository<Interest, UUID> {
+}

--- a/src/main/java/com/springboot/monew/interest/repository/KeywordRepository.java
+++ b/src/main/java/com/springboot/monew/interest/repository/KeywordRepository.java
@@ -1,0 +1,9 @@
+package com.springboot.monew.interest.repository;
+
+import com.springboot.monew.interest.entity.Keyword;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface KeywordRepository extends JpaRepository<Keyword, UUID> {
+}

--- a/src/main/java/com/springboot/monew/interest/service/InterestService.java
+++ b/src/main/java/com/springboot/monew/interest/service/InterestService.java
@@ -1,0 +1,9 @@
+package com.springboot.monew.interest.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class InterestService {
+}


### PR DESCRIPTION
## 📌 해당 이슈카드
Closes #53 #57 

## 📌 작업 내용
- Interest, Keyword, InterestKeyword 엔티티 설계
- Interest의 Controller와 Serivce 기본 구조 구현
- Interest, Keyword, InterestKeyword Repository 기본 구조 구현

## 🔧 변경 사항


## 반영 브랜치
- `feature/#53/interest-entity` -> `dev`

## 💬 기타 참고 사항
- 나중에 Subscriptoin 엔티티를 구현할텐데 Interest의 subscriberCount와 Subscriptoin이 따로 관리되어서 정합성이 깨질 가능성이 있기 때문에 이 부분은 계속 고민한 후 추후에 반영하겠습니다.
