### PR TITLE
[Feat] 사용자 닉네임 수정 기능 구현 및 테스트 코드 및 api 문서화

### DIFF
--- a/src/main/java/com/springboot/monew/users/controller/UserApiDocs.java
+++ b/src/main/java/com/springboot/monew/users/controller/UserApiDocs.java
@@ -4,7 +4,9 @@ import com.springboot.monew.common.exception.ErrorResponse;
 import com.springboot.monew.users.dto.UserDto;
 import com.springboot.monew.users.dto.UserLoginRequest;
 import com.springboot.monew.users.dto.UserRegisterRequest;
+import com.springboot.monew.users.dto.UserUpdateRequest;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
@@ -14,13 +16,18 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+import java.util.UUID;
 
 @Tag(name = "사용자 관리", description = "사용자 관련 API")
 public interface UserApiDocs {
 
     @Operation(
             summary = "회원가입",
-            description = "새로운 사용자를 등록합니다."
+            description = "새로운 사용자를 등록합니다.",
+            operationId = "register"
     )
     @ApiResponses({
             @ApiResponse(
@@ -52,7 +59,8 @@ public interface UserApiDocs {
 
     @Operation(
             summary = "로그인",
-            description = "사용자 로그인을 처리합니다."
+            description = "사용자 로그인을 처리합니다.",
+            operationId = "login"
     )
     @ApiResponses({
             @ApiResponse(
@@ -80,5 +88,49 @@ public interface UserApiDocs {
             @Valid
             @RequestBody
             UserLoginRequest request
+    );
+
+    @Operation(
+            summary = "사용자 정보 수정",
+            description = "사용자의 닉네임을 수정합니다.",
+            operationId = "update"
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "사용자 정보 수정 성공",
+                    content = @Content(schema = @Schema(implementation = UserDto.class))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 (입력값 검증 실패)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "사용자 정보 수정 권한 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "사용자 정보 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 내부 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    ResponseEntity<UserDto> update(
+            @Parameter(description = "사용자 ID")
+            @PathVariable UUID userId,
+
+            @Parameter(hidden = true)
+            @RequestHeader("MoNew-Request-User-ID") UUID requestUserId,
+
+            @Valid
+            @RequestBody
+            UserUpdateRequest request
     );
     }

--- a/src/main/java/com/springboot/monew/users/controller/UserApiDocs.java
+++ b/src/main/java/com/springboot/monew/users/controller/UserApiDocs.java
@@ -117,6 +117,11 @@ public interface UserApiDocs {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             ),
             @ApiResponse(
+                    responseCode = "409",
+                    description = "닉네임 중복",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
                     responseCode = "500",
                     description = "서버 내부 오류",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))

--- a/src/main/java/com/springboot/monew/users/controller/UserController.java
+++ b/src/main/java/com/springboot/monew/users/controller/UserController.java
@@ -3,6 +3,7 @@ package com.springboot.monew.users.controller;
 import com.springboot.monew.users.dto.UserDto;
 import com.springboot.monew.users.dto.UserLoginRequest;
 import com.springboot.monew.users.dto.UserRegisterRequest;
+import com.springboot.monew.users.dto.UserUpdateRequest;
 import com.springboot.monew.users.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +12,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/users")
@@ -32,6 +34,22 @@ public class UserController implements UserApiDocs {
             @Valid @RequestBody UserLoginRequest request
     ) {
         UserDto userDto = userService.login(request);
+        return ResponseEntity.ok(userDto);
+    }
+
+    @PatchMapping("/{userId}")
+    public ResponseEntity<UserDto> update(
+            @PathVariable UUID userId,
+            @RequestHeader("MoNew-Request-User-ID") UUID requestUserId,
+            @Valid @RequestBody UserUpdateRequest request
+    ) {
+        /* userId: 수정 대상 사용자 ID
+           requestUserId: 로그인한 사용자 ID(요구사항상 헤더로 전달)
+           - 아마 닉네임 수정 요청을 보낸 로그인 사용자가 누구인지 판별하기 위해서 헤더로 넣는 것 같음.
+           request: 수정할 닉네임 값
+           서비스에서 userId와 requestUserId를 비교해 본인 요청인지 검증한 뒤 닉네임을 수정한다.
+         */
+        UserDto userDto = userService.update(userId, requestUserId, request);
         return ResponseEntity.ok(userDto);
     }
 }

--- a/src/main/java/com/springboot/monew/users/dto/UserLoginRequest.java
+++ b/src/main/java/com/springboot/monew/users/dto/UserLoginRequest.java
@@ -6,8 +6,8 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "로그인 정보")
 public record UserLoginRequest(
-
         @Schema(description = "로그인 이메일")
         @NotBlank(message = "이메일은 필수입니다.")
         @Size(min = 5, max = 100, message = "이메일은 5자 이상 100자 이하여야 합니다.")

--- a/src/main/java/com/springboot/monew/users/dto/UserUpdateRequest.java
+++ b/src/main/java/com/springboot/monew/users/dto/UserUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.springboot.monew.users.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "수정할 사용자 정보")
+public record UserUpdateRequest(
+        @Schema(description = "수정 닉네임", minLength = 1, maxLength = 20)
+        @NotBlank(message = "닉네임은 필수입니다.")
+        @Size(min = 1, max = 20, message = "닉네임은 1자 이상 20자 이하여야 합니다.")
+        @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "닉네임은 한글, 영문, 숫자만 사용할 수 있습니다.")
+        String nickname
+) {
+}

--- a/src/main/java/com/springboot/monew/users/exception/UserErrorCode.java
+++ b/src/main/java/com/springboot/monew/users/exception/UserErrorCode.java
@@ -10,9 +10,9 @@ import org.springframework.http.HttpStatus;
 public enum UserErrorCode implements ErrorCode {
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "DUPLICATE_EMAIL", "이미 사용 중인 이메일입니다."),
     DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "DUPLICATE_NICKNAME", "이미 사용 중인 닉네임입니다."),
-
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "사용자를 찾을 수 없습니다."),
-    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "INVALID_CREDENTIALS", "이메일 또는 비밀번호가 올바르지 않습니다.");
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "INVALID_CREDENTIALS", "이메일 또는 비밀번호가 올바르지 않습니다."),
+    USER_NOT_OWNED(HttpStatus.FORBIDDEN, "USER_NOT_OWNED", "본인의 사용자 정보만 수정할 수 있습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/springboot/monew/users/service/UserService.java
+++ b/src/main/java/com/springboot/monew/users/service/UserService.java
@@ -3,6 +3,7 @@ package com.springboot.monew.users.service;
 import com.springboot.monew.users.dto.UserDto;
 import com.springboot.monew.users.dto.UserLoginRequest;
 import com.springboot.monew.users.dto.UserRegisterRequest;
+import com.springboot.monew.users.dto.UserUpdateRequest;
 import com.springboot.monew.users.entity.User;
 import com.springboot.monew.users.exception.UserErrorCode;
 import com.springboot.monew.users.exception.UserException;
@@ -14,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Map;
+import java.util.UUID;
 
 @Service
 @Slf4j
@@ -37,7 +39,6 @@ public class UserService {
 
         User savedUser = userRepository.save(user);
         log.info("회원가입 완료 - userId={}, email={}", savedUser.getId(), savedUser.getEmail());
-
         return userMapper.toDto(savedUser);
     }
 
@@ -68,6 +69,37 @@ public class UserService {
         }
 
         log.info("로그인 완료 - userId={}, email={}", user.getId(), user.getEmail());
+        return userMapper.toDto(user);
+    }
+
+    @Transactional
+    public UserDto update(UUID userId, UUID requestUserId, UserUpdateRequest request) {
+        // 다른 개발자 도구로 닉네임 수정을 막기 위해 '수정 대상 사용자'와 '요청을 보낸 사용자'가 같은지 검사
+        if(!userId.equals(requestUserId)) {
+            log.info("닉네임 수정 실패: 사용자 불일치 - userId={}, requestUserId={}", userId, requestUserId);
+            throw new UserException(
+                    UserErrorCode.USER_NOT_OWNED,
+                    Map.of("userId", userId, "requestUserId", requestUserId)
+            );
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(
+                        UserErrorCode.USER_NOT_FOUND,
+                        Map.of("userId", userId)
+                ));
+
+        if(!user.getNickname().equals(request.nickname())
+                && userRepository.existsByNickname(request.nickname())) {
+            log.info("닉네임 수정 실패: 닉네임 중복 - nickname={}", request.nickname());
+            throw new UserException(
+                    UserErrorCode.DUPLICATE_NICKNAME,
+                    Map.of("nickname", request.nickname())
+            );
+        }
+
+        user.updateNickname(request.nickname());
+        log.info("닉네임 수정 완료 - userId={}, nickname={}", user.getId(), user.getNickname());
         return userMapper.toDto(user);
     }
 

--- a/src/main/java/com/springboot/monew/users/service/UserService.java
+++ b/src/main/java/com/springboot/monew/users/service/UserService.java
@@ -45,7 +45,7 @@ public class UserService {
     public UserDto login(UserLoginRequest request) {
         User user = userRepository.findByEmail(request.email())
                 .orElseThrow(() -> {
-                    log.info("로그인 실패: 사용자를 찾을 수 없음 - email={}", request.email());
+                    log.warn("로그인 실패: 사용자를 찾을 수 없음 - email={}", request.email());
                     return new UserException(
                             UserErrorCode.USER_NOT_FOUND,
                             Map.of("email", request.email())
@@ -53,7 +53,7 @@ public class UserService {
                 });
 
         if (user.isDeleted()) {
-            log.info("로그인 실패: 탈퇴한 사용자 - email={}", request.email());
+            log.warn("로그인 실패: 탈퇴한 사용자 - email={}", request.email());
             throw new UserException(
                     UserErrorCode.USER_NOT_FOUND,
                     Map.of("email", request.email())
@@ -76,7 +76,7 @@ public class UserService {
     public UserDto update(UUID userId, UUID requestUserId, UserUpdateRequest request) {
         // 다른 개발자 도구로 닉네임 수정을 막기 위해 '수정 대상 사용자'와 '요청을 보낸 사용자'가 같은지 검사
         if(!userId.equals(requestUserId)) {
-            log.info("닉네임 수정 실패: 사용자 불일치 - userId={}, requestUserId={}", userId, requestUserId);
+            log.warn("닉네임 수정 실패: 사용자 불일치 - userId={}, requestUserId={}", userId, requestUserId);
             throw new UserException(
                     UserErrorCode.USER_NOT_OWNED,
                     Map.of("userId", userId, "requestUserId", requestUserId)
@@ -85,7 +85,7 @@ public class UserService {
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> {
-                    log.info("닉네임 수정 실패: 사용자를 찾을 수 없음 - userId={}", userId);
+                    log.warn("닉네임 수정 실패: 사용자를 찾을 수 없음 - userId={}", userId);
                     return new UserException(
                             UserErrorCode.USER_NOT_FOUND,
                             Map.of("userId", userId)
@@ -93,7 +93,7 @@ public class UserService {
                 });
 
         if(user.isDeleted()) {
-            log.info("닉네임 수정 실패: 탈퇴한 사용자 - userId={}", userId);
+            log.warn("닉네임 수정 실패: 탈퇴한 사용자 - userId={}", userId);
             throw new UserException(
                     UserErrorCode.USER_NOT_FOUND,
                     Map.of("userId", userId)
@@ -102,7 +102,7 @@ public class UserService {
 
         if(!user.getNickname().equals(request.nickname())
                 && userRepository.existsByNickname(request.nickname())) {
-            log.info("닉네임 수정 실패: 닉네임 중복 - nickname={}", request.nickname());
+            log.warn("닉네임 수정 실패: 닉네임 중복 - nickname={}", request.nickname());
             throw new UserException(
                     UserErrorCode.DUPLICATE_NICKNAME,
                     Map.of("nickname", request.nickname())
@@ -116,7 +116,7 @@ public class UserService {
 
     private void validateDuplicateEmail(String email) {
         if (userRepository.existsByEmail(email)) {
-            log.info("회원가입 실패 - email={}", email);
+            log.warn("회원가입 실패 - email={}", email);
             throw new UserException(
                     UserErrorCode.DUPLICATE_EMAIL,
                     Map.of("email", email)
@@ -126,7 +126,7 @@ public class UserService {
 
     private void validateDuplicateNickname(String nickname) {
         if (userRepository.existsByNickname(nickname)) {
-            log.info("회원가입 실패 - nickname={}", nickname);
+            log.warn("회원가입 실패 - nickname={}", nickname);
             throw new UserException(
                     UserErrorCode.DUPLICATE_NICKNAME,
                     Map.of("nickname", nickname)

--- a/src/main/java/com/springboot/monew/users/service/UserService.java
+++ b/src/main/java/com/springboot/monew/users/service/UserService.java
@@ -84,10 +84,21 @@ public class UserService {
         }
 
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(
-                        UserErrorCode.USER_NOT_FOUND,
-                        Map.of("userId", userId)
-                ));
+                .orElseThrow(() -> {
+                    log.info("닉네임 수정 실패: 사용자를 찾을 수 없음 - userId={}", userId);
+                    return new UserException(
+                            UserErrorCode.USER_NOT_FOUND,
+                            Map.of("userId", userId)
+                    );
+                });
+
+        if(user.isDeleted()) {
+            log.info("닉네임 수정 실패: 탈퇴한 사용자 - userId={}", userId);
+            throw new UserException(
+                    UserErrorCode.USER_NOT_FOUND,
+                    Map.of("userId", userId)
+            );
+        }
 
         if(!user.getNickname().equals(request.nickname())
                 && userRepository.existsByNickname(request.nickname())) {

--- a/src/test/java/com/springboot/monew/users/dto/UserRegisterRequestTest.java
+++ b/src/test/java/com/springboot/monew/users/dto/UserRegisterRequestTest.java
@@ -171,6 +171,20 @@ public class UserRegisterRequestTest {
     }
 
     @Test
+    @DisplayName("닉네임이 20자를 초과하면 검증에 실패한다")
+    void validateNickname_fail_whenTooLong() {
+        // given
+        UserRegisterRequest request =
+                new UserRegisterRequest("test@example.com", "a".repeat(21), "ab12!@");
+
+        // when
+        Set<ConstraintViolation<UserRegisterRequest>> violations = validator.validate(request);
+
+        // then
+        assertThat(violations).isNotEmpty();
+    }
+
+    @Test
     @DisplayName("비밀번호가 null이면 검증에 실패한다")
     void validatePassword_fail_whenNull() {
         // given

--- a/src/test/java/com/springboot/monew/users/dto/UserUpdateRequestTest.java
+++ b/src/test/java/com/springboot/monew/users/dto/UserUpdateRequestTest.java
@@ -1,0 +1,129 @@
+package com.springboot.monew.users.dto;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.*;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UserUpdateRequestTest {
+    private static ValidatorFactory factory;
+    private Validator validator;
+
+    @BeforeAll
+    static void setUpFactory() {
+        factory = Validation.buildDefaultValidatorFactory();
+    }
+
+    @BeforeEach
+    void setUp() {
+        validator = factory.getValidator();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        factory.close();
+    }
+
+    @Test
+    @DisplayName("닉네임 형태가 올바르면 검증에 성공한다")
+    void validateNickname_success() {
+        // given
+        UserUpdateRequest request =
+                new UserUpdateRequest("모뉴monew123");
+
+        // when
+        Set<ConstraintViolation<UserUpdateRequest>> violations = validator.validate(request);
+
+        // then
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    @DisplayName("닉네임이 null이면 검증에 실패한다")
+    void validateNickname_fail_whenNull() {
+        // given
+        UserUpdateRequest request =
+                new UserUpdateRequest(null);
+
+        // when
+        Set<ConstraintViolation<UserUpdateRequest>> violations = validator.validate(request);
+
+        // then
+        assertThat(violations).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("닉네임이 비어 있으면 검증에 실패한다")
+    void validateNickname_fail_whenBlank() {
+        // given
+        UserUpdateRequest request =
+                new UserUpdateRequest("");
+
+        // when
+        Set<ConstraintViolation<UserUpdateRequest>> violations = validator.validate(request);
+
+        // then
+        assertThat(violations).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("닉네임이 공백만 있으면 검증에 실패한다")
+    void validateNickname_fail_whenOnlyWhiteSpace() {
+        // given
+        UserUpdateRequest request =
+                new UserUpdateRequest("   ");
+
+        // when
+        Set<ConstraintViolation<UserUpdateRequest>> violations = validator.validate(request);
+
+        // then
+        assertThat(violations).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("닉네임에 공백이 포함되면 검증에 실패한다")
+    void validateNickname_fail_whenContainsWhitespace() {
+        // given
+        UserUpdateRequest request =
+                new UserUpdateRequest("ab c");
+
+        // when
+        Set<ConstraintViolation<UserUpdateRequest>> violations = validator.validate(request);
+
+        // then
+        assertThat(violations).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("닉네임에 특수문자가 포함되면 검증에 실패한다")
+    void validateNickname_fail_whenContainsSpecialCharacter() {
+        // given
+        UserUpdateRequest request =
+                new UserUpdateRequest("ab@c");
+
+        // when
+        Set<ConstraintViolation<UserUpdateRequest>> violations = validator.validate(request);
+
+        // then
+        assertThat(violations).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("닉네임이 20자를 초과하면 검증에 실패한다")
+    void validateNickname_fail_whenTooLong() {
+        // given
+        UserUpdateRequest request =
+                new UserUpdateRequest("a".repeat(21));
+
+        // when
+        Set<ConstraintViolation<UserUpdateRequest>> violations = validator.validate(request);
+
+        // then
+        assertThat(violations).isNotEmpty();
+    }
+}

--- a/src/test/java/com/springboot/monew/users/service/UserServiceTest.java
+++ b/src/test/java/com/springboot/monew/users/service/UserServiceTest.java
@@ -315,4 +315,33 @@ public class UserServiceTest {
         verify(userRepository).existsByNickname(request.nickname());
         verify(userMapper, never()).toDto(any());
     }
+
+    @Test
+    @DisplayName("기존 닉네임으로 수정 요청하면 중복 닉네임 조회 없이 성공한다")
+    void update_sameNickname() {
+        // given
+        UUID userId = UUID.randomUUID();
+        UserUpdateRequest request = new UserUpdateRequest("sameNickname");
+        User user = new User("test@example.com",  "sameNickname", "password123");
+
+        UserDto expected = new UserDto(
+                userId,
+                "test@example.com",
+                "sameNickname",
+                Instant.parse("2026-04-18T00:00:00Z")
+        );
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userMapper.toDto(user)).thenReturn(expected);
+
+        // when
+        UserDto result = userService.update(userId, userId, request);
+
+        // then
+        assertThat(result).isEqualTo(expected);
+        assertThat(user.getNickname()).isEqualTo(request.nickname());
+        verify(userRepository).findById(userId);
+        verify(userRepository, never()).existsByNickname(anyString());
+        verify(userMapper).toDto(user);
+    }
 }

--- a/src/test/java/com/springboot/monew/users/service/UserServiceTest.java
+++ b/src/test/java/com/springboot/monew/users/service/UserServiceTest.java
@@ -3,6 +3,7 @@ package com.springboot.monew.users.service;
 import com.springboot.monew.users.dto.UserDto;
 import com.springboot.monew.users.dto.UserLoginRequest;
 import com.springboot.monew.users.dto.UserRegisterRequest;
+import com.springboot.monew.users.dto.UserUpdateRequest;
 import com.springboot.monew.users.entity.User;
 import com.springboot.monew.users.exception.UserErrorCode;
 import com.springboot.monew.users.exception.UserException;
@@ -214,6 +215,104 @@ public class UserServiceTest {
                     assertThat(exception.getDetails()).isEqualTo(Map.of("email", "deleted@example.com"));
                 });
         verify(userRepository).findByEmail("deleted@example.com");
+        verify(userMapper, never()).toDto(any());
+    }
+
+    @Test
+    @DisplayName("닉네임 수정에 성공하면 수정된 사용자 정보를 반환한다")
+    void update_success() {
+        // given
+        UUID userId = UUID.randomUUID();
+        UserUpdateRequest request = new UserUpdateRequest("newNickname");
+        User user = new User("test@example.com",  "oldNickname", "password123");
+
+        UserDto expected = new UserDto(
+                userId,
+                "test@example.com",
+                "newNickname",
+                Instant.parse("2026-04-18T00:00:00Z")
+        );
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userRepository.existsByNickname(request.nickname())).thenReturn(false);
+        when(userMapper.toDto(user)).thenReturn(expected);
+
+        // when
+        UserDto result = userService.update(userId, userId, request);
+
+        // then
+        assertThat(result).isEqualTo(expected);
+        assertThat(user.getNickname()).isEqualTo(request.nickname());
+        verify(userRepository).findById(userId);
+        verify(userRepository).existsByNickname(request.nickname());
+        verify(userMapper).toDto(user);
+    }
+
+    @Test
+    @DisplayName("요청 사용자와 수정 대상 사용자가 다르면 USER_NOT_OWNED 예외가 발생한다.")
+    void update_userNotOwned() {
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID requestUserId = UUID.randomUUID();
+        UserUpdateRequest request = new UserUpdateRequest("newNickname");
+
+        // when & then
+        assertThatThrownBy(() -> userService.update(userId, requestUserId, request))
+                .isInstanceOf(UserException.class)
+                .satisfies(throwable -> {
+                    UserException exception = (UserException) throwable;
+                    assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_OWNED);
+                    assertThat(exception.getDetails()).isEqualTo(
+                            Map.of("userId", userId, "requestUserId", requestUserId));
+                });
+        verify(userRepository, never()).findById(any());
+        verify(userRepository, never()).existsByNickname(anyString());
+        verify(userMapper, never()).toDto(any());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자의 닉네임을 수정하면 USER_NOT_FOUND 예외가 발생한다")
+    void update_userNotFound() {
+        // given
+        UUID userId = UUID.randomUUID();
+        UserUpdateRequest request = new UserUpdateRequest("newNickname");
+
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.update(userId, userId, request))
+                .isInstanceOf(UserException.class)
+                .satisfies(throwable -> {
+                    UserException exception = (UserException) throwable;
+                    assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
+                    assertThat(exception.getDetails()).isEqualTo(Map.of("userId", userId));
+                });
+        verify(userRepository).findById(userId);
+        verify(userRepository, never()).existsByNickname(anyString());
+        verify(userMapper, never()).toDto(any());
+    }
+
+    @Test
+    @DisplayName("이미 사용 중인 닉네임으로 수정하면 DUPLICATE_NICKNAME 예외가 발생한다")
+    void update_duplicateNickname() {
+        UUID userId = UUID.randomUUID();
+        UserUpdateRequest request = new UserUpdateRequest("duplicateNickname");
+        User user = new User("test@example.com",  "oldNickname", "password123");
+
+        // given
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userRepository.existsByNickname(request.nickname())).thenReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> userService.update(userId, userId, request))
+                .isInstanceOf(UserException.class)
+                .satisfies(throwable -> {
+                    UserException exception = (UserException) throwable;
+                    assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.DUPLICATE_NICKNAME);
+                    assertThat(exception.getDetails()).isEqualTo(Map.of("nickname", request.nickname()));
+                });
+        verify(userRepository).findById(userId);
+        verify(userRepository).existsByNickname(request.nickname());
         verify(userMapper, never()).toDto(any());
     }
 }


### PR DESCRIPTION
## 📌 해당 이슈카드

Closes #9 #62 #63 #64 #65

## 📌 작업 내용
- 사용자 닉네임 수정 API 구현
- 요청 사용자와 수정 대상 사용자가 일치하는지 검증하는 권한 체크 추가
- 닉네임 중복 검증 및 기존 닉네임 유지 케이스 처리
- 사용자 수정 관련 예외 코드 추가
- 사용자 수정 API Swagger 문서화
- 닉네임 수정 정상/예외 케이스 테스트 추가

## 🔧 변경 사항
- `PATCH /api/users/{userId}` 엔드포인트 추가
- `UserUpdateRequest` DTO 추가
- `UserService.update()` 추가
- `USER_NOT_OWNED` 예외 코드 추가
- Swagger 문서에 사용자 정보 수정 API 응답 케이스 추가
- 테스트 코드 추가

## 반영 브랜치
`feature/#9/nickname-update` -> `dev`

## 💬 기타 참고 사항
- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자 프로필(닉네임) 수정 기능 추가 (PATCH /api/users/{userId}), 본인만 수정 가능(요청자 식별 헤더 필요)

* **유효성 검사**
  * 닉네임 검증 강화: 1–20자, 한글/영문/숫자만 허용, 공백/특수문자 차단

* **문서**
  * 프로필 수정 API 및 로그인/회원가입 문서화(작업 식별자 정리) 개선

* **오류 처리**
  * 본인 아닌 수정 시 접근 거부 오류 메시지 추가

* **테스트**
  * 닉네임 유효성 및 프로필 수정 서비스/유닛 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->