### PR TITLE
[Test] 회원가입 테스트 코드 추가 및 UserErrorCode 불필요한 enum 정리

### DIFF
--- a/src/main/java/com/springboot/monew/users/exception/UserErrorCode.java
+++ b/src/main/java/com/springboot/monew/users/exception/UserErrorCode.java
@@ -8,10 +8,6 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum UserErrorCode implements ErrorCode {
-    INVALID_EMAIL(HttpStatus.BAD_REQUEST, "INVALID_EMAIL", "이메일 형식이 올바르지 않습니다."),
-    INVALID_NICKNAME(HttpStatus.BAD_REQUEST, "INVALID_NICKNAME", "닉네임 형식이 올바르지 않습니다."),
-    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "INVALID_PASSWORD", "비밀번호 형식이 올바르지 않습니다."),
-
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "DUPLICATE_EMAIL", "이미 사용 중인 이메일입니다."),
     DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "DUPLICATE_NICKNAME", "이미 사용 중인 닉네임입니다."),
 

--- a/src/test/java/com/springboot/monew/users/controller/UserControllerTest.java
+++ b/src/test/java/com/springboot/monew/users/controller/UserControllerTest.java
@@ -17,6 +17,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.time.Instant;
 import java.util.UUID;
 
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -52,8 +53,8 @@ public class UserControllerTest {
                 createdAt
         );
 
-        Mockito.when(userService.register(ArgumentMatchers.any(UserRegisterRequest.class)))
-                .thenReturn(response);
+        // Mockito.when을 클래스명 없이 간단히 사용하기 위해 static import를 하였음.
+        when(userService.register(ArgumentMatchers.any(UserRegisterRequest.class))).thenReturn(response);
 
         // when & then
         mockMvc.perform(post("/api/users")
@@ -64,5 +65,32 @@ public class UserControllerTest {
                 .andExpect(jsonPath("$.email").value("test@example.com"))
                 .andExpect(jsonPath("$.nickname").value("monew123"))
                 .andExpect(jsonPath("$.createdAt").value("2026-04-17T01:46:03.003Z"));
+
+        // 컨트롤러가 실제로 register을 호출했는지 검증하기 위해 추가
+        verify(userService).register(ArgumentMatchers.any(UserRegisterRequest.class));
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 회원가입 요청이면 400 Bad Request를 반환한다")
+    void register_validationFail() throws Exception {
+        // given
+        UserRegisterRequest request = new UserRegisterRequest(
+                "invalid-email",
+                "",
+                "1234"
+        );
+
+        // when & then
+        mockMvc.perform(post("/api/users")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.details.email").isArray())
+                .andExpect(jsonPath("$.details.nickname").isArray())
+                .andExpect(jsonPath("$.details.password").isArray());
+
+        // 컨트롤러가 실제로 register을 호출을 안했는지 검증하기 위해 추가
+        verify(userService, never()).register(ArgumentMatchers.any(UserRegisterRequest.class));
     }
 }

--- a/src/test/java/com/springboot/monew/users/service/UserServiceTest.java
+++ b/src/test/java/com/springboot/monew/users/service/UserServiceTest.java
@@ -2,6 +2,7 @@ package com.springboot.monew.users.service;
 
 import com.springboot.monew.users.dto.UserDto;
 import com.springboot.monew.users.dto.UserLoginRequest;
+import com.springboot.monew.users.dto.UserRegisterRequest;
 import com.springboot.monew.users.entity.User;
 import com.springboot.monew.users.exception.UserErrorCode;
 import com.springboot.monew.users.exception.UserException;
@@ -19,7 +20,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
-import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -35,9 +37,100 @@ public class UserServiceTest {
     private UserService userService;
 
     @Test
+    @DisplayName("이메일이 중복되면 DUPLICATE_EMAIL 예외가 발생한다")
+    void register_duplicateEmail() {
+        // given
+        UserRegisterRequest request = new UserRegisterRequest(
+                "test@example.com",
+                "monew123",
+                "ab12!@"
+        );
+
+        when(userRepository.existsByEmail(request.email())).thenReturn(true);
+
+        // when & then
+        /*
+            초기에는 catchThrowableOfType을 사용했지만, 현재는 AssertJ에서 권장하는 방식인 assertThatThrownBy를 사용했다.
+            catchThrowableOfType은 예외를 먼저 변수로 받아서 검증하는 구조라 코드가 분리되는 반면,
+            assertThatThrownBy는 예외 발생과 검증을 하나의 체이닝 형태로 이어서 작성할 수 있어 가독성과 확장성이 더 좋다.
+         */
+        assertThatThrownBy(() -> userService.register(request))
+                .isInstanceOf(UserException.class)
+                .satisfies(throwable -> {
+                    UserException exception = (UserException) throwable;
+                    assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.DUPLICATE_EMAIL);
+                    assertThat(exception.getDetails()).isEqualTo(Map.of("email", request.email()));
+                });
+        verify(userRepository).existsByEmail(request.email());
+        verify(userRepository, never()).existsByNickname(anyString());
+        verify(userRepository, never()).save(any());
+        verify(userMapper, never()).toDto(any());
+    }
+
+    @Test
+    @DisplayName("닉네임이 중복되면 DUPLICATE_NICKNAME 예외가 발생한다")
+    void register_duplicateNickname() {
+        // given
+        UserRegisterRequest request = new UserRegisterRequest(
+                "test@example.com",
+                "monew123",
+                "ab12!@"
+        );
+
+        when(userRepository.existsByEmail(request.email())).thenReturn(false);
+        when(userRepository.existsByNickname(request.nickname())).thenReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> userService.register(request))
+                .isInstanceOf(UserException.class)
+                .satisfies(throwable -> {
+                    UserException exception = (UserException) throwable;
+                    assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.DUPLICATE_NICKNAME);
+                    assertThat(exception.getDetails()).isEqualTo(Map.of("nickname", request.nickname()));
+                });
+        verify(userRepository).existsByEmail(request.email());
+        verify(userRepository).existsByNickname(request.nickname());
+        verify(userRepository, never()).save(any());
+        verify(userMapper, never()).toDto(any());
+    }
+
+    @Test
+    @DisplayName("회원가입 성공 시 사용자를 저장한 뒤 UserDto를 반환한다")
+    void register_success() {
+        // given
+        UserRegisterRequest request = new UserRegisterRequest(
+                "test@example.com",
+                "monew123",
+                "ab12!@"
+        );
+
+        User savedUser = new User("test@example.com", "monew123", "ab12!@");
+        UserDto expected = new UserDto(
+                UUID.randomUUID(),
+                "test@example.com",
+                "monew123",
+                Instant.parse("2026-04-18T00:00:00Z")
+        );
+
+        when(userRepository.existsByEmail(request.email())).thenReturn(false);
+        when(userRepository.existsByNickname(request.nickname())).thenReturn(false);
+        when(userRepository.save(any(User.class))).thenReturn(savedUser);
+        when(userMapper.toDto(savedUser)).thenReturn(expected);
+
+        // when
+        UserDto result = userService.register(request);
+
+        // then
+        assertThat(result).isEqualTo(expected);
+        verify(userRepository).existsByEmail(request.email());
+        verify(userRepository).existsByNickname(request.nickname());
+        verify(userRepository).save(any(User.class));
+        verify(userMapper).toDto(savedUser);
+    }
+
+    @Test
     @DisplayName("정상 로그인 시 사용자 정보를 반환한다")
     void login_success() {
-
         // given
         UserLoginRequest request = new UserLoginRequest("test@example.com", "password123");
         User user = new User("test@example.com", "monew123", "password123");
@@ -49,7 +142,7 @@ public class UserServiceTest {
                 Instant.parse("2026-04-18T00:00:00Z")
         );
 
-        when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
+        when(userRepository.findByEmail(request.email())).thenReturn(Optional.of(user));
         when(userMapper.toDto(user)).thenReturn(expected);
 
         // when
@@ -57,14 +150,13 @@ public class UserServiceTest {
 
         // then
         assertThat(result).isEqualTo(expected);
-        verify(userRepository).findByEmail("test@example.com");
+        verify(userRepository).findByEmail(request.email());
         verify(userMapper).toDto(user);
     }
 
     @Test
     @DisplayName("존재하지 않는 사용자로 로그인하면 USER_NOT_FOUND 예외가 발생한다")
     void login_userNotFound() {
-
         // given
         UserLoginRequest request = new UserLoginRequest("missing@example.com", "password123");
 
@@ -85,12 +177,11 @@ public class UserServiceTest {
     @Test
     @DisplayName("비밀번호가 일치하지 않으면 INVALID_CREDENTIALS 예외가 발생한다")
     void login_invalidPassword() {
-
         // given
         UserLoginRequest request = new UserLoginRequest("test@example.com", "wrong-password");
         User user = new User("test@example.com", "monew123", "password123");
 
-        when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
+        when(userRepository.findByEmail(request.email())).thenReturn(Optional.of(user));
 
         // when & then
         assertThatThrownBy(() -> userService.login(request))
@@ -98,16 +189,15 @@ public class UserServiceTest {
                 .satisfies(throwable -> {
                     UserException exception = (UserException) throwable;
                     assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.INVALID_CREDENTIALS);
-                    assertThat(exception.getDetails()).isEqualTo(Map.of("email", "test@example.com"));
+                    assertThat(exception.getDetails()).isEqualTo(Map.of("email", request.email()));
                 });
-        verify(userRepository).findByEmail("test@example.com");
+        verify(userRepository).findByEmail(request.email());
         verify(userMapper, never()).toDto(any());
     }
 
     @Test
     @DisplayName("삭제된 사용자는 로그인할 수 없고 USER_NOT_FOUND 예외가 발생한다")
     void login_deletedUser() {
-
         // given
         UserLoginRequest request = new UserLoginRequest("deleted@example.com", "password123");
         User deletedUser = new User("deleted@example.com", "monew123", "password123");


### PR DESCRIPTION
## 📌 해당 이슈카드
Closes #55 

## 📌 작업 내용
- 회원가입 기능에 대한 Controller 테스트와 Service 테스트를 추가했습니다.
- 정상 회원가입 흐름과 중복/유효성 검증 예외 케이스를 검증하도록 테스트를 구성했습니다.
- 회원가입과 직접 관련 없는 `UserErrorCode`의 불필요한 enum 항목을 정리했습니다.

## 🔧 변경 사항
- 요청 값 유효성 검증 실패 시 `400 Bad Request`를 반환하는 테스트를 추가했습니다.
- 이메일 및 닉네임 중복 시 예외가 발생하는 Service 테스트를 추가했습니다.
- 사용자 저장 이후 `UserDto`가 정상 반환되는 Service 테스트를 추가했습니다.
- 회원가입 테스트 범위에 맞춰 `UserErrorCode` 내 불필요한 enum을 정리했습니다.

## 반영 브랜치
`feature/#55/register-test` -> `dev`

## 💬 기타 참고 사항
- 불필요한 enum들인 'INVALID_EMAIL, INVALID_NICKNAME, INVALID_PASSWORD를 삭제하고,
 요구사항 정의서에는 '요청값 유효성 검증 실패 → 400 Bad Request' 이렇게 바꿔줬습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 사용자 등록 및 로그인 기능에 대한 테스트 커버리지 개선
  * 중복 이메일/닉네임 처리 및 유효성 검사 테스트 추가
  * 잘못된 요청 처리에 대한 테스트 케이스 추가

* **Bug Fixes**
  * 사용자 입력 유효성 검사 오류 처리 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->