### PR TITLE
[Feat] 댓글 논리 삭제, 물리 삭제, 좋아요 취소 기능 구현 

### DIFF
--- a/src/main/java/com/springboot/monew/comment/controller/CommentController.java
+++ b/src/main/java/com/springboot/monew/comment/controller/CommentController.java
@@ -68,10 +68,10 @@ public class CommentController implements CommentApiDocs{
         return ResponseEntity.ok(commentService.update(commentId, userId, request));
     }
 
-    // TODO: 댓글 물리 삭제 API
+    // 댓글 물리 삭제 API
     @DeleteMapping("/{commentId}/hard")
-    public ResponseEntity<?> hardDelete() {
-        return ResponseEntity.ok().build();
+    public void hardDelete(@PathVariable UUID commentId) {
+        commentService.hardDelete(commentId);
     }
 
 }

--- a/src/main/java/com/springboot/monew/comment/controller/CommentController.java
+++ b/src/main/java/com/springboot/monew/comment/controller/CommentController.java
@@ -46,10 +46,13 @@ public class CommentController implements CommentApiDocs{
                 .body(commentLikeDto);
     }
 
-    // TODO: 댓글 좋아요 취소 API
+    // 댓글 좋아요 취소 API
     @DeleteMapping("/{commentId}/comment-likes")
-    public ResponseEntity<?> unlike() {
-        return ResponseEntity.ok().build();
+    public void unlike(
+            @PathVariable UUID commentId,
+            @RequestHeader("Monew-Request-User-ID") UUID userId
+    ) {
+        commentService.unlike(commentId, userId);
     }
 
     // 댓글 논리 삭제 API

--- a/src/main/java/com/springboot/monew/comment/controller/CommentController.java
+++ b/src/main/java/com/springboot/monew/comment/controller/CommentController.java
@@ -35,7 +35,7 @@ public class CommentController implements CommentApiDocs{
                 .body(commentDto);
     }
 
-    // TODO: 관심사 댓글 좋아요 API
+    // 관심사 댓글 좋아요 API
     @PostMapping("/{commentId}/comment-likes")
     public ResponseEntity<CommentLikeDto> like(
             @PathVariable UUID commentId,
@@ -52,10 +52,10 @@ public class CommentController implements CommentApiDocs{
         return ResponseEntity.ok().build();
     }
 
-    // TODO: 댓글 논리 삭제 API
+    // 댓글 논리 삭제 API
     @DeleteMapping("/{commentId}")
-    public ResponseEntity<?> softDelete() {
-        return ResponseEntity.ok().build();
+    public void softDelete(@PathVariable UUID commentId) {
+        commentService.softDelete(commentId);
     }
 
     // 댓글 정보 수정 API

--- a/src/main/java/com/springboot/monew/comment/controller/CommentController.java
+++ b/src/main/java/com/springboot/monew/comment/controller/CommentController.java
@@ -57,8 +57,9 @@ public class CommentController implements CommentApiDocs{
 
     // 댓글 논리 삭제 API
     @DeleteMapping("/{commentId}")
-    public void softDelete(@PathVariable UUID commentId) {
+    public ResponseEntity<Void> softDelete(@PathVariable UUID commentId) {
         commentService.softDelete(commentId);
+        return ResponseEntity.noContent().build();
     }
 
     // 댓글 정보 수정 API
@@ -73,8 +74,9 @@ public class CommentController implements CommentApiDocs{
 
     // 댓글 물리 삭제 API
     @DeleteMapping("/{commentId}/hard")
-    public void hardDelete(@PathVariable UUID commentId) {
+    public ResponseEntity<Void> hardDelete(@PathVariable UUID commentId) {
         commentService.hardDelete(commentId);
+        return ResponseEntity.noContent().build();
     }
 
 }

--- a/src/main/java/com/springboot/monew/comment/repository/CommentLikeRepository.java
+++ b/src/main/java/com/springboot/monew/comment/repository/CommentLikeRepository.java
@@ -1,11 +1,14 @@
 package com.springboot.monew.comment.repository;
 
+import com.springboot.monew.comment.entity.Comment;
 import com.springboot.monew.comment.entity.CommentLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface CommentLikeRepository extends JpaRepository<CommentLike, UUID> {
+    Optional<CommentLike> findCommentLikeByComment(Comment comment);
     // TODO: User 구현 시 주석 해제
     // boolean existsByCommentIdAndUserId(UUID commentId, UUID userId);
 }

--- a/src/main/java/com/springboot/monew/comment/repository/CommentRepository.java
+++ b/src/main/java/com/springboot/monew/comment/repository/CommentRepository.java
@@ -15,4 +15,8 @@ public interface CommentRepository extends JpaRepository<Comment, UUID> {
     @Modifying
     @Query("UPDATE Comment c SET c.likeCount = c.likeCount + 1 WHERE  c.id = :id")
     void incrementLikeCount(@Param("id") UUID id);
+
+    @Modifying
+    @Query("UPDATE Comment c SET c.likeCount = c.likeCount - 1 WHERE  c.id = :id")
+    void decrementLikeCount(@Param("id") UUID id);
 }

--- a/src/main/java/com/springboot/monew/comment/repository/CommentRepository.java
+++ b/src/main/java/com/springboot/monew/comment/repository/CommentRepository.java
@@ -17,6 +17,13 @@ public interface CommentRepository extends JpaRepository<Comment, UUID> {
     void incrementLikeCount(@Param("id") UUID id);
 
     @Modifying
-    @Query("UPDATE Comment c SET c.likeCount = c.likeCount - 1 WHERE  c.id = :id")
+    @Query("""
+            UPDATE Comment c
+            SET c.likeCount = CASE
+            WHEN c.likeCount > 0 THEN c.likeCount - 1
+            ELSE 0
+            END
+            WHERE c.id = :id
+    """)
     void decrementLikeCount(@Param("id") UUID id);
 }

--- a/src/main/java/com/springboot/monew/comment/service/CommentService.java
+++ b/src/main/java/com/springboot/monew/comment/service/CommentService.java
@@ -77,6 +77,7 @@ public class CommentService {
         return commentMapper.toCommentDto(comment,likeByMe);
     }
 
+    // 댓글 좋아요
     @Transactional
     public CommentLikeDto like(UUID commentId, UUID userId){
         // 댓글 조회 (존재, SoftDelete 여부)
@@ -106,6 +107,7 @@ public class CommentService {
         return commentLikeMapper.toCommentLikeDto(commentLike);
     }
 
+    // 댓글 논리 삭제
     @Transactional
     public void softDelete(UUID commentId) {
         // 조회 -> 존재하지 않는 경우, 이미 논리 삭제한 경우
@@ -123,5 +125,18 @@ public class CommentService {
         }
         // 논리 삭제 (false -> true)
         comment.delete();
+    }
+
+    // 댓글 물리 삭제
+    @Transactional
+    public void hardDelete(UUID commentId) {
+        // 조회 - 소프트 딜릿 여부에 상관없이 삭제
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new CommentException(
+                        CommentErrorCode.COMMENT_NOT_FOUND,
+                        Map.of("commentId", commentId))
+                );
+
+        commentRepository.delete(comment);
     }
 }

--- a/src/main/java/com/springboot/monew/comment/service/CommentService.java
+++ b/src/main/java/com/springboot/monew/comment/service/CommentService.java
@@ -139,4 +139,33 @@ public class CommentService {
 
         commentRepository.delete(comment);
     }
+
+    // 댓글 좋아요 취소
+    @Transactional
+    public void unlike(UUID commentId, UUID userId) {
+        // 댓글 -> 존재, 소프트 딜릿 여부 확인
+        Comment comment = commentRepository.findByIdAndIsDeletedFalse(commentId)
+                .orElseThrow(() -> new CommentException(
+                        CommentErrorCode.COMMENT_NOT_FOUND,
+                        Map.of("commentId", commentId)
+                ));
+
+        // Todo: User -> 존재, 소프트 딜릿 여부 확인
+        // User user = userRepository.findByIdAndDeletedAt~(userId);
+
+        // Todo : 좋아요 존재 확인 (comment, user), 로직 수정해야 함.
+        CommentLike commentLike = commentLikeRepository.findCommentLikeByComment(comment)
+                .orElseThrow(
+                        () -> new CommentException(
+                                CommentErrorCode.COMMENT_LIKE_NOT_FOUND,
+                                Map.of("commentId", commentId)
+                        )
+                );
+
+        // 좋아요 삭제(하드 딜릿) -> 좋아요 취소 시 이력에서 바로 삭제되므로 하드딜릿이 맞다고 판단
+        commentLikeRepository.delete(commentLike);
+
+        // Comment 쪽 likeCount 감소 (동시성 문제 고려)
+        commentRepository.decrementLikeCount(comment.getId());
+    }
 }

--- a/src/main/java/com/springboot/monew/comment/service/CommentService.java
+++ b/src/main/java/com/springboot/monew/comment/service/CommentService.java
@@ -10,7 +10,6 @@ import com.springboot.monew.comment.mapper.CommentLikeMapper;
 import com.springboot.monew.comment.mapper.CommentMapper;
 import com.springboot.monew.comment.repository.CommentLikeRepository;
 import com.springboot.monew.comment.repository.CommentRepository;
-import com.springboot.monew.exception.ErrorCode;
 import com.springboot.monew.exception.comment.CommentErrorCode;
 import com.springboot.monew.exception.comment.CommentException;
 import lombok.RequiredArgsConstructor;
@@ -125,6 +124,7 @@ public class CommentService {
         }
         // 논리 삭제 (false -> true)
         comment.delete();
+        log.info("댓글 논리 삭제 완료 - commentId: {}", commentId);
     }
 
     // 댓글 물리 삭제
@@ -138,6 +138,7 @@ public class CommentService {
                 );
 
         commentRepository.delete(comment);
+        log.info("댓글 물리 삭제 완료 - commentId: {}", commentId);
     }
 
     // 댓글 좋아요 취소
@@ -167,5 +168,6 @@ public class CommentService {
 
         // Comment 쪽 likeCount 감소 (동시성 문제 고려)
         commentRepository.decrementLikeCount(comment.getId());
+        log.info("좋아요 취소 완료 - commentId: {}, userId: {}", commentId, userId);
     }
 }

--- a/src/main/java/com/springboot/monew/comment/service/CommentService.java
+++ b/src/main/java/com/springboot/monew/comment/service/CommentService.java
@@ -105,4 +105,23 @@ public class CommentService {
         // Comment, CommentLike -> CommentLikeDto로 변환
         return commentLikeMapper.toCommentLikeDto(commentLike);
     }
+
+    @Transactional
+    public void softDelete(UUID commentId) {
+        // 조회 -> 존재하지 않는 경우, 이미 논리 삭제한 경우
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new CommentException(
+                        CommentErrorCode.COMMENT_NOT_FOUND,
+                        Map.of("commentId", commentId))
+                );
+        if (comment.isDeleted()) {
+            throw new CommentException(
+                    CommentErrorCode.COMMENT_ALREADY_DELETED,
+                    Map.of("commentId", commentId)
+            );
+
+        }
+        // 논리 삭제 (false -> true)
+        comment.delete();
+    }
 }

--- a/src/main/java/com/springboot/monew/exception/comment/CommentErrorCode.java
+++ b/src/main/java/com/springboot/monew/exception/comment/CommentErrorCode.java
@@ -11,7 +11,8 @@ public enum CommentErrorCode implements ErrorCode {
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "CM01", "댓글을 찾을 수 없습니다."),
     COMMENT_NOT_OWNED_BY_USER(HttpStatus.FORBIDDEN, "CM02", "본인의 댓글이 아닙니다."),
     COMMENT_LIKE_ALREADY_EXISTS(HttpStatus.CONFLICT, "CM03", "이미 좋아요를 눌렀습니다."),
-    COMMENT_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "CM04", "좋아요를 누르지 않았습니다.");
+    COMMENT_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "CM04", "좋아요를 누르지 않았습니다."),
+    COMMENT_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "CM05", "이미 삭제한 댓글입니다." );
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
## 관련 이슈 카드 

Closes #16 #168 #169 

## 📌 작업 내용
  - 댓글 논리 삭제, 물리 삭제, 좋아요 취소 기능 구현

## 🔧 변경 사항
  - 댓글 논리 삭제 API 구현 (DELETE /api/comments/{commentId}) - isDeleted 플래그 처리
  - 댓글 물리 삭제 API 구현 (DELETE /api/comments/{commentId}/hard) - DB에서 완전 삭제
  - 댓글 좋아요 취소 API 구현 (DELETE /api/comments/{commentId}/comment-likes)
  - 좋아요 취소 시 댓글 likeCount 감소 처리
  - 중복 삭제 방지 에러 코드 추가 (CommentErrorCode)
  - 각 기능 로그 추가

## 반영 브랜치
  `feature/#16/comment-delete` -> `dev`

## 💬 기타 참고 사항
  - TODO 주석 처리된 부분은 User, Article 구현 완료 후 반영 예정입니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 댓글 좋아요 취소(사용자 식별 헤더 기반) 동작 추가
  * 댓글 일시 삭제(soft delete) 및 완전 삭제(hard delete) 엔드포인트 동작 구현
  * 댓글 좋아수 자동 감소 및 관련 조회 지원 추가

* **Bug Fixes**
  * 이미 삭제된 댓글에 대한 명확한 오류 처리 추가
  * 삭제/취소 요청에 대해 적절한 상태 코드(204 등) 반환으로 응답 일관성 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->