### PR TITLE
[Feat] 관심사 수정 구현

### DIFF
--- a/src/main/java/com/springboot/monew/interest/controller/InterestApiDocs.java
+++ b/src/main/java/com/springboot/monew/interest/controller/InterestApiDocs.java
@@ -1,4 +1,5 @@
 package com.springboot.monew.interest.controller;
 
 public interface InterestApiDocs {
+
 }

--- a/src/main/java/com/springboot/monew/interest/controller/InterestController.java
+++ b/src/main/java/com/springboot/monew/interest/controller/InterestController.java
@@ -5,6 +5,8 @@ import com.springboot.monew.interest.dto.request.InterestUpdateRequest;
 import com.springboot.monew.interest.dto.response.InterestDto;
 import com.springboot.monew.interest.service.InterestService;
 import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -15,26 +17,25 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.net.URI;
-import java.util.UUID;
-
 @Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/interests")
 public class InterestController implements InterestApiDocs {
 
-    private final InterestService interestService;
+  private final InterestService interestService;
 
-    @PostMapping
-    public ResponseEntity<InterestDto> create(@Valid @RequestBody InterestRegisterRequest request) {
-        InterestDto interestDto = interestService.create(request);
-        return ResponseEntity.created(URI.create("/api/interests/" + interestDto.id())).body(interestDto);
-    }
+  @PostMapping
+  public ResponseEntity<InterestDto> create(@Valid @RequestBody InterestRegisterRequest request) {
+    InterestDto interestDto = interestService.create(request);
+    return ResponseEntity.created(URI.create("/api/interests/" + interestDto.id()))
+        .body(interestDto);
+  }
 
-    @PatchMapping("/{interestId}")
-    public ResponseEntity<InterestDto> update(@PathVariable UUID interestId, @Valid @RequestBody InterestUpdateRequest request) {
-        InterestDto interestDto = interestService.update(interestId, request);
-        return ResponseEntity.ok(interestDto);
-    }
+  @PatchMapping("/{interestId}")
+  public ResponseEntity<InterestDto> update(@PathVariable UUID interestId,
+      @Valid @RequestBody InterestUpdateRequest request) {
+    InterestDto interestDto = interestService.update(interestId, request);
+    return ResponseEntity.ok(interestDto);
+  }
 }

--- a/src/main/java/com/springboot/monew/interest/controller/InterestController.java
+++ b/src/main/java/com/springboot/monew/interest/controller/InterestController.java
@@ -1,12 +1,18 @@
 package com.springboot.monew.interest.controller;
 
 import com.springboot.monew.interest.dto.request.InterestRegisterRequest;
+import com.springboot.monew.interest.dto.request.InterestUpdateRequest;
 import com.springboot.monew.interest.dto.response.InterestDto;
 import com.springboot.monew.interest.service.InterestService;
 import jakarta.validation.Valid;
+
+import java.util.UUID;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,5 +32,11 @@ public class InterestController implements InterestApiDocs {
     public ResponseEntity<InterestDto> create(@Valid @RequestBody InterestRegisterRequest request) {
         InterestDto interestDto = interestService.create(request);
         return ResponseEntity.created(URI.create("/api/interests/" + interestDto.id())).body(interestDto);
+    }
+
+    @PatchMapping("/{interestId}")
+    public ResponseEntity<InterestDto> update(@PathVariable UUID interestId, @Valid @RequestBody InterestUpdateRequest request) {
+        InterestDto interestDto = interestService.update(interestId, request);
+        return ResponseEntity.ok(interestDto);
     }
 }

--- a/src/main/java/com/springboot/monew/interest/controller/InterestController.java
+++ b/src/main/java/com/springboot/monew/interest/controller/InterestController.java
@@ -5,9 +5,6 @@ import com.springboot.monew.interest.dto.request.InterestUpdateRequest;
 import com.springboot.monew.interest.dto.response.InterestDto;
 import com.springboot.monew.interest.service.InterestService;
 import jakarta.validation.Valid;
-
-import java.util.UUID;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -19,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;
+import java.util.UUID;
 
 @Slf4j
 @RestController

--- a/src/main/java/com/springboot/monew/interest/dto/request/InterestRegisterRequest.java
+++ b/src/main/java/com/springboot/monew/interest/dto/request/InterestRegisterRequest.java
@@ -3,20 +3,20 @@ package com.springboot.monew.interest.dto.request;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
-
 import java.util.List;
 
 // 관심사 등록 요청 dto
 public record InterestRegisterRequest(
-        @NotBlank(message = "관심사 이름은 필수입니다.")
-        @Size(min = 1, max = 50, message = "관심사 이름은 1자 이상 50자 이하로 입력해주세요.")
-        String name,
+    @NotBlank(message = "관심사 이름은 필수입니다.")
+    @Size(min = 1, max = 50, message = "관심사 이름은 1자 이상 50자 이하로 입력해주세요.")
+    String name,
 
-        @NotEmpty(message = "키워드는 최소 1개 이상 입력해야 합니다.")
-        @Size(min = 1, max = 10, message = "키워드는 최대 10개까지 입력할 수 있습니다.")
-        List<
-                @NotBlank(message = "키워드는 공백일 수 없습니다.")
-                @Size(max = 100, message = "키워드는 100자 이하로 입력해주세요.")
-                        String> keywords
+    @NotEmpty(message = "키워드는 최소 1개 이상 입력해야 합니다.")
+    @Size(min = 1, max = 10, message = "키워드는 최대 10개까지 입력할 수 있습니다.")
+    List<
+        @NotBlank(message = "키워드는 공백일 수 없습니다.")
+        @Size(max = 100, message = "키워드는 100자 이하로 입력해주세요.")
+            String> keywords
 ) {
+
 }

--- a/src/main/java/com/springboot/monew/interest/dto/request/InterestUpdateRequest.java
+++ b/src/main/java/com/springboot/monew/interest/dto/request/InterestUpdateRequest.java
@@ -3,16 +3,16 @@ package com.springboot.monew.interest.dto.request;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
-
 import java.util.List;
 
 // 관심사 수정 요청 dto
 public record InterestUpdateRequest(
-        @NotEmpty(message = "키워드는 최소 1개 이상 입력해야 합니다.")
-        @Size(min = 1, max = 10, message = "키워드는 최대 10개까지 입력할 수 있습니다.")
-        List<
-                @NotBlank(message = "키워드는 공백일 수 없습니다.")
-                @Size(max = 100, message = "키워드는 100자 이하로 입력해주세요.")
-                        String> keywords
+    @NotEmpty(message = "키워드는 최소 1개 이상 입력해야 합니다.")
+    @Size(min = 1, max = 10, message = "키워드는 최대 10개까지 입력할 수 있습니다.")
+    List<
+        @NotBlank(message = "키워드는 공백일 수 없습니다.")
+        @Size(max = 100, message = "키워드는 100자 이하로 입력해주세요.")
+            String> keywords
 ) {
+
 }

--- a/src/main/java/com/springboot/monew/interest/dto/response/CursorPageResponseInterestDto.java
+++ b/src/main/java/com/springboot/monew/interest/dto/response/CursorPageResponseInterestDto.java
@@ -5,11 +5,12 @@ import java.util.List;
 
 // 커서 기반 관심사 페이지 응답 dto
 public record CursorPageResponseInterestDto(
-        List<InterestDto> content,
-        String nextCursor,
-        Instant nextAfter,
-        int size,
-        long totalElements,
-        boolean hasNext
+    List<InterestDto> content,
+    String nextCursor,
+    Instant nextAfter,
+    int size,
+    long totalElements,
+    boolean hasNext
 ) {
+
 }

--- a/src/main/java/com/springboot/monew/interest/dto/response/InterestDto.java
+++ b/src/main/java/com/springboot/monew/interest/dto/response/InterestDto.java
@@ -5,10 +5,11 @@ import java.util.UUID;
 
 // 관심사 응답 dto
 public record InterestDto(
-        UUID id,
-        String name,
-        List<String> keywords,
-        long subscriberCount,
-        boolean subscribedByMe
+    UUID id,
+    String name,
+    List<String> keywords,
+    long subscriberCount,
+    boolean subscribedByMe
 ) {
+
 }

--- a/src/main/java/com/springboot/monew/interest/dto/response/SubscriptionDto.java
+++ b/src/main/java/com/springboot/monew/interest/dto/response/SubscriptionDto.java
@@ -6,11 +6,12 @@ import java.util.UUID;
 
 // 구독 응답 dto
 public record SubscriptionDto(
-        UUID id,
-        UUID interestId,
-        String interestName,
-        List<String> interestKeywords,
-        long interestSubscriberCount,
-        Instant createdAt
+    UUID id,
+    UUID interestId,
+    String interestName,
+    List<String> interestKeywords,
+    long interestSubscriberCount,
+    Instant createdAt
 ) {
+
 }

--- a/src/main/java/com/springboot/monew/interest/entity/Interest.java
+++ b/src/main/java/com/springboot/monew/interest/entity/Interest.java
@@ -11,38 +11,38 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Table(
-        name = "interests",
-        uniqueConstraints = {
-                @UniqueConstraint(
-                        name = "UK_INTERESTS_NAME",
-                        columnNames = "name"
-                )
-        }
+    name = "interests",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "UK_INTERESTS_NAME",
+            columnNames = "name"
+        )
+    }
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Interest extends BaseUpdatableEntity {
 
-    @Column(name = "name", nullable = false, length = 50)
-    private String name;
+  @Column(name = "name", nullable = false, length = 50)
+  private String name;
 
-    @Column(name = "subscriber_count", nullable = false)
-    private long subscriberCount;
+  @Column(name = "subscriber_count", nullable = false)
+  private long subscriberCount;
 
-    public Interest(String name) {
-        this.name = name;
-        this.subscriberCount = 0;
+  public Interest(String name) {
+    this.name = name;
+    this.subscriberCount = 0;
+  }
+
+  // 구독자 수 증가
+  public void increaseSubscriberCount() {
+    this.subscriberCount++;
+  }
+
+  // 구독자 수 감소
+  public void decreaseSubscriberCount() {
+    if (this.subscriberCount > 0) {
+      this.subscriberCount--;
     }
-
-    // 구독자 수 증가
-    public void increaseSubscriberCount() {
-        this.subscriberCount++;
-    }
-
-    // 구독자 수 감소
-    public void decreaseSubscriberCount() {
-        if (this.subscriberCount > 0) {
-            this.subscriberCount--;
-        }
-    }
+  }
 }

--- a/src/main/java/com/springboot/monew/interest/entity/InterestKeyword.java
+++ b/src/main/java/com/springboot/monew/interest/entity/InterestKeyword.java
@@ -13,28 +13,28 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Table(
-        name = "interest_keywords",
-        uniqueConstraints = {
-                @UniqueConstraint(
-                        name = "UK_INTEREST_KEYWORDS_INTEREST_ID_KEYWORD_ID",
-                        columnNames = {"interest_id", "keyword_id"}
-                )
-        }
+    name = "interest_keywords",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "UK_INTEREST_KEYWORDS_INTEREST_ID_KEYWORD_ID",
+            columnNames = {"interest_id", "keyword_id"}
+        )
+    }
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class InterestKeyword extends BaseEntity {
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "interest_id", nullable = false)
-    private Interest interest;
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "interest_id", nullable = false)
+  private Interest interest;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "keyword_id", nullable = false)
-    private Keyword keyword;
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "keyword_id", nullable = false)
+  private Keyword keyword;
 
-    public InterestKeyword(Interest interest, Keyword keyword) {
-        this.interest = interest;
-        this.keyword = keyword;
-    }
+  public InterestKeyword(Interest interest, Keyword keyword) {
+    this.interest = interest;
+    this.keyword = keyword;
+  }
 }

--- a/src/main/java/com/springboot/monew/interest/entity/Keyword.java
+++ b/src/main/java/com/springboot/monew/interest/entity/Keyword.java
@@ -11,22 +11,22 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Table(
-        name = "keywords",
-        uniqueConstraints = {
-                @UniqueConstraint(
-                        name = "UK_KEYWORDS_NAME",
-                        columnNames = "name"
-                )
-        }
+    name = "keywords",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "UK_KEYWORDS_NAME",
+            columnNames = "name"
+        )
+    }
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Keyword extends BaseEntity {
 
-    @Column(name = "name", nullable = false, length = 100)
-    String name;
+  @Column(name = "name", nullable = false, length = 100)
+  String name;
 
-    public Keyword(String name) {
-        this.name = name;
-    }
+  public Keyword(String name) {
+    this.name = name;
+  }
 }

--- a/src/main/java/com/springboot/monew/interest/entity/Subscription.java
+++ b/src/main/java/com/springboot/monew/interest/entity/Subscription.java
@@ -14,28 +14,28 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Table(
-        name = "subscriptions",
-        uniqueConstraints = {
-                @UniqueConstraint(
-                        name = "UK_SUBSCRIPTIONS_USER_ID_INTEREST_ID",
-                        columnNames = {"user_id", "interest_id"}
-                )
-        }
+    name = "subscriptions",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "UK_SUBSCRIPTIONS_USER_ID_INTEREST_ID",
+            columnNames = {"user_id", "interest_id"}
+        )
+    }
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Subscription extends BaseEntity {
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user;
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "interest_id", nullable = false)
-    private Interest interest;
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "interest_id", nullable = false)
+  private Interest interest;
 
-    public Subscription(User user, Interest interest) {
-        this.user = user;
-        this.interest = interest;
-    }
+  public Subscription(User user, Interest interest) {
+    this.user = user;
+    this.interest = interest;
+  }
 }

--- a/src/main/java/com/springboot/monew/interest/exception/InterestErrorCode.java
+++ b/src/main/java/com/springboot/monew/interest/exception/InterestErrorCode.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum InterestErrorCode implements ErrorCode {
 
     INTEREST_NAME_DUPLICATION(HttpStatus.CONFLICT, "IN01", "유사한 이름의 관심사가 이미 존재합니다."),
-    DUPLICATE_KEYWORDS(HttpStatus.BAD_REQUEST, "IN02", "키워드는 중복될 수 없습니다.");
+    DUPLICATE_KEYWORDS(HttpStatus.BAD_REQUEST, "IN02", "키워드는 중복될 수 없습니다."),
+    INTEREST_NOT_FOUND(HttpStatus.NOT_FOUND, "IN03", "관심사를 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/springboot/monew/interest/exception/InterestErrorCode.java
+++ b/src/main/java/com/springboot/monew/interest/exception/InterestErrorCode.java
@@ -9,11 +9,11 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum InterestErrorCode implements ErrorCode {
 
-    INTEREST_NAME_DUPLICATION(HttpStatus.CONFLICT, "IN01", "유사한 이름의 관심사가 이미 존재합니다."),
-    DUPLICATE_KEYWORDS(HttpStatus.BAD_REQUEST, "IN02", "키워드는 중복될 수 없습니다."),
-    INTEREST_NOT_FOUND(HttpStatus.NOT_FOUND, "IN03", "관심사를 찾을 수 없습니다.");
+  INTEREST_NAME_DUPLICATION(HttpStatus.CONFLICT, "IN01", "유사한 이름의 관심사가 이미 존재합니다."),
+  DUPLICATE_KEYWORDS(HttpStatus.BAD_REQUEST, "IN02", "키워드는 중복될 수 없습니다."),
+  INTEREST_NOT_FOUND(HttpStatus.NOT_FOUND, "IN03", "관심사를 찾을 수 없습니다.");
 
-    private final HttpStatus httpStatus;
-    private final String code;
-    private final String message;
+  private final HttpStatus httpStatus;
+  private final String code;
+  private final String message;
 }

--- a/src/main/java/com/springboot/monew/interest/exception/InterestException.java
+++ b/src/main/java/com/springboot/monew/interest/exception/InterestException.java
@@ -2,11 +2,11 @@ package com.springboot.monew.interest.exception;
 
 import com.springboot.monew.common.exception.ErrorCode;
 import com.springboot.monew.common.exception.MonewException;
-
 import java.util.Map;
 
 public class InterestException extends MonewException {
-    public InterestException(ErrorCode errorCode, Map<String, Object> details) {
-        super(errorCode, details);
-    }
+
+  public InterestException(ErrorCode errorCode, Map<String, Object> details) {
+    super(errorCode, details);
+  }
 }

--- a/src/main/java/com/springboot/monew/interest/mapper/InterestDtoMapper.java
+++ b/src/main/java/com/springboot/monew/interest/mapper/InterestDtoMapper.java
@@ -2,18 +2,17 @@ package com.springboot.monew.interest.mapper;
 
 import com.springboot.monew.interest.dto.response.InterestDto;
 import com.springboot.monew.interest.entity.Interest;
+import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-
-import java.util.List;
 
 @Mapper(componentModel = "spring")
 public interface InterestDtoMapper {
 
-    @Mapping(source = "interest.id", target = "id")
-    @Mapping(source = "interest.name", target = "name")
-    @Mapping(source = "keywords", target = "keywords")
-    @Mapping(source = "interest.subscriberCount", target = "subscriberCount")
-    @Mapping(source = "subscribedByMe", target = "subscribedByMe")
-    InterestDto toInterestDto(Interest interest, List<String> keywords, boolean subscribedByMe);
+  @Mapping(source = "interest.id", target = "id")
+  @Mapping(source = "interest.name", target = "name")
+  @Mapping(source = "keywords", target = "keywords")
+  @Mapping(source = "interest.subscriberCount", target = "subscriberCount")
+  @Mapping(source = "subscribedByMe", target = "subscribedByMe")
+  InterestDto toInterestDto(Interest interest, List<String> keywords, boolean subscribedByMe);
 }

--- a/src/main/java/com/springboot/monew/interest/mapper/SubscriptionDtoMapper.java
+++ b/src/main/java/com/springboot/monew/interest/mapper/SubscriptionDtoMapper.java
@@ -2,19 +2,18 @@ package com.springboot.monew.interest.mapper;
 
 import com.springboot.monew.interest.dto.response.SubscriptionDto;
 import com.springboot.monew.interest.entity.Subscription;
+import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-
-import java.util.List;
 
 @Mapper(componentModel = "spring")
 public interface SubscriptionDtoMapper {
 
-    @Mapping(source = "subscription.id", target = "id")
-    @Mapping(source = "subscription.interest.id", target = "interestId")
-    @Mapping(source = "subscription.interest.name", target = "interestName")
-    @Mapping(source = "interestKeywords", target = "interestKeywords")
-    @Mapping(source = "subscription.interest.subscriberCount", target = "interestSubscriberCount")
-    @Mapping(source = "subscription.createdAt", target = "createdAt")
-    SubscriptionDto toSubscriptionDto(Subscription subscription, List<String> interestKeywords);
+  @Mapping(source = "subscription.id", target = "id")
+  @Mapping(source = "subscription.interest.id", target = "interestId")
+  @Mapping(source = "subscription.interest.name", target = "interestName")
+  @Mapping(source = "interestKeywords", target = "interestKeywords")
+  @Mapping(source = "subscription.interest.subscriberCount", target = "interestSubscriberCount")
+  @Mapping(source = "subscription.createdAt", target = "createdAt")
+  SubscriptionDto toSubscriptionDto(Subscription subscription, List<String> interestKeywords);
 }

--- a/src/main/java/com/springboot/monew/interest/repository/InterestKeywordRepository.java
+++ b/src/main/java/com/springboot/monew/interest/repository/InterestKeywordRepository.java
@@ -3,10 +3,9 @@ package com.springboot.monew.interest.repository;
 import com.springboot.monew.interest.entity.Interest;
 import com.springboot.monew.interest.entity.InterestKeyword;
 import com.springboot.monew.interest.entity.Keyword;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.List;
 import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface InterestKeywordRepository extends JpaRepository<InterestKeyword, UUID> {
 

--- a/src/main/java/com/springboot/monew/interest/repository/InterestKeywordRepository.java
+++ b/src/main/java/com/springboot/monew/interest/repository/InterestKeywordRepository.java
@@ -1,9 +1,16 @@
 package com.springboot.monew.interest.repository;
 
+import com.springboot.monew.interest.entity.Interest;
 import com.springboot.monew.interest.entity.InterestKeyword;
+import com.springboot.monew.interest.entity.Keyword;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface InterestKeywordRepository extends JpaRepository<InterestKeyword, UUID> {
+
+  List<InterestKeyword> findAllByInterest(Interest interest);
+
+  boolean existsByKeyword(Keyword keyword);
 }

--- a/src/main/java/com/springboot/monew/interest/repository/InterestRepository.java
+++ b/src/main/java/com/springboot/monew/interest/repository/InterestRepository.java
@@ -1,16 +1,15 @@
 package com.springboot.monew.interest.repository;
 
 import com.springboot.monew.interest.entity.Interest;
+import java.util.List;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-import java.util.List;
-import java.util.UUID;
-
 public interface InterestRepository extends JpaRepository<Interest, UUID> {
 
-    boolean existsByName(String name);
+  boolean existsByName(String name);
 
-    @Query("SELECT i.name FROM Interest i")
-    List<String> findAllNames();
+  @Query("SELECT i.name FROM Interest i")
+  List<String> findAllNames();
 }

--- a/src/main/java/com/springboot/monew/interest/repository/KeywordRepository.java
+++ b/src/main/java/com/springboot/monew/interest/repository/KeywordRepository.java
@@ -1,12 +1,11 @@
 package com.springboot.monew.interest.repository;
 
 import com.springboot.monew.interest.entity.Keyword;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface KeywordRepository extends JpaRepository<Keyword, UUID> {
 
-    Optional<Keyword> findByName(String name);
+  Optional<Keyword> findByName(String name);
 }

--- a/src/main/java/com/springboot/monew/interest/repository/SubscriptionRepository.java
+++ b/src/main/java/com/springboot/monew/interest/repository/SubscriptionRepository.java
@@ -1,9 +1,9 @@
 package com.springboot.monew.interest.repository;
 
 import com.springboot.monew.interest.entity.Subscription;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.UUID;
-
 public interface SubscriptionRepository extends JpaRepository<Subscription, UUID> {
+
 }

--- a/src/main/java/com/springboot/monew/interest/service/InterestService.java
+++ b/src/main/java/com/springboot/monew/interest/service/InterestService.java
@@ -1,6 +1,7 @@
 package com.springboot.monew.interest.service;
 
 import com.springboot.monew.interest.dto.request.InterestRegisterRequest;
+import com.springboot.monew.interest.dto.request.InterestUpdateRequest;
 import com.springboot.monew.interest.dto.response.InterestDto;
 import com.springboot.monew.interest.entity.Interest;
 import com.springboot.monew.interest.entity.InterestKeyword;
@@ -12,6 +13,9 @@ import com.springboot.monew.interest.repository.InterestKeywordRepository;
 import com.springboot.monew.interest.repository.InterestRepository;
 import com.springboot.monew.interest.repository.KeywordRepository;
 import com.springboot.monew.interest.util.StringSimilarityUtil;
+
+import java.util.UUID;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -63,6 +67,44 @@ public class InterestService {
         return interestDtoMapper.toInterestDto(interest, keywordNames, false);
     }
 
+    @Transactional
+    public InterestDto update(UUID interestId, InterestUpdateRequest request) {
+        // 관심사 조회, 존재하지 않는 관심사라면 예외 발생
+        Interest interest = interestRepository.findById(interestId)
+                .orElseThrow(() -> new InterestException(InterestErrorCode.INTEREST_NOT_FOUND, Map.of("interestId", interestId)));
+
+        // 키워드 목록 추출
+        List<String> keywordNames = request.keywords();
+        // 입력 받은 키워드 중 중복이 있는지 검증
+        validateDuplicateKeywords(keywordNames);
+
+        // 해당 관심사의 연결 목록 조회
+        List<InterestKeyword> existingInterestKeywords = interestKeywordRepository.findAllByInterest(interest);
+        // 해당 관심사의 기존 키워드 목록 추출
+        List<Keyword> oldKeywords = existingInterestKeywords.stream()
+                .map(InterestKeyword::getKeyword)
+                .toList();
+
+        // 조회한 관심사-키워드 연결 삭제
+        interestKeywordRepository.deleteAll(existingInterestKeywords);
+
+        // 요청 받은 키워드 목록 순회
+        for (String keywordName : keywordNames) {
+            // 새로운 키워드라면 저장
+            Keyword keyword = keywordRepository.findByName(keywordName)
+                    .orElseGet(() -> keywordRepository.save(new Keyword(keywordName)));
+
+            // 관심사-키워드 연결 저장
+            interestKeywordRepository.save(new InterestKeyword(interest, keyword));
+        }
+
+        // 이전 키워드 목록을 순회하며 더 이상 연결된 관심사가 없다면 삭제
+        deleteOrphanKeywords(oldKeywords);
+
+        log.info("관심사 수정 완료 - interestId: {}, keywordNames: {}", interest.getId(), keywordNames);
+        return interestDtoMapper.toInterestDto(interest, keywordNames, false);
+    }
+
     private void validateDuplicateInterestName(String interestName) {
         // 관심사 이름이 이미 존재하면 예외 발생
         if (interestRepository.existsByName(interestName)) {
@@ -94,4 +136,15 @@ public class InterestService {
             throw new InterestException(InterestErrorCode.DUPLICATE_KEYWORDS, Map.of());
         }
     }
+
+    private void deleteOrphanKeywords(List<Keyword> keywords) {
+        for (Keyword keyword : keywords) {
+            // 해당 키워드와 연결된 관심사가 존재하지 않는다면
+            if (!interestKeywordRepository.existsByKeyword(keyword)) {
+                // 키워드 삭제
+                keywordRepository.delete(keyword);
+            }
+        }
+    }
+
 }

--- a/src/main/java/com/springboot/monew/interest/service/InterestService.java
+++ b/src/main/java/com/springboot/monew/interest/service/InterestService.java
@@ -13,88 +13,90 @@ import com.springboot.monew.interest.repository.InterestKeywordRepository;
 import com.springboot.monew.interest.repository.InterestRepository;
 import com.springboot.monew.interest.repository.KeywordRepository;
 import com.springboot.monew.interest.util.StringSimilarityUtil;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class InterestService {
 
-    // 유사도 임계값 (80%)
-    private static final double NAME_SIMILARITY_THRESHOLD = 0.8;
+  // 유사도 임계값 (80%)
+  private static final double NAME_SIMILARITY_THRESHOLD = 0.8;
 
-    private final InterestRepository interestRepository;
-    private final KeywordRepository keywordRepository;
-    private final InterestKeywordRepository interestKeywordRepository;
-    private final InterestDtoMapper interestDtoMapper;
+  private final InterestRepository interestRepository;
+  private final KeywordRepository keywordRepository;
+  private final InterestKeywordRepository interestKeywordRepository;
+  private final InterestDtoMapper interestDtoMapper;
 
-    @Transactional
-    public InterestDto create(InterestRegisterRequest request) {
-        // 관심사 이름과 키워드 목록 추출
-        String interestName = request.name();
-        List<String> keywordNames = request.keywords();
+  @Transactional
+  public InterestDto create(InterestRegisterRequest request) {
+    // 관심사 이름과 키워드 목록 추출
+    String interestName = request.name();
+    List<String> keywordNames = request.keywords();
 
-        // 관심사 이름이 이미 존재하는지 검증
-        validateDuplicateInterestName(interestName);
-        // 80% 이상 유사한 관심사 이름이 존재하는지 검증
-        validateSimilarInterestName(interestName);
-        // 입력 받은 키워드 중 중복이 있는지 검증
-        validateDuplicateKeywords(keywordNames);
+    // 관심사 이름이 이미 존재하는지 검증
+    validateDuplicateInterestName(interestName);
+    // 80% 이상 유사한 관심사 이름이 존재하는지 검증
+    validateSimilarInterestName(interestName);
+    // 입력 받은 키워드 중 중복이 있는지 검증
+    validateDuplicateKeywords(keywordNames);
 
-        // 관심사 저장
-        Interest interest = interestRepository.save(new Interest(interestName));
+    // 관심사 저장
+    Interest interest = interestRepository.save(new Interest(interestName));
 
-        // 요청 받은 키워드 목록 순회
-        for (String keywordName : keywordNames) {
-            Keyword keyword = getOrCreateKeyword(keywordName);
-            interestKeywordRepository.save(new InterestKeyword(interest, keyword));
-        }
-
-        log.info("관심사 등록 완료 - interestId: {}, interestName: {}, keywordNames: {}", interest.getId(), interest.getName(), keywordNames);
-        return interestDtoMapper.toInterestDto(interest, keywordNames, false);
+    // 요청 받은 키워드 목록 순회
+    for (String keywordName : keywordNames) {
+      Keyword keyword = getOrCreateKeyword(keywordName);
+      interestKeywordRepository.save(new InterestKeyword(interest, keyword));
     }
 
-    @Transactional
-    public InterestDto update(UUID interestId, InterestUpdateRequest request) {
-        // 관심사 조회, 존재하지 않는 관심사라면 예외 발생
-        Interest interest = interestRepository.findById(interestId)
-                .orElseThrow(() -> new InterestException(InterestErrorCode.INTEREST_NOT_FOUND, Map.of("interestId", interestId)));
+    log.info("관심사 등록 완료 - interestId: {}, interestName: {}, keywordNames: {}", interest.getId(),
+        interest.getName(), keywordNames);
+    return interestDtoMapper.toInterestDto(interest, keywordNames, false);
+  }
 
-        // 키워드 목록 추출
-        List<String> keywordNames = request.keywords();
-        // 입력 받은 키워드 중 중복이 있는지 검증
-        validateDuplicateKeywords(keywordNames);
+  @Transactional
+  public InterestDto update(UUID interestId, InterestUpdateRequest request) {
+    // 관심사 조회, 존재하지 않는 관심사라면 예외 발생
+    Interest interest = interestRepository.findById(interestId)
+        .orElseThrow(() -> new InterestException(InterestErrorCode.INTEREST_NOT_FOUND,
+            Map.of("interestId", interestId)));
 
-        // 해당 관심사의 연결 목록 조회
-        List<InterestKeyword> existingInterestKeywords = interestKeywordRepository.findAllByInterest(interest);
-        // 해당 관심사의 기존 키워드 목록 추출
-        List<Keyword> oldKeywords = existingInterestKeywords.stream()
-                .map(InterestKeyword::getKeyword)
-                .toList();
+    // 키워드 목록 추출
+    List<String> keywordNames = request.keywords();
+    // 입력 받은 키워드 중 중복이 있는지 검증
+    validateDuplicateKeywords(keywordNames);
 
-        // 조회한 관심사-키워드 연결 삭제
-        interestKeywordRepository.deleteAll(existingInterestKeywords);
+    // 해당 관심사의 연결 목록 조회
+    List<InterestKeyword> existingInterestKeywords = interestKeywordRepository.findAllByInterest(
+        interest);
+    // 해당 관심사의 기존 키워드 목록 추출
+    List<Keyword> oldKeywords = existingInterestKeywords.stream()
+        .map(InterestKeyword::getKeyword)
+        .toList();
 
-        // 요청 받은 키워드 목록 순회
-        for (String keywordName : keywordNames) {
-            Keyword keyword = getOrCreateKeyword(keywordName);
-            interestKeywordRepository.save(new InterestKeyword(interest, keyword));
-        }
+    // 조회한 관심사-키워드 연결 삭제
+    interestKeywordRepository.deleteAll(existingInterestKeywords);
 
-        // 이전 키워드 목록을 순회하며 더 이상 연결된 관심사가 없다면 삭제
-        deleteOrphanKeywords(oldKeywords);
-
-        log.info("관심사 수정 완료 - interestId: {}, keywordNames: {}", interest.getId(), keywordNames);
-        return interestDtoMapper.toInterestDto(interest, keywordNames, false);
+    // 요청 받은 키워드 목록 순회
+    for (String keywordName : keywordNames) {
+      Keyword keyword = getOrCreateKeyword(keywordName);
+      interestKeywordRepository.save(new InterestKeyword(interest, keyword));
     }
+
+    // 이전 키워드 목록을 순회하며 더 이상 연결된 관심사가 없다면 삭제
+    deleteOrphanKeywords(oldKeywords);
+
+    log.info("관심사 수정 완료 - interestId: {}, keywordNames: {}", interest.getId(), keywordNames);
+    return interestDtoMapper.toInterestDto(interest, keywordNames, false);
+  }
 
   private Keyword getOrCreateKeyword(String keywordName) {
     return keywordRepository.findByName(keywordName)
@@ -111,46 +113,49 @@ public class InterestService {
     }
   }
 
-    private void validateDuplicateInterestName(String interestName) {
-        // 관심사 이름이 이미 존재하면 예외 발생
-        if (interestRepository.existsByName(interestName)) {
-            throw new InterestException(InterestErrorCode.INTEREST_NAME_DUPLICATION, Map.of("name", interestName));
-        }
+  private void validateDuplicateInterestName(String interestName) {
+    // 관심사 이름이 이미 존재하면 예외 발생
+    if (interestRepository.existsByName(interestName)) {
+      throw new InterestException(InterestErrorCode.INTEREST_NAME_DUPLICATION,
+          Map.of("name", interestName));
     }
+  }
 
-    private void validateSimilarInterestName(String interestName) {
-        // 관심사 이름 전체 조회
-        List<String> existingNames = interestRepository.findAllNames();
+  private void validateSimilarInterestName(String interestName) {
+    // 관심사 이름 전체 조회
+    List<String> existingNames = interestRepository.findAllNames();
 
-        // 관심사 이름 순회
-        for (String existingName : existingNames) {
-            // 관심사 이름 유사도 체크
-            if (StringSimilarityUtil.isSimilarEnough(interestName, existingName, NAME_SIMILARITY_THRESHOLD)) {
-                throw new InterestException(InterestErrorCode.INTEREST_NAME_DUPLICATION, Map.of("name", interestName));
-            }
-        }
+    // 관심사 이름 순회
+    for (String existingName : existingNames) {
+      // 관심사 이름 유사도 체크
+      if (StringSimilarityUtil.isSimilarEnough(interestName, existingName,
+          NAME_SIMILARITY_THRESHOLD)) {
+        throw new InterestException(InterestErrorCode.INTEREST_NAME_DUPLICATION,
+            Map.of("name", interestName));
+      }
     }
+  }
 
-    private void validateDuplicateKeywords(List<String> keywords) {
-        // 키워드 목록 중복 제거 후 개수 파악
-        long distinctCount = keywords.stream()
-                .distinct()
-                .count();
+  private void validateDuplicateKeywords(List<String> keywords) {
+    // 키워드 목록 중복 제거 후 개수 파악
+    long distinctCount = keywords.stream()
+        .distinct()
+        .count();
 
-        // 중복으로 제거된 키워드가 있다면 예외 발생
-        if (distinctCount != keywords.size()) {
-            throw new InterestException(InterestErrorCode.DUPLICATE_KEYWORDS, Map.of());
-        }
+    // 중복으로 제거된 키워드가 있다면 예외 발생
+    if (distinctCount != keywords.size()) {
+      throw new InterestException(InterestErrorCode.DUPLICATE_KEYWORDS, Map.of());
     }
+  }
 
-    private void deleteOrphanKeywords(List<Keyword> keywords) {
-        for (Keyword keyword : keywords) {
-            // 해당 키워드와 연결된 관심사가 존재하지 않는다면
-            if (!interestKeywordRepository.existsByKeyword(keyword)) {
-                // 키워드 삭제
-                keywordRepository.delete(keyword);
-            }
-        }
+  private void deleteOrphanKeywords(List<Keyword> keywords) {
+    for (Keyword keyword : keywords) {
+      // 해당 키워드와 연결된 관심사가 존재하지 않는다면
+      if (!interestKeywordRepository.existsByKeyword(keyword)) {
+        // 키워드 삭제
+        keywordRepository.delete(keyword);
+      }
     }
+  }
 
 }

--- a/src/main/java/com/springboot/monew/interest/service/InterestService.java
+++ b/src/main/java/com/springboot/monew/interest/service/InterestService.java
@@ -13,9 +13,6 @@ import com.springboot.monew.interest.repository.InterestKeywordRepository;
 import com.springboot.monew.interest.repository.InterestRepository;
 import com.springboot.monew.interest.repository.KeywordRepository;
 import com.springboot.monew.interest.util.StringSimilarityUtil;
-
-import java.util.UUID;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -23,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 @Slf4j
 @Service

--- a/src/main/java/com/springboot/monew/interest/service/InterestService.java
+++ b/src/main/java/com/springboot/monew/interest/service/InterestService.java
@@ -15,6 +15,7 @@ import com.springboot.monew.interest.repository.KeywordRepository;
 import com.springboot.monew.interest.util.StringSimilarityUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -53,11 +54,7 @@ public class InterestService {
 
         // 요청 받은 키워드 목록 순회
         for (String keywordName : keywordNames) {
-            // 새로운 키워드라면 저장
-            Keyword keyword = keywordRepository.findByName(keywordName)
-                    .orElseGet(() -> keywordRepository.save(new Keyword(keywordName)));
-
-            // 관심사-키워드 연결 저장
+            Keyword keyword = getOrCreateKeyword(keywordName);
             interestKeywordRepository.save(new InterestKeyword(interest, keyword));
         }
 
@@ -88,11 +85,7 @@ public class InterestService {
 
         // 요청 받은 키워드 목록 순회
         for (String keywordName : keywordNames) {
-            // 새로운 키워드라면 저장
-            Keyword keyword = keywordRepository.findByName(keywordName)
-                    .orElseGet(() -> keywordRepository.save(new Keyword(keywordName)));
-
-            // 관심사-키워드 연결 저장
+            Keyword keyword = getOrCreateKeyword(keywordName);
             interestKeywordRepository.save(new InterestKeyword(interest, keyword));
         }
 
@@ -102,6 +95,21 @@ public class InterestService {
         log.info("관심사 수정 완료 - interestId: {}, keywordNames: {}", interest.getId(), keywordNames);
         return interestDtoMapper.toInterestDto(interest, keywordNames, false);
     }
+
+  private Keyword getOrCreateKeyword(String keywordName) {
+    return keywordRepository.findByName(keywordName)
+        .orElseGet(() -> saveKeywordSafely(keywordName));
+  }
+
+  private Keyword saveKeywordSafely(String keywordName) {
+    try {
+      return keywordRepository.saveAndFlush(new Keyword(keywordName));
+    } catch (DataIntegrityViolationException e) {
+      log.debug("키워드 동시 생성 충돌 발생. 기존 키워드 재조회: {}", keywordName);
+      return keywordRepository.findByName(keywordName)
+          .orElseThrow(() -> e);
+    }
+  }
 
     private void validateDuplicateInterestName(String interestName) {
         // 관심사 이름이 이미 존재하면 예외 발생

--- a/src/main/java/com/springboot/monew/interest/service/SubscriptionService.java
+++ b/src/main/java/com/springboot/monew/interest/service/SubscriptionService.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class SubscriptionService {
+
 }

--- a/src/main/java/com/springboot/monew/interest/util/StringSimilarityUtil.java
+++ b/src/main/java/com/springboot/monew/interest/util/StringSimilarityUtil.java
@@ -4,30 +4,30 @@ import org.apache.commons.text.similarity.LevenshteinDistance;
 
 public final class StringSimilarityUtil {
 
-    // Levenshtein Distance(레벤슈타인 거리) 알고리즘
-    private static final LevenshteinDistance LEVENSHTEIN_DISTANCE =
-            LevenshteinDistance.getDefaultInstance();
+  // Levenshtein Distance(레벤슈타인 거리) 알고리즘
+  private static final LevenshteinDistance LEVENSHTEIN_DISTANCE =
+      LevenshteinDistance.getDefaultInstance();
 
-    private StringSimilarityUtil() {
+  private StringSimilarityUtil() {
+  }
+
+  public static double similarity(String a, String b) {
+    if (a == null || b == null) {
+      return 0.0;
     }
 
-    public static double similarity(String a, String b) {
-        if (a == null || b == null) {
-            return 0.0;
-        }
-
-        int maxLength = Math.max(a.length(), b.length());
-        if (maxLength == 0) {
-            return 1.0;
-        }
-
-        // Levenshtein Distance 알고리즘 적용
-        int distance = LEVENSHTEIN_DISTANCE.apply(a, b);
-        return (double) (maxLength - distance) / maxLength;
+    int maxLength = Math.max(a.length(), b.length());
+    if (maxLength == 0) {
+      return 1.0;
     }
 
-    public static boolean isSimilarEnough(String a, String b, double threshold) {
-        // 임계값과 비교 후 임계값 이상이면 true 반환
-        return similarity(a, b) >= threshold;
-    }
+    // Levenshtein Distance 알고리즘 적용
+    int distance = LEVENSHTEIN_DISTANCE.apply(a, b);
+    return (double) (maxLength - distance) / maxLength;
+  }
+
+  public static boolean isSimilarEnough(String a, String b, double threshold) {
+    // 임계값과 비교 후 임계값 이상이면 true 반환
+    return similarity(a, b) >= threshold;
+  }
 }


### PR DESCRIPTION
## 📌 해당 이슈카드
Closes #101 #107

## 📌 작업 내용
- 관심사 수정 컨트롤러 구현
- 관심사 수정 서비스 구현
- 코드 포맷팅 적용

## 🔧 변경 사항

## 반영 브랜치
`feature/#101#107/Interest-update` -> `dev`

## 💬 기타 참고 사항
- `InterestErrorCode`, `InterestController`, `InterestKeywordRepository`, `InterestService` 코드만 관심사 수정 구현에 해당합니다.
- 나머지 코드는 코드 포맷팅만 진행하였습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 관심사 업데이트 API 추가 — 관심사의 키워드를 수정(대체)할 수 있음 (PATCH)

* **버그 수정**
  * 존재하지 않는 관심사 요청 시 명확한 "관심사를 찾을 수 없습니다." 응답 제공

* **코드 개선**
  * 전반적인 포맷팅·정렬 개선 및 내부 로직 정리로 유지보수성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->