### PR TITLE
[feat] 알람 엔티티, 맵퍼, dto 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,10 @@ dependencies {
     testImplementation 'com.h2database:h2'
     runtimeOnly 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation platform('org.instancio:instancio-bom:6.0.0-RC2')
+    testImplementation('org.instancio:instancio-core')
+    testImplementation('org.instancio:instancio-junit')
+    testImplementation('org.instancio:instancio-guava')
 
     //aws
     implementation 'software.amazon.awssdk:s3:2.31.7'

--- a/src/main/java/com/springboot/monew/common/mapper/BaseMapper.java
+++ b/src/main/java/com/springboot/monew/common/mapper/BaseMapper.java
@@ -1,0 +1,8 @@
+package com.springboot.monew.common.mapper;
+
+import java.util.List;
+
+public interface BaseMapper<T, R> {
+    R toDto(T entity);
+    List<R> toDto(List<T> entities);
+}

--- a/src/main/java/com/springboot/monew/common/mapper/CommonMapperConfig.java
+++ b/src/main/java/com/springboot/monew/common/mapper/CommonMapperConfig.java
@@ -1,0 +1,11 @@
+package com.springboot.monew.common.mapper;
+
+import org.mapstruct.*;
+
+@MapperConfig(
+        componentModel = MappingConstants.ComponentModel.SPRING,
+        unmappedTargetPolicy = ReportingPolicy.IGNORE,
+        nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE,
+        injectionStrategy = InjectionStrategy.CONSTRUCTOR)
+public interface CommonMapperConfig {
+}

--- a/src/main/java/com/springboot/monew/notification/dto/NotificationDto.java
+++ b/src/main/java/com/springboot/monew/notification/dto/NotificationDto.java
@@ -1,0 +1,17 @@
+package com.springboot.monew.notification.dto;
+
+import com.springboot.monew.notification.entity.Notification;
+import com.springboot.monew.notification.entity.ResourceType;
+import lombok.Builder;
+
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * DTO for {@link Notification}
+ */
+@Builder
+public record NotificationDto(UUID id, Instant createdAt, Instant updatedAt, Boolean confirmed, String content,
+                              ResourceType resourceType, UUID userId, UUID resourceId) implements Serializable {
+}

--- a/src/main/java/com/springboot/monew/notification/entity/Notification.java
+++ b/src/main/java/com/springboot/monew/notification/entity/Notification.java
@@ -1,0 +1,85 @@
+package com.springboot.monew.notification.entity;
+
+import com.springboot.monew.common.entity.BaseEntity;
+import com.springboot.monew.entity.CommentLike;
+import com.springboot.monew.entity.Interest;
+import com.springboot.monew.entity.User;
+import com.springboot.monew.notification.exception.NotificationErrorCode;
+import com.springboot.monew.notification.exception.NotificationException;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+@Getter
+@Setter
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "notifications")
+public class Notification extends BaseEntity {
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+
+    @Column(name = "confirmed", nullable = false)
+    private Boolean confirmed = false;
+
+    @Column(name = "content", nullable = false, length = 100)
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "resource_type", nullable = false, length = 10)
+    private ResourceType resourceType;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "interest_id")
+    private Interest interest;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_likes_id")
+    private CommentLike commentLike;
+
+    @Builder
+    public Notification(String content,
+                        ResourceType resourceType,
+                        User user,
+                        Interest interest,
+                        CommentLike commentLike) {
+        this.content = content;
+        this.resourceType = resourceType;
+        this.user = user;
+        this.interest = interest;
+        this.commentLike = commentLike;
+    }
+
+    @Transient
+    public UUID getResourceId() {
+        if (resourceType == ResourceType.COMMENT && commentLike != null) {
+            return commentLike.getId();
+        }
+        if (resourceType == ResourceType.INTEREST && interest != null) {
+            return interest.getId();
+        }
+        Map<String, Object> details = new HashMap<>();
+        details.put("resourceType", resourceType);
+        details.put("commentLike", commentLike);
+        details.put("interest", interest);
+        throw new NotificationException(NotificationErrorCode.INVALID_DATA, details);
+    }
+
+    public Optional<Interest> getInterest() {
+        return Optional.ofNullable(interest);
+    }
+
+    public Optional<CommentLike> getCommentLike() {
+        return Optional.ofNullable(commentLike);
+    }
+
+}

--- a/src/main/java/com/springboot/monew/notification/entity/Notification.java
+++ b/src/main/java/com/springboot/monew/notification/entity/Notification.java
@@ -1,11 +1,11 @@
 package com.springboot.monew.notification.entity;
 
+import com.springboot.monew.comment.entity.CommentLike;
 import com.springboot.monew.common.entity.BaseEntity;
-import com.springboot.monew.entity.CommentLike;
-import com.springboot.monew.entity.Interest;
-import com.springboot.monew.entity.User;
+import com.springboot.monew.interest.entity.Interest;
 import com.springboot.monew.notification.exception.NotificationErrorCode;
 import com.springboot.monew.notification.exception.NotificationException;
+import com.springboot.monew.users.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -70,9 +70,11 @@ public class Notification extends BaseEntity {
             return interest.getId();
         }
         Map<String, Object> details = new HashMap<>();
+        UUID commentLikeId = commentLike == null ? null : commentLike.getId();
+        UUID interestId = interest == null ? null : interest.getId();
         details.put("resourceType", resourceType);
-        details.put("commentLike", commentLike);
-        details.put("interest", interest);
+        details.put("commentLike", commentLikeId);
+        details.put("interest", interestId);
         throw new NotificationException(NotificationErrorCode.INVALID_DATA, details);
     }
 

--- a/src/main/java/com/springboot/monew/notification/entity/Notification.java
+++ b/src/main/java/com/springboot/monew/notification/entity/Notification.java
@@ -7,7 +7,10 @@ import com.springboot.monew.entity.User;
 import com.springboot.monew.notification.exception.NotificationErrorCode;
 import com.springboot.monew.notification.exception.NotificationException;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 import java.time.Instant;
 import java.util.HashMap;
@@ -16,7 +19,6 @@ import java.util.Optional;
 import java.util.UUID;
 
 @Getter
-@Setter
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "notifications")
@@ -82,4 +84,10 @@ public class Notification extends BaseEntity {
         return Optional.ofNullable(commentLike);
     }
 
+    public void updateConfirmed() {
+        if (!confirmed) {
+            confirmed = true;
+            updatedAt = Instant.now();
+        }
+    }
 }

--- a/src/main/java/com/springboot/monew/notification/entity/ResourceType.java
+++ b/src/main/java/com/springboot/monew/notification/entity/ResourceType.java
@@ -1,0 +1,5 @@
+package com.springboot.monew.notification.entity;
+
+public enum ResourceType {
+    INTEREST, COMMENT,
+}

--- a/src/main/java/com/springboot/monew/notification/exception/NotificationErrorCode.java
+++ b/src/main/java/com/springboot/monew/notification/exception/NotificationErrorCode.java
@@ -1,0 +1,17 @@
+package com.springboot.monew.notification.exception;
+
+import com.springboot.monew.common.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum NotificationErrorCode implements ErrorCode {
+    INVALID_DATA(HttpStatus.INTERNAL_SERVER_ERROR, "N001", "유효한 데이터가 아닙니다"),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/springboot/monew/notification/exception/NotificationException.java
+++ b/src/main/java/com/springboot/monew/notification/exception/NotificationException.java
@@ -1,0 +1,12 @@
+package com.springboot.monew.notification.exception;
+
+import com.springboot.monew.common.exception.ErrorCode;
+import com.springboot.monew.common.exception.MonewException;
+
+import java.util.Map;
+
+public class NotificationException extends MonewException {
+    public NotificationException(ErrorCode errorCode, Map<String, Object> details) {
+        super(errorCode, details);
+    }
+}

--- a/src/main/java/com/springboot/monew/notification/mapper/NotificationMapper.java
+++ b/src/main/java/com/springboot/monew/notification/mapper/NotificationMapper.java
@@ -1,0 +1,22 @@
+package com.springboot.monew.notification.mapper;
+
+import com.springboot.monew.common.mapper.BaseMapper;
+import com.springboot.monew.common.mapper.CommonMapperConfig;
+import com.springboot.monew.notification.dto.NotificationDto;
+import com.springboot.monew.notification.entity.Notification;
+import org.mapstruct.*;
+
+import java.time.Instant;
+
+@Mapper(config = CommonMapperConfig.class)
+public interface NotificationMapper extends BaseMapper<Notification, NotificationDto> {
+    @Override
+    @Mapping(target = "userId", source = "user.id")
+    NotificationDto toDto(Notification entity);
+
+    default Notification partialUpdate(Notification notification) {
+        notification.setUpdatedAt(Instant.now());
+        notification.setConfirmed(true);
+        return notification;
+    }
+}

--- a/src/main/java/com/springboot/monew/notification/mapper/NotificationMapper.java
+++ b/src/main/java/com/springboot/monew/notification/mapper/NotificationMapper.java
@@ -4,19 +4,12 @@ import com.springboot.monew.common.mapper.BaseMapper;
 import com.springboot.monew.common.mapper.CommonMapperConfig;
 import com.springboot.monew.notification.dto.NotificationDto;
 import com.springboot.monew.notification.entity.Notification;
-import org.mapstruct.*;
-
-import java.time.Instant;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(config = CommonMapperConfig.class)
 public interface NotificationMapper extends BaseMapper<Notification, NotificationDto> {
     @Override
     @Mapping(target = "userId", source = "user.id")
     NotificationDto toDto(Notification entity);
-
-    default Notification partialUpdate(Notification notification) {
-        notification.setUpdatedAt(Instant.now());
-        notification.setConfirmed(true);
-        return notification;
-    }
 }

--- a/src/test/java/com/springboot/monew/entity/NotificationTest.java
+++ b/src/test/java/com/springboot/monew/entity/NotificationTest.java
@@ -15,7 +15,7 @@ class NotificationTest {
 
     @Test
     @DisplayName("interest 객체가 존재하면 interestId를 반환한다")
-    void return_interest_id() {
+    void returnInterestId() {
         Notification notification = NotificationsFixture.createEntityWithInterest();
         UUID resourceId = notification.getInterest().map(Interest::getId).orElseThrow();
         Assertions.assertThat(resourceId).isEqualTo(notification.getResourceId());
@@ -23,7 +23,7 @@ class NotificationTest {
 
     @Test
     @DisplayName("commentLikes 객체가 존재하면 commentLikesId를 반환한다")
-    void return_commentLikes_id() {
+    void returnCommentLikesId() {
         Notification notification = NotificationsFixture.createEntityWithCommentLike();
         UUID resourceId = notification.getCommentLike().map(CommentLike::getId).orElseThrow();
         Assertions.assertThat(resourceId).isEqualTo(notification.getResourceId());

--- a/src/test/java/com/springboot/monew/entity/NotificationTest.java
+++ b/src/test/java/com/springboot/monew/entity/NotificationTest.java
@@ -1,0 +1,31 @@
+package com.springboot.monew.entity;
+
+import com.springboot.monew.fixture.NotificationsFixture;
+import com.springboot.monew.notification.entity.Notification;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.UUID;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationTest {
+
+    @Test
+    @DisplayName("interest 객체가 존재하면 interestId를 반환한다")
+    void return_interest_id() {
+        Notification notification = NotificationsFixture.createEntityWithInterest();
+        UUID resourceId = notification.getInterest().map(Interest::getId).orElseThrow();
+        Assertions.assertThat(resourceId).isEqualTo(notification.getResourceId());
+    }
+
+    @Test
+    @DisplayName("commentLikes 객체가 존재하면 commentLikesId를 반환한다")
+    void return_commentLikes_id() {
+        Notification notification = NotificationsFixture.createEntityWithCommentLike();
+        UUID resourceId = notification.getCommentLike().map(CommentLike::getId).orElseThrow();
+        Assertions.assertThat(resourceId).isEqualTo(notification.getResourceId());
+    }
+}

--- a/src/test/java/com/springboot/monew/fixture/CommentLikeFixture.java
+++ b/src/test/java/com/springboot/monew/fixture/CommentLikeFixture.java
@@ -1,0 +1,13 @@
+package com.springboot.monew.fixture;
+
+import com.springboot.monew.entity.CommentLike;
+import org.instancio.Instancio;
+
+public final class CommentLikeFixture {
+    private CommentLikeFixture() {
+    }
+
+    public static CommentLike createEntity() {
+        return Instancio.create(CommentLike.class);
+    }
+}

--- a/src/test/java/com/springboot/monew/fixture/InterestFixture.java
+++ b/src/test/java/com/springboot/monew/fixture/InterestFixture.java
@@ -1,0 +1,13 @@
+package com.springboot.monew.fixture;
+
+import com.springboot.monew.entity.Interest;
+import org.instancio.Instancio;
+
+public final class InterestFixture {
+    private InterestFixture() {
+    }
+
+    public static Interest createEntity() {
+        return Instancio.create(Interest.class);
+    }
+}

--- a/src/test/java/com/springboot/monew/fixture/NotificationsFixture.java
+++ b/src/test/java/com/springboot/monew/fixture/NotificationsFixture.java
@@ -1,0 +1,23 @@
+package com.springboot.monew.fixture;
+
+import com.springboot.monew.notification.entity.Notification;
+import org.instancio.Instancio;
+
+import static org.instancio.Select.field;
+
+public final class NotificationsFixture {
+    private NotificationsFixture() {
+    }
+
+    public static Notification createEntityWithInterest() {
+        return Instancio.of(Notification.class)
+                .ignore(field(Notification::getCommentLike))
+                .create();
+    }
+
+    public static Notification createEntityWithCommentLike() {
+        return Instancio.of(Notification.class)
+                .ignore(field(Notification::getInterest))
+                .create();
+    }
+}

--- a/src/test/java/com/springboot/monew/fixture/NotificationsFixture.java
+++ b/src/test/java/com/springboot/monew/fixture/NotificationsFixture.java
@@ -1,6 +1,7 @@
 package com.springboot.monew.fixture;
 
 import com.springboot.monew.notification.entity.Notification;
+import com.springboot.monew.notification.entity.ResourceType;
 import org.instancio.Instancio;
 
 import static org.instancio.Select.field;
@@ -12,12 +13,14 @@ public final class NotificationsFixture {
     public static Notification createEntityWithInterest() {
         return Instancio.of(Notification.class)
                 .ignore(field(Notification::getCommentLike))
+                .set(field(Notification::getResourceType), ResourceType.INTEREST)
                 .create();
     }
 
     public static Notification createEntityWithCommentLike() {
         return Instancio.of(Notification.class)
                 .ignore(field(Notification::getInterest))
+                .set(field(Notification::getResourceType), ResourceType.COMMENT)
                 .create();
     }
 }

--- a/src/test/java/com/springboot/monew/mapper/NotificationMapperTest.java
+++ b/src/test/java/com/springboot/monew/mapper/NotificationMapperTest.java
@@ -17,7 +17,7 @@ public class NotificationMapperTest {
 
     @Test
     @DisplayName("Notification 객체와 dto 공통 필드의 값이 같다")
-    void entity_equal_to_dto() {
+    void entityIsEqualToDto() {
         // given
         Notification notification = NotificationsFixture.createEntityWithCommentLike();
 

--- a/src/test/java/com/springboot/monew/mapper/NotificationMapperTest.java
+++ b/src/test/java/com/springboot/monew/mapper/NotificationMapperTest.java
@@ -1,7 +1,10 @@
 package com.springboot.monew.mapper;
 
 import com.springboot.monew.fixture.NotificationsFixture;
+import com.springboot.monew.notification.dto.NotificationDto;
 import com.springboot.monew.notification.entity.Notification;
+import com.springboot.monew.notification.mapper.NotificationMapper;
+import com.springboot.monew.notification.mapper.NotificationMapperImpl;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,7 +26,7 @@ public class NotificationMapperTest {
 
         // then
         Assertions.assertThat(dto)
-                .extracting("updateAt", "confirmed", "content", "userId", "resourceType", "resourceId")
-                .isEqualTo(notification);
+                .extracting("id", "createdAt", "updatedAt", "confirmed", "content", "userId", "resourceType", "resourceId")
+                .contains(notification.getId(), notification.getCreatedAt(), notification.getUpdatedAt(), notification.getConfirmed(), notification.getContent(), notification.getUser().getId(), notification.getResourceType(), notification.getResourceId());
     }
 }

--- a/src/test/java/com/springboot/monew/mapper/NotificationMapperTest.java
+++ b/src/test/java/com/springboot/monew/mapper/NotificationMapperTest.java
@@ -1,0 +1,29 @@
+package com.springboot.monew.mapper;
+
+import com.springboot.monew.fixture.NotificationsFixture;
+import com.springboot.monew.notification.entity.Notification;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class NotificationMapperTest {
+    private final NotificationMapper mapper = new NotificationMapperImpl();
+
+    @Test
+    @DisplayName("Notification 객체와 dto 공통 필드의 값이 같다")
+    void entity_equal_to_dto() {
+        // given
+        Notification notification = NotificationsFixture.createEntityWithCommentLike();
+
+        // when
+        NotificationDto dto = mapper.toDto(notification);
+
+        // then
+        Assertions.assertThat(dto)
+                .extracting("updateAt", "confirmed", "content", "userId", "resourceType", "resourceId")
+                .isEqualTo(notification);
+    }
+}


### PR DESCRIPTION
## 📌 해당 이슈카드
Close #159 

## 📌 작업 내용
- Notification entity, mapper, dto 구현
- entity, mapper unit test 

## 🔧 변경 사항


## 반영 브랜치
- `feature/#53/interest-entity` -> `dev`

## 💬 기타 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 알림 시스템 기본 인프라 추가(알림 DTO·엔티티, 공통 매핑 구성 및 공용 매퍼)
  * INTEREST/COMMENT 리소스 유형 지원 및 관련 식별자 조회·갱신 로직 추가
  * 알림 전용 오류 코드·예외 처리 추가

* **테스트**
  * 알림 엔티티와 매퍼 검증용 단위 테스트 및 테스트 픽스처 추가

* **잡일**
  * 테스트용 데이터 생성 라이브러리(Instancio) 의존성 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->