### PR TITLE
[Feat] 관심사 삭제 구현 및 키워드 처리 개선

### DIFF
--- a/src/main/java/com/springboot/monew/interest/controller/InterestController.java
+++ b/src/main/java/com/springboot/monew/interest/controller/InterestController.java
@@ -10,6 +10,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -37,5 +38,11 @@ public class InterestController implements InterestApiDocs {
       @Valid @RequestBody InterestUpdateRequest request) {
     InterestDto interestDto = interestService.update(interestId, request);
     return ResponseEntity.ok(interestDto);
+  }
+
+  @DeleteMapping("/{interestId}")
+  public ResponseEntity<Void> delete(@PathVariable UUID interestId) {
+    interestService.delete(interestId);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/com/springboot/monew/interest/repository/InterestKeywordRepository.java
+++ b/src/main/java/com/springboot/monew/interest/repository/InterestKeywordRepository.java
@@ -2,14 +2,26 @@ package com.springboot.monew.interest.repository;
 
 import com.springboot.monew.interest.entity.Interest;
 import com.springboot.monew.interest.entity.InterestKeyword;
-import com.springboot.monew.interest.entity.Keyword;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface InterestKeywordRepository extends JpaRepository<InterestKeyword, UUID> {
 
-  List<InterestKeyword> findAllByInterest(Interest interest);
+  @Query("""
+          SELECT ik
+          FROM InterestKeyword ik
+          JOIN FETCH ik.keyword
+          WHERE ik.interest = :interest
+      """)
+  List<InterestKeyword> findAllByInterestWithKeyword(@Param("interest") Interest interest);
 
-  boolean existsByKeyword(Keyword keyword);
+  @Query("""
+          SELECT DISTINCT ik.keyword.id
+          FROM InterestKeyword ik
+          WHERE ik.keyword.id IN :keywordIds
+      """)
+  List<UUID> findReferencedKeywordIds(@Param("keywordIds") List<UUID> keywordIds);
 }

--- a/src/main/java/com/springboot/monew/interest/repository/KeywordRepository.java
+++ b/src/main/java/com/springboot/monew/interest/repository/KeywordRepository.java
@@ -1,11 +1,27 @@
 package com.springboot.monew.interest.repository;
 
 import com.springboot.monew.interest.entity.Keyword;
+import java.util.Collection;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface KeywordRepository extends JpaRepository<Keyword, UUID> {
 
   Optional<Keyword> findByName(String name);
+
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query("""
+        DELETE FROM Keyword k
+        WHERE k.id IN :keywordIds
+          AND NOT EXISTS (
+              SELECT 1
+              FROM InterestKeyword ik
+              WHERE ik.keyword = k
+          )
+    """)
+  int deleteOrphanKeywordsByIds(@Param("keywordIds") Collection<UUID> keywordIds);
 }

--- a/src/main/java/com/springboot/monew/interest/service/InterestService.java
+++ b/src/main/java/com/springboot/monew/interest/service/InterestService.java
@@ -98,6 +98,32 @@ public class InterestService {
     return interestDtoMapper.toInterestDto(interest, keywordNames, false);
   }
 
+  @Transactional
+  public void delete(UUID interestId) {
+    // 관심사 조회, 존재하지 않는 관심사라면 예외 발생
+    Interest interest = interestRepository.findById(interestId)
+        .orElseThrow(() -> new InterestException(InterestErrorCode.INTEREST_NOT_FOUND,
+            Map.of("interestId", interestId)));
+
+    // 해당 관심사의 연결 목록 조회
+    List<InterestKeyword> existingInterestKeywords = interestKeywordRepository.findAllByInterest(
+        interest);
+    // 해당 관심사의 기존 키워드 목록 추출
+    List<Keyword> oldKeywords = existingInterestKeywords.stream()
+        .map(InterestKeyword::getKeyword)
+        .toList();
+
+    // 조회한 관심사-키워드 연결 삭제
+    interestKeywordRepository.deleteAll(existingInterestKeywords);
+    // 관심사 삭제
+    interestRepository.delete(interest);
+
+    // 이전 키워드 목록을 순회하며 더 이상 연결된 관심사가 없다면 삭제
+    deleteOrphanKeywords(oldKeywords);
+
+    log.info("관심사 삭제 완료 - interestId={}, interestName={}", interest.getId(), interest.getName());
+  }
+
   private Keyword getOrCreateKeyword(String keywordName) {
     return keywordRepository.findByName(keywordName)
         .orElseGet(() -> saveKeywordSafely(keywordName));

--- a/src/main/java/com/springboot/monew/interest/service/InterestService.java
+++ b/src/main/java/com/springboot/monew/interest/service/InterestService.java
@@ -13,8 +13,10 @@ import com.springboot.monew.interest.repository.InterestKeywordRepository;
 import com.springboot.monew.interest.repository.InterestRepository;
 import com.springboot.monew.interest.repository.KeywordRepository;
 import com.springboot.monew.interest.util.StringSimilarityUtil;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -75,7 +77,7 @@ public class InterestService {
     validateDuplicateKeywords(keywordNames);
 
     // 해당 관심사의 연결 목록 조회
-    List<InterestKeyword> existingInterestKeywords = interestKeywordRepository.findAllByInterest(
+    List<InterestKeyword> existingInterestKeywords = interestKeywordRepository.findAllByInterestWithKeyword(
         interest);
     // 해당 관심사의 기존 키워드 목록 추출
     List<Keyword> oldKeywords = existingInterestKeywords.stream()
@@ -106,7 +108,7 @@ public class InterestService {
             Map.of("interestId", interestId)));
 
     // 해당 관심사의 연결 목록 조회
-    List<InterestKeyword> existingInterestKeywords = interestKeywordRepository.findAllByInterest(
+    List<InterestKeyword> existingInterestKeywords = interestKeywordRepository.findAllByInterestWithKeyword(
         interest);
     // 해당 관심사의 기존 키워드 목록 추출
     List<Keyword> oldKeywords = existingInterestKeywords.stream()
@@ -118,7 +120,7 @@ public class InterestService {
     // 관심사 삭제
     interestRepository.delete(interest);
 
-    // 이전 키워드 목록을 순회하며 더 이상 연결된 관심사가 없다면 삭제
+    // 관심사와 연결되어 있던 키워드 목록을 순회하며 더 이상 연결된 관심사가 없다면 삭제
     deleteOrphanKeywords(oldKeywords);
 
     log.info("관심사 삭제 완료 - interestId={}, interestName={}", interest.getId(), interest.getName());
@@ -175,12 +177,28 @@ public class InterestService {
   }
 
   private void deleteOrphanKeywords(List<Keyword> keywords) {
-    for (Keyword keyword : keywords) {
-      // 해당 키워드와 연결된 관심사가 존재하지 않는다면
-      if (!interestKeywordRepository.existsByKeyword(keyword)) {
-        // 키워드 삭제
-        keywordRepository.delete(keyword);
-      }
+    if (keywords.isEmpty()) {
+      return;
+    }
+
+    // 키워드 객체 리스트에서 id를 추출하여 id 리스트로 변환
+    List<UUID> keywordIds = keywords.stream()
+        .map(Keyword::getId)
+        .toList();
+
+    // 아직 참조 중인 키워드가 있는지 한번에 조회
+    Set<UUID> referencedKeywordIds = new HashSet<>(
+        interestKeywordRepository.findReferencedKeywordIds(keywordIds)
+    );
+
+    // 더 이상 관심사 연결이 없는 키워드만 추출
+    List<Keyword> orphanKeywords = keywords.stream()
+        .filter(keyword -> !referencedKeywordIds.contains(keyword.getId()))
+        .toList();
+
+    // 더 이상 관심사 연결이 없는 키워드가 존재한다면 삭제
+    if (!orphanKeywords.isEmpty()) {
+      keywordRepository.deleteAll(orphanKeywords);
     }
   }
 

--- a/src/main/java/com/springboot/monew/interest/service/InterestService.java
+++ b/src/main/java/com/springboot/monew/interest/service/InterestService.java
@@ -186,20 +186,7 @@ public class InterestService {
         .map(Keyword::getId)
         .toList();
 
-    // 아직 참조 중인 키워드가 있는지 한번에 조회
-    Set<UUID> referencedKeywordIds = new HashSet<>(
-        interestKeywordRepository.findReferencedKeywordIds(keywordIds)
-    );
-
-    // 더 이상 관심사 연결이 없는 키워드만 추출
-    List<Keyword> orphanKeywords = keywords.stream()
-        .filter(keyword -> !referencedKeywordIds.contains(keyword.getId()))
-        .toList();
-
-    // 더 이상 관심사 연결이 없는 키워드가 존재한다면 삭제
-    if (!orphanKeywords.isEmpty()) {
-      keywordRepository.deleteAll(orphanKeywords);
-    }
+    keywordRepository.deleteOrphanKeywordsByIds(keywordIds);
   }
 
 }


### PR DESCRIPTION
## 📌 해당 이슈카드
Closes #117 #124 

## 📌 작업 내용
- 관심사 삭제 컨트롤러 구현
- 관심사 삭제 서비스 구현
- InterestKeywordRepository 조회 메서드 개선
- 키워드 고아 객체 처리 개선

## 🔧 변경 사항
- 관심사 수정 및 삭제 과정에서 사용하는 키워드 조회 메서드를 개선하였고 키워드 고아 객체 처리를 담당하는 `deleteOrphanKeywords()`를 개선하였습니다.

## 반영 브랜치
`feature/#117#124/Interest-delete` -> `dev`

## 💬 기타 참고 사항
- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 관심사 삭제(DELETE) 기능 추가 — 더 이상 필요 없는 관심사를 직접 삭제 가능

* **성능 개선**
  * 관심사/키워드 연관 처리 및 삭제 로직 최적화로 대량 데이터에서 더 빠른 처리 제공
<!-- end of auto-generated comment: release notes by coderabbit.ai -->