### PR TITLE
[Feat] 관심사 등록 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,9 @@ dependencies {
     //aws
     implementation 'software.amazon.awssdk:s3:2.31.7'
     implementation 'software.amazon.awssdk:auth:2.31.7'
+
+    // 관심사 이름 유사도 체크를 위한 라이브러리 의존성 추가
+    implementation 'org.apache.commons:commons-text:1.11.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/springboot/monew/interest/controller/InterestController.java
+++ b/src/main/java/com/springboot/monew/interest/controller/InterestController.java
@@ -25,6 +25,6 @@ public class InterestController implements InterestApiDocs {
     @PostMapping
     public ResponseEntity<InterestDto> create(@Valid @RequestBody InterestRegisterRequest request) {
         InterestDto interestDto = interestService.create(request);
-        return ResponseEntity.created(URI.create("/api/interests")).body(interestDto);
+        return ResponseEntity.created(URI.create("/api/interests/" + interestDto.id())).body(interestDto);
     }
 }

--- a/src/main/java/com/springboot/monew/interest/controller/InterestController.java
+++ b/src/main/java/com/springboot/monew/interest/controller/InterestController.java
@@ -1,10 +1,18 @@
 package com.springboot.monew.interest.controller;
 
+import com.springboot.monew.interest.dto.request.InterestRegisterRequest;
+import com.springboot.monew.interest.dto.response.InterestDto;
 import com.springboot.monew.interest.service.InterestService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
 
 @Slf4j
 @RestController
@@ -13,4 +21,10 @@ import org.springframework.web.bind.annotation.RestController;
 public class InterestController implements InterestApiDocs {
 
     private final InterestService interestService;
+
+    @PostMapping
+    public ResponseEntity<InterestDto> create(@Valid @RequestBody InterestRegisterRequest request) {
+        InterestDto interestDto = interestService.create(request);
+        return ResponseEntity.created(URI.create("/api/interests")).body(interestDto);
+    }
 }

--- a/src/main/java/com/springboot/monew/interest/exception/InterestErrorCode.java
+++ b/src/main/java/com/springboot/monew/interest/exception/InterestErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum InterestErrorCode implements ErrorCode {
     INTEREST_NAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "IN01", "유사한 이름의 관심사가 이미 존재합니다."),
-    DUPLICATE_KEYWORDS(HttpStatus.BAD_REQUEST, "IN02", "키워드는 중복될 수 없습니다.");
+    INTEREST_NAME_SIMILARITY_CONFLICT(HttpStatus.CONFLICT, "IN02", "유사한 이름의 관심사가 이미 존재합니다."),
+    DUPLICATE_KEYWORDS(HttpStatus.BAD_REQUEST, "IN03", "키워드는 중복될 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/springboot/monew/interest/exception/InterestErrorCode.java
+++ b/src/main/java/com/springboot/monew/interest/exception/InterestErrorCode.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum InterestErrorCode implements ErrorCode {
+    // 관심사 이름이 이미 존재하는 예외와 80% 이상 유사한 관심사 이름이 존재하는 예외의 메시지를 동일하게 처리
     INTEREST_NAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "IN01", "유사한 이름의 관심사가 이미 존재합니다."),
     INTEREST_NAME_SIMILARITY_CONFLICT(HttpStatus.CONFLICT, "IN02", "유사한 이름의 관심사가 이미 존재합니다."),
     DUPLICATE_KEYWORDS(HttpStatus.BAD_REQUEST, "IN03", "키워드는 중복될 수 없습니다.");

--- a/src/main/java/com/springboot/monew/interest/exception/InterestErrorCode.java
+++ b/src/main/java/com/springboot/monew/interest/exception/InterestErrorCode.java
@@ -1,0 +1,17 @@
+package com.springboot.monew.interest.exception;
+
+import com.springboot.monew.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum InterestErrorCode implements ErrorCode {
+    INTEREST_NAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "IN01", "유사한 이름의 관심사가 이미 존재합니다."),
+    DUPLICATE_KEYWORDS(HttpStatus.BAD_REQUEST, "IN02", "키워드는 중복될 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/springboot/monew/interest/exception/InterestErrorCode.java
+++ b/src/main/java/com/springboot/monew/interest/exception/InterestErrorCode.java
@@ -1,6 +1,6 @@
 package com.springboot.monew.interest.exception;
 
-import com.springboot.monew.exception.ErrorCode;
+import com.springboot.monew.common.exception.ErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/springboot/monew/interest/exception/InterestErrorCode.java
+++ b/src/main/java/com/springboot/monew/interest/exception/InterestErrorCode.java
@@ -8,10 +8,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum InterestErrorCode implements ErrorCode {
-    // 관심사 이름이 이미 존재하는 예외와 80% 이상 유사한 관심사 이름이 존재하는 예외의 메시지를 동일하게 처리
-    INTEREST_NAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "IN01", "유사한 이름의 관심사가 이미 존재합니다."),
-    INTEREST_NAME_SIMILARITY_CONFLICT(HttpStatus.CONFLICT, "IN02", "유사한 이름의 관심사가 이미 존재합니다."),
-    DUPLICATE_KEYWORDS(HttpStatus.BAD_REQUEST, "IN03", "키워드는 중복될 수 없습니다.");
+
+    INTEREST_NAME_DUPLICATION(HttpStatus.CONFLICT, "IN01", "유사한 이름의 관심사가 이미 존재합니다."),
+    DUPLICATE_KEYWORDS(HttpStatus.BAD_REQUEST, "IN02", "키워드는 중복될 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/springboot/monew/interest/exception/InterestException.java
+++ b/src/main/java/com/springboot/monew/interest/exception/InterestException.java
@@ -1,0 +1,12 @@
+package com.springboot.monew.interest.exception;
+
+import com.springboot.monew.exception.ErrorCode;
+import com.springboot.monew.exception.MonewException;
+
+import java.util.Map;
+
+public class InterestException extends MonewException {
+    public InterestException(ErrorCode errorCode, Map<String, Object> details) {
+        super(errorCode, details);
+    }
+}

--- a/src/main/java/com/springboot/monew/interest/exception/InterestException.java
+++ b/src/main/java/com/springboot/monew/interest/exception/InterestException.java
@@ -1,7 +1,7 @@
 package com.springboot.monew.interest.exception;
 
-import com.springboot.monew.exception.ErrorCode;
-import com.springboot.monew.exception.MonewException;
+import com.springboot.monew.common.exception.ErrorCode;
+import com.springboot.monew.common.exception.MonewException;
 
 import java.util.Map;
 

--- a/src/main/java/com/springboot/monew/interest/repository/InterestRepository.java
+++ b/src/main/java/com/springboot/monew/interest/repository/InterestRepository.java
@@ -2,8 +2,15 @@ package com.springboot.monew.interest.repository;
 
 import com.springboot.monew.interest.entity.Interest;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface InterestRepository extends JpaRepository<Interest, UUID> {
+
+    boolean existsByName(String name);
+
+    @Query("SELECT i.name FROM Interest i")
+    List<String> findAllNames();
 }

--- a/src/main/java/com/springboot/monew/interest/repository/KeywordRepository.java
+++ b/src/main/java/com/springboot/monew/interest/repository/KeywordRepository.java
@@ -3,7 +3,10 @@ package com.springboot.monew.interest.repository;
 import com.springboot.monew.interest.entity.Keyword;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface KeywordRepository extends JpaRepository<Keyword, UUID> {
+
+    Optional<Keyword> findByName(String name);
 }

--- a/src/main/java/com/springboot/monew/interest/service/InterestService.java
+++ b/src/main/java/com/springboot/monew/interest/service/InterestService.java
@@ -15,6 +15,7 @@ import com.springboot.monew.interest.util.StringSimilarityUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
@@ -31,6 +32,7 @@ public class InterestService {
     private final InterestKeywordRepository interestKeywordRepository;
     private final InterestDtoMapper interestDtoMapper;
 
+    @Transactional
     public InterestDto create(InterestRegisterRequest request) {
         String interestName = request.name();
         List<String> keywordNames = request.keywords();

--- a/src/main/java/com/springboot/monew/interest/service/InterestService.java
+++ b/src/main/java/com/springboot/monew/interest/service/InterestService.java
@@ -65,7 +65,7 @@ public class InterestService {
 
         for (String existingName : existingNames) {
             if (StringSimilarityUtil.isSimilarEnough(interestName, existingName, NAME_SIMILARITY_THRESHOLD)) {
-                throw new InterestException(InterestErrorCode.INTEREST_NAME_ALREADY_EXISTS, Map.of("name", interestName));
+                throw new InterestException(InterestErrorCode.INTEREST_NAME_SIMILARITY_CONFLICT, Map.of("name", interestName));
             }
         }
     }

--- a/src/main/java/com/springboot/monew/interest/service/InterestService.java
+++ b/src/main/java/com/springboot/monew/interest/service/InterestService.java
@@ -25,6 +25,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class InterestService {
 
+    // 유사도 임계값 (80%)
     private static final double NAME_SIMILARITY_THRESHOLD = 0.8;
 
     private final InterestRepository interestRepository;
@@ -34,19 +35,27 @@ public class InterestService {
 
     @Transactional
     public InterestDto create(InterestRegisterRequest request) {
+        // 관심사 이름과 키워드 목록 추출
         String interestName = request.name();
         List<String> keywordNames = request.keywords();
 
+        // 관심사 이름이 이미 존재하는지 검증
         validateDuplicateInterestName(interestName);
+        // 80% 이상 유사한 관심사 이름이 존재하는지 검증
         validateSimilarInterestName(interestName);
+        // 입력 받은 키워드 중 중복이 있는지 검증
         validateDuplicateKeywords(keywordNames);
 
+        // 관심사 저장
         Interest interest = interestRepository.save(new Interest(interestName));
 
+        // 요청 받은 키워드 목록 순회
         for (String keywordName : keywordNames) {
+            // 새로운 키워드라면 저장
             Keyword keyword = keywordRepository.findByName(keywordName)
                     .orElseGet(() -> keywordRepository.save(new Keyword(keywordName)));
 
+            // 관심사-키워드 연결 저장
             interestKeywordRepository.save(new InterestKeyword(interest, keyword));
         }
 
@@ -55,15 +64,19 @@ public class InterestService {
     }
 
     private void validateDuplicateInterestName(String interestName) {
+        // 관심사 이름이 이미 존재하면 예외 발생
         if (interestRepository.existsByName(interestName)) {
             throw new InterestException(InterestErrorCode.INTEREST_NAME_ALREADY_EXISTS, Map.of("name", interestName));
         }
     }
 
     private void validateSimilarInterestName(String interestName) {
+        // 관심사 이름 전체 조회
         List<String> existingNames = interestRepository.findAllNames();
 
+        // 관심사 이름 순회
         for (String existingName : existingNames) {
+            // 관심사 이름 유사도 체크
             if (StringSimilarityUtil.isSimilarEnough(interestName, existingName, NAME_SIMILARITY_THRESHOLD)) {
                 throw new InterestException(InterestErrorCode.INTEREST_NAME_SIMILARITY_CONFLICT, Map.of("name", interestName));
             }
@@ -71,10 +84,12 @@ public class InterestService {
     }
 
     private void validateDuplicateKeywords(List<String> keywords) {
+        // 키워드 목록 중복 제거 후 개수 파악
         long distinctCount = keywords.stream()
                 .distinct()
                 .count();
 
+        // 중복으로 제거된 키워드가 있다면 예외 발생
         if (distinctCount != keywords.size()) {
             throw new InterestException(InterestErrorCode.DUPLICATE_KEYWORDS, Map.of());
         }

--- a/src/main/java/com/springboot/monew/interest/service/InterestService.java
+++ b/src/main/java/com/springboot/monew/interest/service/InterestService.java
@@ -5,6 +5,8 @@ import com.springboot.monew.interest.dto.response.InterestDto;
 import com.springboot.monew.interest.entity.Interest;
 import com.springboot.monew.interest.entity.InterestKeyword;
 import com.springboot.monew.interest.entity.Keyword;
+import com.springboot.monew.interest.exception.InterestErrorCode;
+import com.springboot.monew.interest.exception.InterestException;
 import com.springboot.monew.interest.mapper.InterestDtoMapper;
 import com.springboot.monew.interest.repository.InterestKeywordRepository;
 import com.springboot.monew.interest.repository.InterestRepository;
@@ -14,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -48,8 +51,7 @@ public class InterestService {
 
     private void validateDuplicateInterestName(String interestName) {
         if (interestRepository.existsByName(interestName)) {
-            // 예외 개선 필요 - "이미 존재하는 관심사 이름입니다."
-            throw new RuntimeException();
+            throw new InterestException(InterestErrorCode.INTEREST_NAME_ALREADY_EXISTS, Map.of("name", interestName));
         }
     }
 
@@ -58,8 +60,7 @@ public class InterestService {
 
         for (String existingName : existingNames) {
             if (StringSimilarityUtil.isSimilarEnough(interestName, existingName, NAME_SIMILARITY_THRESHOLD)) {
-                // 예외 개선 필요 - "유사도 80% 이상의 관심사 이름은 등록할 수 없습니다."
-                throw new RuntimeException();
+                throw new InterestException(InterestErrorCode.INTEREST_NAME_ALREADY_EXISTS, Map.of("name", interestName));
             }
         }
     }
@@ -70,8 +71,7 @@ public class InterestService {
                 .count();
 
         if (distinctCount != keywords.size()) {
-            // 예외 개선 필요 - "키워드는 중복될 수 없습니다."
-            throw new RuntimeException();
+            throw new InterestException(InterestErrorCode.DUPLICATE_KEYWORDS, Map.of());
         }
     }
 }

--- a/src/main/java/com/springboot/monew/interest/service/InterestService.java
+++ b/src/main/java/com/springboot/monew/interest/service/InterestService.java
@@ -13,11 +13,13 @@ import com.springboot.monew.interest.repository.InterestRepository;
 import com.springboot.monew.interest.repository.KeywordRepository;
 import com.springboot.monew.interest.util.StringSimilarityUtil;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Map;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class InterestService {
@@ -46,6 +48,7 @@ public class InterestService {
             interestKeywordRepository.save(new InterestKeyword(interest, keyword));
         }
 
+        log.info("관심사 등록 완료 - interestId: {}, interestName: {}, keywordNames: {}", interest.getId(), interest.getName(), keywordNames);
         return interestDtoMapper.toInterestDto(interest, keywordNames, false);
     }
 

--- a/src/main/java/com/springboot/monew/interest/service/InterestService.java
+++ b/src/main/java/com/springboot/monew/interest/service/InterestService.java
@@ -66,7 +66,7 @@ public class InterestService {
     private void validateDuplicateInterestName(String interestName) {
         // 관심사 이름이 이미 존재하면 예외 발생
         if (interestRepository.existsByName(interestName)) {
-            throw new InterestException(InterestErrorCode.INTEREST_NAME_ALREADY_EXISTS, Map.of("name", interestName));
+            throw new InterestException(InterestErrorCode.INTEREST_NAME_DUPLICATION, Map.of("name", interestName));
         }
     }
 
@@ -78,7 +78,7 @@ public class InterestService {
         for (String existingName : existingNames) {
             // 관심사 이름 유사도 체크
             if (StringSimilarityUtil.isSimilarEnough(interestName, existingName, NAME_SIMILARITY_THRESHOLD)) {
-                throw new InterestException(InterestErrorCode.INTEREST_NAME_SIMILARITY_CONFLICT, Map.of("name", interestName));
+                throw new InterestException(InterestErrorCode.INTEREST_NAME_DUPLICATION, Map.of("name", interestName));
             }
         }
     }

--- a/src/main/java/com/springboot/monew/interest/service/InterestService.java
+++ b/src/main/java/com/springboot/monew/interest/service/InterestService.java
@@ -1,9 +1,77 @@
 package com.springboot.monew.interest.service;
 
+import com.springboot.monew.interest.dto.request.InterestRegisterRequest;
+import com.springboot.monew.interest.dto.response.InterestDto;
+import com.springboot.monew.interest.entity.Interest;
+import com.springboot.monew.interest.entity.InterestKeyword;
+import com.springboot.monew.interest.entity.Keyword;
+import com.springboot.monew.interest.mapper.InterestDtoMapper;
+import com.springboot.monew.interest.repository.InterestKeywordRepository;
+import com.springboot.monew.interest.repository.InterestRepository;
+import com.springboot.monew.interest.repository.KeywordRepository;
+import com.springboot.monew.interest.util.StringSimilarityUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class InterestService {
+
+    private static final double NAME_SIMILARITY_THRESHOLD = 0.8;
+
+    private final InterestRepository interestRepository;
+    private final KeywordRepository keywordRepository;
+    private final InterestKeywordRepository interestKeywordRepository;
+    private final InterestDtoMapper interestDtoMapper;
+
+    public InterestDto create(InterestRegisterRequest request) {
+        String interestName = request.name();
+        List<String> keywordNames = request.keywords();
+
+        validateDuplicateInterestName(interestName);
+        validateSimilarInterestName(interestName);
+        validateDuplicateKeywords(keywordNames);
+
+        Interest interest = interestRepository.save(new Interest(interestName));
+
+        for (String keywordName : keywordNames) {
+            Keyword keyword = keywordRepository.findByName(keywordName)
+                    .orElseGet(() -> keywordRepository.save(new Keyword(keywordName)));
+
+            interestKeywordRepository.save(new InterestKeyword(interest, keyword));
+        }
+
+        return interestDtoMapper.toInterestDto(interest, keywordNames, false);
+    }
+
+    private void validateDuplicateInterestName(String interestName) {
+        if (interestRepository.existsByName(interestName)) {
+            // 예외 개선 필요 - "이미 존재하는 관심사 이름입니다."
+            throw new RuntimeException();
+        }
+    }
+
+    private void validateSimilarInterestName(String interestName) {
+        List<String> existingNames = interestRepository.findAllNames();
+
+        for (String existingName : existingNames) {
+            if (StringSimilarityUtil.isSimilarEnough(interestName, existingName, NAME_SIMILARITY_THRESHOLD)) {
+                // 예외 개선 필요 - "유사도 80% 이상의 관심사 이름은 등록할 수 없습니다."
+                throw new RuntimeException();
+            }
+        }
+    }
+
+    private void validateDuplicateKeywords(List<String> keywords) {
+        long distinctCount = keywords.stream()
+                .distinct()
+                .count();
+
+        if (distinctCount != keywords.size()) {
+            // 예외 개선 필요 - "키워드는 중복될 수 없습니다."
+            throw new RuntimeException();
+        }
+    }
 }

--- a/src/main/java/com/springboot/monew/interest/util/StringSimilarityUtil.java
+++ b/src/main/java/com/springboot/monew/interest/util/StringSimilarityUtil.java
@@ -4,6 +4,7 @@ import org.apache.commons.text.similarity.LevenshteinDistance;
 
 public final class StringSimilarityUtil {
 
+    // Levenshtein Distance(레벤슈타인 거리) 알고리즘
     private static final LevenshteinDistance LEVENSHTEIN_DISTANCE =
             LevenshteinDistance.getDefaultInstance();
 
@@ -20,11 +21,13 @@ public final class StringSimilarityUtil {
             return 1.0;
         }
 
+        // Levenshtein Distance 알고리즘 적용
         int distance = LEVENSHTEIN_DISTANCE.apply(a, b);
         return (double) (maxLength - distance) / maxLength;
     }
 
     public static boolean isSimilarEnough(String a, String b, double threshold) {
+        // 임계값과 비교 후 임계값 이상이면 true 반환
         return similarity(a, b) >= threshold;
     }
 }

--- a/src/main/java/com/springboot/monew/interest/util/StringSimilarityUtil.java
+++ b/src/main/java/com/springboot/monew/interest/util/StringSimilarityUtil.java
@@ -1,0 +1,30 @@
+package com.springboot.monew.interest.util;
+
+import org.apache.commons.text.similarity.LevenshteinDistance;
+
+public final class StringSimilarityUtil {
+
+    private static final LevenshteinDistance LEVENSHTEIN_DISTANCE =
+            LevenshteinDistance.getDefaultInstance();
+
+    private StringSimilarityUtil() {
+    }
+
+    public static double similarity(String a, String b) {
+        if (a == null || b == null) {
+            return 0.0;
+        }
+
+        int maxLength = Math.max(a.length(), b.length());
+        if (maxLength == 0) {
+            return 1.0;
+        }
+
+        int distance = LEVENSHTEIN_DISTANCE.apply(a, b);
+        return (double) (maxLength - distance) / maxLength;
+    }
+
+    public static boolean isSimilarEnough(String a, String b, double threshold) {
+        return similarity(a, b) >= threshold;
+    }
+}


### PR DESCRIPTION
## 📌 해당 이슈카드
Closes #81 #87 

## 📌 작업 내용
- 유사도 체크를 위한 Levenshtein Distance(레벤슈타인 거리) 알고리즘 유틸 구현
- 관심사 등록 컨트롤러 구현
- 관심사 등록 서비스 구현
- InterestException과 InterestErrorCode 추가

## 🔧 변경 사항
- 유사도 체크를 위한 라이브러리 의존성 추가 `org.apache.commons:commons-text:1.11.0`

## 반영 브랜치
`feature/#81#87/Interest-create` -> `dev`

## 💬 기타 참고 사항
- N+1문제가 발생할 가능성과 더 적절한 Repository 메서드를 고려해본다면 개선 가능성이 있어보이지만 일단 빠른 기능 개발을 위해 추후 수정/조회/삭제가 구현이 완료된다면 그때 개선 작업을 해볼 생각입니다.
- Levenshtein Distance(레벤슈타인 거리) 알고리즘은 한 문자열을 다른 문자열로 바꾸기 위해 필요한 최소한의 연산 횟수를 계산하여 유사도를 체크하는 알고리즘입니다. 라이브러리가 존재하여 의존성 추가 후 사용했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 관심사 등록용 POST API 엔드포인트 추가
  * 관심사 이름의 중복 및 유사성 자동 검사와 적절한 오류 응답 추가
  * 관심사 내 키워드 중복 방지 및 키워드별 조회/처리 흐름 추가
  * 등록 성공 시 생성된 리소스의 위치(Location)를 반환하는 응답 동작 구현

* **기타**
  * 문자열 유사도 계산 유틸리티 추가
  * 문자열 처리 라이브러리 의존성 추가 (빌드 설정 변경)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->