### PR TITLE
[Feat] 사용자 논리 삭제 구현 및 테스트 코드 작성

### DIFF
--- a/src/main/java/com/springboot/monew/users/controller/UserApiDocs.java
+++ b/src/main/java/com/springboot/monew/users/controller/UserApiDocs.java
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 
@@ -131,11 +132,42 @@ public interface UserApiDocs {
             @Parameter(description = "사용자 ID")
             @PathVariable UUID userId,
 
-            @Parameter(hidden = true)
+            @Parameter(description = "요청자 ID")
             @RequestHeader("MoNew-Request-User-ID") UUID requestUserId,
 
             @Valid
             @RequestBody
             UserUpdateRequest request
+    );
+
+    @Operation(
+            summary = "사용자 논리 삭제",
+            description = "사용자 논리적으로 삭제합니다.",
+            operationId = "delete"
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "204",
+                    description = "사용자 삭제 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "사용자 삭제 권한 없음"
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "사용자 정보 없음"
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 내부 오류"
+            )
+    })
+    ResponseEntity<Void> delete(
+            @Parameter(description = "사용자 ID")
+            @PathVariable UUID userId,
+
+            @Parameter(description = "요청자 ID")
+            @RequestHeader("MoNew-Request-User-ID") UUID requestUserId
     );
     }

--- a/src/main/java/com/springboot/monew/users/controller/UserController.java
+++ b/src/main/java/com/springboot/monew/users/controller/UserController.java
@@ -52,4 +52,13 @@ public class UserController implements UserApiDocs {
         UserDto userDto = userService.update(userId, requestUserId, request);
         return ResponseEntity.ok(userDto);
     }
+
+    @DeleteMapping("/{userId}")
+    public ResponseEntity<Void> delete(
+            @PathVariable UUID userId,
+            @RequestHeader("MoNew-Request-User-ID") UUID requestUserId
+    )  {
+        userService.delete(userId, requestUserId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/springboot/monew/users/service/UserService.java
+++ b/src/main/java/com/springboot/monew/users/service/UserService.java
@@ -75,13 +75,7 @@ public class UserService {
     @Transactional
     public UserDto update(UUID userId, UUID requestUserId, UserUpdateRequest request) {
         // 다른 개발자 도구로 닉네임 수정을 막기 위해 '수정 대상 사용자'와 '요청을 보낸 사용자'가 같은지 검사
-        if(!userId.equals(requestUserId)) {
-            log.warn("닉네임 수정 실패: 사용자 불일치 - userId={}, requestUserId={}", userId, requestUserId);
-            throw new UserException(
-                    UserErrorCode.USER_NOT_OWNED,
-                    Map.of("userId", userId, "requestUserId", requestUserId)
-            );
-        }
+        validateOwner(userId, requestUserId);
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> {
@@ -114,6 +108,31 @@ public class UserService {
         return userMapper.toDto(user);
     }
 
+    @Transactional
+    public void delete(UUID userId, UUID requestUserId) {
+        validateOwner(userId, requestUserId);
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> {
+                    log.warn("사용자 탈퇴 실패: 사용자를 찾을 수 없음 - userId={}", userId);
+                    return new UserException(
+                            UserErrorCode.USER_NOT_FOUND,
+                            Map.of("userId", userId)
+                    );
+                });
+
+        if (user.isDeleted()) {
+            log.warn("사용자 탈퇴 실패: 탈퇴한 사용자 - userId={}", userId);
+            throw new UserException(
+                    UserErrorCode.USER_NOT_FOUND,
+                    Map.of("userId", userId)
+            );
+        }
+
+        user.delete();
+        log.info("사용자 탈퇴 완료 - userId={}", user.getId());
+    }
+
     private void validateDuplicateEmail(String email) {
         if (userRepository.existsByEmail(email)) {
             log.warn("회원가입 실패 - email={}", email);
@@ -130,6 +149,16 @@ public class UserService {
             throw new UserException(
                     UserErrorCode.DUPLICATE_NICKNAME,
                     Map.of("nickname", nickname)
+            );
+        }
+    }
+
+    private void validateOwner(UUID userId, UUID requestUserId) {
+        if(!userId.equals(requestUserId)) {
+            log.warn("사용자 권한 검증 실패: 사용자 불일치 - userId={}, requestUserId={}", userId, requestUserId);
+            throw new UserException(
+                    UserErrorCode.USER_NOT_OWNED,
+                    Map.of("userId", userId, "requestUserId", requestUserId)
             );
         }
     }

--- a/src/test/java/com/springboot/monew/users/controller/UserControllerTest.java
+++ b/src/test/java/com/springboot/monew/users/controller/UserControllerTest.java
@@ -2,12 +2,13 @@ package com.springboot.monew.users.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.springboot.monew.users.dto.UserDto;
+import com.springboot.monew.users.dto.UserLoginRequest;
 import com.springboot.monew.users.dto.UserRegisterRequest;
+import com.springboot.monew.users.dto.UserUpdateRequest;
 import com.springboot.monew.users.service.UserService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
@@ -18,7 +19,7 @@ import java.time.Instant;
 import java.util.UUID;
 
 import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(UserController.class)
@@ -54,7 +55,7 @@ public class UserControllerTest {
         );
 
         // Mockito.when을 클래스명 없이 간단히 사용하기 위해 static import를 하였음.
-        when(userService.register(ArgumentMatchers.any(UserRegisterRequest.class))).thenReturn(response);
+        when(userService.register(any(UserRegisterRequest.class))).thenReturn(response);
 
         // when & then
         mockMvc.perform(post("/api/users")
@@ -67,7 +68,7 @@ public class UserControllerTest {
                 .andExpect(jsonPath("$.createdAt").value("2026-04-17T01:46:03.003Z"));
 
         // 컨트롤러가 실제로 register을 호출했는지 검증하기 위해 추가
-        verify(userService).register(ArgumentMatchers.any(UserRegisterRequest.class));
+        verify(userService).register(any(UserRegisterRequest.class));
     }
 
     @Test
@@ -91,6 +92,126 @@ public class UserControllerTest {
                 .andExpect(jsonPath("$.details.password").isArray());
 
         // 컨트롤러가 실제로 register을 호출을 안했는지 검증하기 위해 추가
-        verify(userService, never()).register(ArgumentMatchers.any(UserRegisterRequest.class));
+        verify(userService, never()).register(any(UserRegisterRequest.class));
+    }
+
+    @Test
+    @DisplayName("정상 로그인 요청이면 200 OK와 사용자 정보를 반환한다")
+    void login_success() throws Exception {
+        // given
+        UserLoginRequest request = new UserLoginRequest(
+                "test@example.com",
+                "password123"
+        );
+
+        UUID userId = UUID.randomUUID();
+        Instant createdAt = Instant.parse("2026-04-17T01:46:03.003Z");
+
+        UserDto expected = new UserDto(
+                userId,
+                "test@example.com",
+                "monew123",
+                createdAt
+        );
+
+        when(userService.login(any(UserLoginRequest.class))).thenReturn(expected);
+
+        // when & then
+        mockMvc.perform(post("/api/users/login")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.email").value(expected.email()))
+                .andExpect(jsonPath("$.nickname").value(expected.nickname()))
+                .andExpect(jsonPath("$.createdAt").value("2026-04-17T01:46:03.003Z"));
+
+        verify(userService).login(any(UserLoginRequest.class));
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 로그인 요청이면 400 Bad Request를 반환한다")
+    void login_validationFail() throws Exception {
+        //given
+        UserLoginRequest request = new UserLoginRequest(
+                "invalid-email",
+                ""
+        );
+
+        // when & then
+        mockMvc.perform(post("/api/users/login")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.details.email").isArray())
+                .andExpect(jsonPath("$.details.password").isArray());
+
+        verify(userService, never()).login(any(UserLoginRequest.class));
+    }
+
+    @Test
+    @DisplayName("정상 사용자 정보 수정 요청이면 200 OK와 수정된 사용자 정보를 반환한다")
+    void update_success() throws Exception {
+        // given
+        UUID userId = UUID.randomUUID();
+
+        UserUpdateRequest request = new UserUpdateRequest("newNickname");
+        Instant createdAt = Instant.parse("2026-04-17T01:46:03.003Z");
+
+        UserDto expected = new UserDto(
+                userId,
+                "test@example.com",
+                "monew123",
+                createdAt
+        );
+
+        when(userService.update(eq(userId), eq(userId), any(UserUpdateRequest.class))).thenReturn(expected);
+
+        // when & then
+        mockMvc.perform(patch("/api/users/{userId}", userId)
+                    .header("MoNew-Request-User-ID", userId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(userId.toString()))
+                .andExpect(jsonPath("$.email").value(expected.email()))
+                .andExpect(jsonPath("$.nickname").value(expected.nickname()))
+                .andExpect(jsonPath("$.createdAt").value("2026-04-17T01:46:03.003Z"));
+
+        verify(userService).update(eq(userId), eq(userId), any(UserUpdateRequest.class));
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 사용자 정보 수정 요청이면 400 Bad Request를 반환한다")
+    void update_validationFail() throws Exception {
+        // given
+        UUID userId = UUID.randomUUID();
+
+        UserUpdateRequest request = new UserUpdateRequest("");
+
+        // when & then
+        mockMvc.perform(patch("/api/users/{userId}", userId)
+                    .header("MoNew-Request-User-ID", userId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.details.nickname").isArray());
+
+        verify(userService, never()).update(eq(userId), eq(userId), any(UserUpdateRequest.class));
+    }
+
+    @Test
+    @DisplayName("정상 사용자 삭제 요청이면 204 No Content를 반환한다")
+    void delete_success() throws Exception {
+        // given
+        UUID userId = UUID.randomUUID();
+
+        // when & then
+        mockMvc.perform(delete("/api/users/{userId}", userId)
+                    .header("MoNew-Request-User-ID", userId))
+                .andExpect(status().isNoContent());
+
+        verify(userService).delete(userId, userId);
     }
 }

--- a/src/test/java/com/springboot/monew/users/service/UserServiceTest.java
+++ b/src/test/java/com/springboot/monew/users/service/UserServiceTest.java
@@ -293,6 +293,30 @@ public class UserServiceTest {
     }
 
     @Test
+    @DisplayName("삭제된 사용자의 닉네임을 수정하면 USER_NOT_FOUND 예외가 발생한다.")
+    void update_deletedUser() {
+        // given
+        UUID userId = UUID.randomUUID();
+        UserUpdateRequest request = new UserUpdateRequest("newNickname");
+        User deletedUser = new User("deleted@example.com", "monew123", "password123");
+        deletedUser.delete();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(deletedUser));
+
+        // when & then
+        assertThatThrownBy(() -> userService.update(userId, userId, request))
+                .isInstanceOf(UserException.class)
+                .satisfies(throwable -> {
+                    UserException exception = (UserException) throwable;
+                    assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
+                    assertThat(exception.getDetails()).isEqualTo(Map.of("userId", userId));
+                });
+
+        verify(userRepository).findById(userId);
+        verify(userRepository, never()).existsByNickname(anyString());
+    }
+
+    @Test
     @DisplayName("이미 사용 중인 닉네임으로 수정하면 DUPLICATE_NICKNAME 예외가 발생한다")
     void update_duplicateNickname() {
         UUID userId = UUID.randomUUID();
@@ -343,5 +367,84 @@ public class UserServiceTest {
         verify(userRepository).findById(userId);
         verify(userRepository, never()).existsByNickname(anyString());
         verify(userMapper).toDto(user);
+    }
+
+    @Test
+    @DisplayName("사용자 삭제에 성공하면 deletedAt이 설정된다")
+    void delete_success() {
+        // given
+        UUID userId = UUID.randomUUID();
+        User user = new User("test@example.com", "monew123", "password123");
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        // 삭제 되기 전 확인 검증용
+        assertThat(user.isDeleted()).isFalse();
+
+        // when
+        userService.delete(userId, userId);
+
+        // then
+        assertThat(user.isDeleted()).isTrue();
+        verify(userRepository).findById(userId);
+    }
+
+    @Test
+    @DisplayName("요청 사용자와 삭제 대상 사용자가 다르면 USER_NOT_OWNED 예외가 발생한다")
+    void delete_userNotOwned() {
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID requestUserId = UUID.randomUUID();
+
+        // when & then
+        assertThatThrownBy(() -> userService.delete(userId, requestUserId))
+                .isInstanceOf(UserException.class)
+                .satisfies(throwable -> {
+                    UserException exception = (UserException) throwable;
+                    assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_OWNED);
+                    assertThat(exception.getDetails()).isEqualTo(Map.of("userId", userId, "requestUserId", requestUserId));
+                });
+        verify(userRepository, never()).findById(any());
+        verify(userMapper, never()).toDto(any());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자를 삭제하면 USER_NOT_FOUND 예외가 발생한다")
+    void delete_userNotFound() {
+        // given
+        UUID userId = UUID.randomUUID();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.delete(userId, userId))
+                .isInstanceOf(UserException.class)
+                .satisfies(throwable -> {
+                    UserException exception = (UserException) throwable;
+                    assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
+                    assertThat(exception.getDetails()).isEqualTo(Map.of("userId", userId));
+                });
+        verify(userRepository).findById(userId);
+    }
+
+    @Test
+    @DisplayName("이미 삭제된 사용자를 삭제하면 USER_NOT_FOUND 예외가 발생한다")
+    void delete_deletedUser() {
+        // given
+        UUID userId = UUID.randomUUID();
+        User deletedUser = new User("deleted@example.com", "monew123", "password123");
+        deletedUser.delete();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(deletedUser));
+
+        // when & then
+        assertThatThrownBy(() -> userService.delete(userId, userId))
+                .isInstanceOf(UserException.class)
+                .satisfies(throwable -> {
+                    UserException exception = (UserException) throwable;
+                    assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
+                    assertThat(exception.getDetails()).isEqualTo(Map.of("userId", userId));
+                });
+        verify(userRepository).findById(userId);
+        assertThat(deletedUser.isDeleted()).isTrue();
     }
 }


### PR DESCRIPTION
## 📌 해당 이슈카드

Closes #10 #67 #68 #69 #72

## 📌 작업 내용

- 사용자 삭제 API를 추가했습니다.
- 사용자 삭제 요청 시 `deletedAt` 기반 논리 삭제가 수행되도록 처리했습니다.
- 삭제된 사용자는 로그인할 수 없도록 차단했습니다.
- 삭제 대상 사용자와 요청 사용자가 일치할 때만 삭제할 수 있도록 본인 검증 로직을 적용했습니다.
- 사용자 삭제 API에 대한 Swagger 문서화를 추가했습니다.
- 사용자 삭제, 로그인, 사용자 정보 수정 흐름에 대한 컨트롤러/서비스 테스트를 추가했습니다.

## 🔧 변경 사항
- `DELETE /api/users/{userId}` 엔드포인트 추가
- 공통 본인 검증 로직 `validateOwner` 분리
- 사용자 논리 삭제 API 문서 추가
- 회원가입, 로그인, 사용자 정보 수정, 사용자 삭제 API 요청/응답 테스트 보강

## 반영 브랜치
`feature/#10/user-delete` -> `dev`

## 💬 기타 참고 사항
- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자 계정 삭제 기능 추가 (204 상태 코드 반환)
  * API 문서에 사용자 삭제 엔드포인트 설명 추가

* **개선사항**
  * 사용자 소유권 검증 로직 강화로 보안 개선
  * 삭제된 사용자 처리 및 오류 응답 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->