### PR TITLE
[Feat] 사용자 물리 삭제 기능 구현 및 테스트 코드 작성

### DIFF
--- a/src/main/java/com/springboot/monew/config/SchedulingConfig.java
+++ b/src/main/java/com/springboot/monew/config/SchedulingConfig.java
@@ -1,0 +1,10 @@
+package com.springboot.monew.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+
+}

--- a/src/main/java/com/springboot/monew/users/controller/UserApiDocs.java
+++ b/src/main/java/com/springboot/monew/users/controller/UserApiDocs.java
@@ -14,160 +14,157 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-
+import java.util.UUID;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
-
-import java.util.UUID;
 
 @Tag(name = "사용자 관리", description = "사용자 관련 API")
 public interface UserApiDocs {
 
-    @Operation(
-            summary = "회원가입",
-            description = "새로운 사용자를 등록합니다.",
-            operationId = "register"
-    )
-    @ApiResponses({
-            @ApiResponse(
-                    responseCode = "201",
-                    description = "회원가입 성공",
-                    content = @Content(schema = @Schema(implementation = UserDto.class))
-            ),
-            @ApiResponse(
-                    responseCode = "400",
-                    description = "잘못된 요청 (입력값 검증 실패)",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
-            ),
-            @ApiResponse(
-                    responseCode = "409",
-                    description = "이메일 중복 또는 닉네임 중복",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
-            ),
-            @ApiResponse(
-                    responseCode = "500",
-                    description = "서버 내부 오류",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
-            )
-    })
-    ResponseEntity<UserDto> register(
-            @Valid
-            @RequestBody
-            UserRegisterRequest request
-    );
+  @Operation(
+      summary = "회원가입",
+      description = "새로운 사용자를 등록합니다.",
+      operationId = "register"
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "201",
+          description = "회원가입 성공",
+          content = @Content(schema = @Schema(implementation = UserDto.class))
+      ),
+      @ApiResponse(
+          responseCode = "400",
+          description = "잘못된 요청 (입력값 검증 실패)",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "409",
+          description = "이메일 중복 또는 닉네임 중복",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "500",
+          description = "서버 내부 오류",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      )
+  })
+  ResponseEntity<UserDto> register(
+      @Valid
+      @RequestBody
+      UserRegisterRequest request
+  );
 
-    @Operation(
-            summary = "로그인",
-            description = "사용자 로그인을 처리합니다.",
-            operationId = "login"
-    )
-    @ApiResponses({
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "로그인 성공",
-                    content = @Content(schema = @Schema(implementation = UserDto.class))
-            ),
-            @ApiResponse(
-                    responseCode = "400",
-                    description = "잘못된 요청 (입력값 검증 실패)",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
-            ),
-            @ApiResponse(
-                    responseCode = "401",
-                    description = "로그인 실패 (이메일 또는 비밀번호 불일치)",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
-            ),
-            @ApiResponse(
-                    responseCode = "500",
-                    description = "서버 내부 오류",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
-            )
-    })
-    ResponseEntity<UserDto> login(
-            @Valid
-            @RequestBody
-            UserLoginRequest request
-    );
+  @Operation(
+      summary = "로그인",
+      description = "사용자 로그인을 처리합니다.",
+      operationId = "login"
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "로그인 성공",
+          content = @Content(schema = @Schema(implementation = UserDto.class))
+      ),
+      @ApiResponse(
+          responseCode = "400",
+          description = "잘못된 요청 (입력값 검증 실패)",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "401",
+          description = "로그인 실패 (이메일 또는 비밀번호 불일치)",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "500",
+          description = "서버 내부 오류",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      )
+  })
+  ResponseEntity<UserDto> login(
+      @Valid
+      @RequestBody
+      UserLoginRequest request
+  );
 
-    @Operation(
-            summary = "사용자 정보 수정",
-            description = "사용자의 닉네임을 수정합니다.",
-            operationId = "update"
-    )
-    @ApiResponses({
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "사용자 정보 수정 성공",
-                    content = @Content(schema = @Schema(implementation = UserDto.class))
-            ),
-            @ApiResponse(
-                    responseCode = "400",
-                    description = "잘못된 요청 (입력값 검증 실패)",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
-            ),
-            @ApiResponse(
-                    responseCode = "403",
-                    description = "사용자 정보 수정 권한 없음",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
-            ),
-            @ApiResponse(
-                    responseCode = "404",
-                    description = "사용자 정보 없음",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
-            ),
-            @ApiResponse(
-                    responseCode = "409",
-                    description = "닉네임 중복",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
-            ),
-            @ApiResponse(
-                    responseCode = "500",
-                    description = "서버 내부 오류",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
-            )
-    })
-    ResponseEntity<UserDto> update(
-            @Parameter(description = "사용자 ID")
-            @PathVariable UUID userId,
+  @Operation(
+      summary = "사용자 정보 수정",
+      description = "사용자의 닉네임을 수정합니다.",
+      operationId = "update"
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "사용자 정보 수정 성공",
+          content = @Content(schema = @Schema(implementation = UserDto.class))
+      ),
+      @ApiResponse(
+          responseCode = "400",
+          description = "잘못된 요청 (입력값 검증 실패)",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "403",
+          description = "사용자 정보 수정 권한 없음",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "404",
+          description = "사용자 정보 없음",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "409",
+          description = "닉네임 중복",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "500",
+          description = "서버 내부 오류",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      )
+  })
+  ResponseEntity<UserDto> update(
+      @Parameter(description = "사용자 ID")
+      @PathVariable UUID userId,
 
-            @Parameter(description = "요청자 ID")
-            @RequestHeader("MoNew-Request-User-ID") UUID requestUserId,
+      @Parameter(description = "요청자 ID")
+      @RequestHeader("Monew-Request-User-ID") UUID requestUserId,
 
-            @Valid
-            @RequestBody
-            UserUpdateRequest request
-    );
+      @Valid
+      @RequestBody
+      UserUpdateRequest request
+  );
 
-    @Operation(
-            summary = "사용자 논리 삭제",
-            description = "사용자 논리적으로 삭제합니다.",
-            operationId = "delete"
-    )
-    @ApiResponses({
-            @ApiResponse(
-                    responseCode = "204",
-                    description = "사용자 삭제 성공"
-            ),
-            @ApiResponse(
-                    responseCode = "403",
-                    description = "사용자 삭제 권한 없음"
-            ),
-            @ApiResponse(
-                    responseCode = "404",
-                    description = "사용자 정보 없음"
-            ),
-            @ApiResponse(
-                    responseCode = "500",
-                    description = "서버 내부 오류"
-            )
-    })
-    ResponseEntity<Void> delete(
-            @Parameter(description = "사용자 ID")
-            @PathVariable UUID userId,
+  @Operation(
+      summary = "사용자 논리 삭제",
+      description = "사용자 논리적으로 삭제합니다.",
+      operationId = "delete"
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "204",
+          description = "사용자 삭제 성공"
+      ),
+      @ApiResponse(
+          responseCode = "403",
+          description = "사용자 삭제 권한 없음"
+      ),
+      @ApiResponse(
+          responseCode = "404",
+          description = "사용자 정보 없음"
+      ),
+      @ApiResponse(
+          responseCode = "500",
+          description = "서버 내부 오류"
+      )
+  })
+  ResponseEntity<Void> delete(
+      @Parameter(description = "사용자 ID")
+      @PathVariable UUID userId,
 
-            @Parameter(description = "요청자 ID")
-            @RequestHeader("MoNew-Request-User-ID") UUID requestUserId
-    );
-    }
+      @Parameter(description = "요청자 ID")
+      @RequestHeader("Monew-Request-User-ID") UUID requestUserId
+  );
+}

--- a/src/main/java/com/springboot/monew/users/controller/UserApiDocs.java
+++ b/src/main/java/com/springboot/monew/users/controller/UserApiDocs.java
@@ -139,7 +139,7 @@ public interface UserApiDocs {
 
   @Operation(
       summary = "사용자 논리 삭제",
-      description = "사용자 논리적으로 삭제합니다.",
+      description = "사용자를 논리적으로 삭제합니다.",
       operationId = "delete"
   )
   @ApiResponses({
@@ -161,6 +161,37 @@ public interface UserApiDocs {
       )
   })
   ResponseEntity<Void> delete(
+      @Parameter(description = "사용자 ID")
+      @PathVariable UUID userId,
+
+      @Parameter(description = "요청자 ID")
+      @RequestHeader("Monew-Request-User-ID") UUID requestUserId
+  );
+
+  @Operation(
+      summary = "사용자 물리 삭제",
+      description = "사용자를 물리적으로 삭제합니다.",
+      operationId = "hardDelete_1"
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "204",
+          description = "사용자 삭제 성공"
+      ),
+      @ApiResponse(
+          responseCode = "403",
+          description = "사용자 삭제 권한 없음"
+      ),
+      @ApiResponse(
+          responseCode = "404",
+          description = "사용자 정보 없음"
+      ),
+      @ApiResponse(
+          responseCode = "500",
+          description = "서버 내부 오류"
+      )
+  })
+  ResponseEntity<Void> hardDelete(
       @Parameter(description = "사용자 ID")
       @PathVariable UUID userId,
 

--- a/src/main/java/com/springboot/monew/users/controller/UserController.java
+++ b/src/main/java/com/springboot/monew/users/controller/UserController.java
@@ -6,59 +6,64 @@ import com.springboot.monew.users.dto.UserRegisterRequest;
 import com.springboot.monew.users.dto.UserUpdateRequest;
 import com.springboot.monew.users.service.UserService;
 import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
-
 import java.net.URI;
 import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
 public class UserController implements UserApiDocs {
 
-    private final UserService userService;
+  private final UserService userService;
 
-    @PostMapping
-    public ResponseEntity<UserDto> register(
-            @Valid @RequestBody UserRegisterRequest request
-    ) {
-        UserDto userDto = userService.register(request);
-        return ResponseEntity.created(URI.create("/api/users/" + userDto.id())).body(userDto);
-    }
+  @PostMapping
+  public ResponseEntity<UserDto> register(
+      @Valid @RequestBody UserRegisterRequest request
+  ) {
+    UserDto userDto = userService.register(request);
+    return ResponseEntity.created(URI.create("/api/users/" + userDto.id())).body(userDto);
+  }
 
-    @PostMapping("/login")
-    public ResponseEntity<UserDto> login(
-            @Valid @RequestBody UserLoginRequest request
-    ) {
-        UserDto userDto = userService.login(request);
-        return ResponseEntity.ok(userDto);
-    }
+  @PostMapping("/login")
+  public ResponseEntity<UserDto> login(
+      @Valid @RequestBody UserLoginRequest request
+  ) {
+    UserDto userDto = userService.login(request);
+    return ResponseEntity.ok(userDto);
+  }
 
-    @PatchMapping("/{userId}")
-    public ResponseEntity<UserDto> update(
-            @PathVariable UUID userId,
-            @RequestHeader("MoNew-Request-User-ID") UUID requestUserId,
-            @Valid @RequestBody UserUpdateRequest request
-    ) {
+  @PatchMapping("/{userId}")
+  public ResponseEntity<UserDto> update(
+      @PathVariable UUID userId,
+      @RequestHeader("Monew-Request-User-ID") UUID requestUserId,
+      @Valid @RequestBody UserUpdateRequest request
+  ) {
         /* userId: 수정 대상 사용자 ID
            requestUserId: 로그인한 사용자 ID(요구사항상 헤더로 전달)
            - 아마 닉네임 수정 요청을 보낸 로그인 사용자가 누구인지 판별하기 위해서 헤더로 넣는 것 같음.
            request: 수정할 닉네임 값
            서비스에서 userId와 requestUserId를 비교해 본인 요청인지 검증한 뒤 닉네임을 수정한다.
          */
-        UserDto userDto = userService.update(userId, requestUserId, request);
-        return ResponseEntity.ok(userDto);
-    }
+    UserDto userDto = userService.update(userId, requestUserId, request);
+    return ResponseEntity.ok(userDto);
+  }
 
-    @DeleteMapping("/{userId}")
-    public ResponseEntity<Void> delete(
-            @PathVariable UUID userId,
-            @RequestHeader("MoNew-Request-User-ID") UUID requestUserId
-    )  {
-        userService.delete(userId, requestUserId);
-        return ResponseEntity.noContent().build();
-    }
+  @DeleteMapping("/{userId}")
+  public ResponseEntity<Void> delete(
+      @PathVariable UUID userId,
+      @RequestHeader("Monew-Request-User-ID") UUID requestUserId
+  ) {
+    userService.delete(userId, requestUserId);
+    return ResponseEntity.noContent().build();
+  }
 }

--- a/src/main/java/com/springboot/monew/users/controller/UserController.java
+++ b/src/main/java/com/springboot/monew/users/controller/UserController.java
@@ -66,4 +66,13 @@ public class UserController implements UserApiDocs {
     userService.delete(userId, requestUserId);
     return ResponseEntity.noContent().build();
   }
+
+  @DeleteMapping("/{userId}/hard")
+  public ResponseEntity<Void> hardDelete(
+      @PathVariable UUID userId,
+      @RequestHeader("Monew-Request-User-ID") UUID requestUserId
+  ) {
+    userService.hardDelete(userId, requestUserId);
+    return ResponseEntity.noContent().build();
+  }
 }

--- a/src/main/java/com/springboot/monew/users/dto/UserDto.java
+++ b/src/main/java/com/springboot/monew/users/dto/UserDto.java
@@ -1,22 +1,22 @@
 package com.springboot.monew.users.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import java.time.Instant;
 import java.util.UUID;
 
 @Schema(description = "사용자 정보")
 public record UserDto(
-        @Schema(description = "사용자 ID", format = "uuid")
-        UUID id,
+    @Schema(description = "사용자 ID", format = "uuid")
+    UUID id,
 
-        @Schema(description = "이메일")
-        String email,
+    @Schema(description = "이메일")
+    String email,
 
-        @Schema(description = "닉네임")
-        String nickname,
+    @Schema(description = "닉네임")
+    String nickname,
 
-        @Schema(description = "가입한 날짜", format = "date-time")
-        Instant createdAt
+    @Schema(description = "가입한 날짜", format = "date-time")
+    Instant createdAt
 ) {
+
 }

--- a/src/main/java/com/springboot/monew/users/dto/UserLoginRequest.java
+++ b/src/main/java/com/springboot/monew/users/dto/UserLoginRequest.java
@@ -8,17 +8,18 @@ import jakarta.validation.constraints.Size;
 
 @Schema(description = "로그인 정보")
 public record UserLoginRequest(
-        @Schema(description = "로그인 이메일")
-        @NotBlank(message = "이메일은 필수입니다.")
-        @Size(min = 5, max = 100, message = "이메일은 5자 이상 100자 이하여야 합니다.")
-        @Email(message = "올바른 이메일 형식이 아닙니다.")
-        @Pattern(regexp = "^\\S+$", message = "이메일에 공백이 포함될 수 없습니다.")
-        String email,
+    @Schema(description = "로그인 이메일")
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Size(min = 5, max = 100, message = "이메일은 5자 이상 100자 이하여야 합니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    @Pattern(regexp = "^\\S+$", message = "이메일에 공백이 포함될 수 없습니다.")
+    String email,
 
-        @Schema(description = "로그인 비밀번호", minLength = 6, maxLength = 20)
-        @NotBlank(message = "비밀번호는 필수입니다.")
-        @Size(min = 6, max = 20, message = "비밀번호는 6자 이상 20자 이하여야 합니다.")
-        @Pattern(regexp = "^\\S+$", message = "비밀번호에 공백이 포함될 수 없습니다.")
-        String password
+    @Schema(description = "로그인 비밀번호", minLength = 6, maxLength = 20)
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Size(min = 6, max = 20, message = "비밀번호는 6자 이상 20자 이하여야 합니다.")
+    @Pattern(regexp = "^\\S+$", message = "비밀번호에 공백이 포함될 수 없습니다.")
+    String password
 ) {
+
 }

--- a/src/main/java/com/springboot/monew/users/dto/UserRegisterRequest.java
+++ b/src/main/java/com/springboot/monew/users/dto/UserRegisterRequest.java
@@ -8,29 +8,30 @@ import jakarta.validation.constraints.Size;
 
 @Schema(description = "회원가입 정보")
 public record UserRegisterRequest(
-        @Schema(description = "가입 이메일")
-        @NotBlank(message = "이메일은 필수입니다.")
-        @Size(min = 5, max = 100, message = "이메일은 5자 이상 100자 이하여야 합니다.")
-        @Email(message = "올바른 이메일 형식이 아닙니다.")
-        @Pattern(regexp = "^\\S+$", message = "이메일에 공백이 포함될 수 없습니다.")
-        String email,
+    @Schema(description = "가입 이메일")
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Size(min = 5, max = 100, message = "이메일은 5자 이상 100자 이하여야 합니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    @Pattern(regexp = "^\\S+$", message = "이메일에 공백이 포함될 수 없습니다.")
+    String email,
 
-        @Schema(description = "가입 닉네임", minLength = 1, maxLength = 20)
-        @NotBlank(message = "닉네임은 필수입니다.")
-        @Size(min = 1, max = 20, message = "닉네임은 1자 이상 20자 이하여야 합니다.")
-        @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "닉네임은 한글, 영문, 숫자만 사용할 수 있습니다.")
-        String nickname,
+    @Schema(description = "가입 닉네임", minLength = 1, maxLength = 20)
+    @NotBlank(message = "닉네임은 필수입니다.")
+    @Size(min = 1, max = 20, message = "닉네임은 1자 이상 20자 이하여야 합니다.")
+    @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "닉네임은 한글, 영문, 숫자만 사용할 수 있습니다.")
+    String nickname,
 
-        @Schema(description = "가입 비밀번호", minLength = 6, maxLength = 20)
-        @NotBlank(message = "비밀번호는 필수입니다.")
-        @Size(min = 6, max = 20, message = "비밀번호는 6자 이상 20자 이하여야 합니다.")
-        @Pattern(regexp = "^\\S+$", message = "비밀번호에 공백이 포함될 수 없습니다.")
-        @Pattern(regexp = ".*[A-Za-z].*", message = "비밀번호에는 영문이 포함되어야 합니다.")
-        @Pattern(regexp = ".*\\d.*", message = "비밀번호에는 숫자가 포함되어야 합니다.")
-        @Pattern(
-                regexp = ".*[!@#$%^&*()_+\\-={}\\[\\]:;\"'<>,.?/\\\\|`~].*",
-                message = "비밀번호에는 특수문자가 포함되어야 합니다."
-        )
-        String password
+    @Schema(description = "가입 비밀번호", minLength = 6, maxLength = 20)
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Size(min = 6, max = 20, message = "비밀번호는 6자 이상 20자 이하여야 합니다.")
+    @Pattern(regexp = "^\\S+$", message = "비밀번호에 공백이 포함될 수 없습니다.")
+    @Pattern(regexp = ".*[A-Za-z].*", message = "비밀번호에는 영문이 포함되어야 합니다.")
+    @Pattern(regexp = ".*\\d.*", message = "비밀번호에는 숫자가 포함되어야 합니다.")
+    @Pattern(
+        regexp = ".*[!@#$%^&*()_+\\-={}\\[\\]:;\"'<>,.?/\\\\|`~].*",
+        message = "비밀번호에는 특수문자가 포함되어야 합니다."
+    )
+    String password
 ) {
+
 }

--- a/src/main/java/com/springboot/monew/users/dto/UserUpdateRequest.java
+++ b/src/main/java/com/springboot/monew/users/dto/UserUpdateRequest.java
@@ -7,10 +7,11 @@ import jakarta.validation.constraints.Size;
 
 @Schema(description = "수정할 사용자 정보")
 public record UserUpdateRequest(
-        @Schema(description = "수정 닉네임", minLength = 1, maxLength = 20)
-        @NotBlank(message = "닉네임은 필수입니다.")
-        @Size(min = 1, max = 20, message = "닉네임은 1자 이상 20자 이하여야 합니다.")
-        @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "닉네임은 한글, 영문, 숫자만 사용할 수 있습니다.")
-        String nickname
+    @Schema(description = "수정 닉네임", minLength = 1, maxLength = 20)
+    @NotBlank(message = "닉네임은 필수입니다.")
+    @Size(min = 1, max = 20, message = "닉네임은 1자 이상 20자 이하여야 합니다.")
+    @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "닉네임은 한글, 영문, 숫자만 사용할 수 있습니다.")
+    String nickname
 ) {
+
 }

--- a/src/main/java/com/springboot/monew/users/entity/User.java
+++ b/src/main/java/com/springboot/monew/users/entity/User.java
@@ -5,57 +5,56 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.Instant;
-
 @Entity
 @Table(
-        name = "users",
-        uniqueConstraints = {
-                @UniqueConstraint(name = "UK_USERS_EMAIL", columnNames = "email"),
-                @UniqueConstraint(name = "UK_USERS_NICKNAME", columnNames = "nickname")
-        }
+    name = "users",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "UK_USERS_EMAIL", columnNames = "email"),
+        @UniqueConstraint(name = "UK_USERS_NICKNAME", columnNames = "nickname")
+    }
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseUpdatableEntity {
 
-    @Column(name = "email", nullable = false, length = 100)
-    private String email;
+  @Column(name = "email", nullable = false, length = 100)
+  private String email;
 
-    @Column(name = "nickname", nullable = false, length = 20)
-    private String nickname;
+  @Column(name = "nickname", nullable = false, length = 20)
+  private String nickname;
 
-    @Column(name = "password", nullable = false, length = 255)
-    private String password;
+  @Column(name = "password", nullable = false, length = 255)
+  private String password;
 
-    @Column(name = "deleted_at")
-    private Instant deletedAt;
+  @Column(name = "deleted_at")
+  private Instant deletedAt;
 
-    public User(String email, String nickname, String password) {
-        this.email = email;
-        this.nickname = nickname;
-        this.password = password;
+  public User(String email, String nickname, String password) {
+    this.email = email;
+    this.nickname = nickname;
+    this.password = password;
+  }
+
+  public void updateNickname(String nickname) {
+    this.nickname = nickname;
+  }
+
+  public void updatePassword(String password) {
+    this.password = password;
+  }
+
+  public void delete() {
+    if (this.deletedAt == null) {
+      this.deletedAt = Instant.now();
     }
+  }
 
-    public void updateNickname(String nickname) {
-        this.nickname = nickname;
-    }
-
-    public void updatePassword(String password) {
-        this.password = password;
-    }
-
-    public void delete() {
-        if (this.deletedAt == null) {
-            this.deletedAt = Instant.now();
-        }
-    }
-
-    public boolean isDeleted() {
-        return this.deletedAt != null;
-    }
+  public boolean isDeleted() {
+    return this.deletedAt != null;
+  }
 }

--- a/src/main/java/com/springboot/monew/users/exception/UserErrorCode.java
+++ b/src/main/java/com/springboot/monew/users/exception/UserErrorCode.java
@@ -8,13 +8,13 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum UserErrorCode implements ErrorCode {
-    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "DUPLICATE_EMAIL", "이미 사용 중인 이메일입니다."),
-    DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "DUPLICATE_NICKNAME", "이미 사용 중인 닉네임입니다."),
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "사용자를 찾을 수 없습니다."),
-    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "INVALID_CREDENTIALS", "이메일 또는 비밀번호가 올바르지 않습니다."),
-    USER_NOT_OWNED(HttpStatus.FORBIDDEN, "USER_NOT_OWNED", "본인의 사용자 정보만 수정할 수 있습니다.");
+  DUPLICATE_EMAIL(HttpStatus.CONFLICT, "DUPLICATE_EMAIL", "이미 사용 중인 이메일입니다."),
+  DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "DUPLICATE_NICKNAME", "이미 사용 중인 닉네임입니다."),
+  USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "사용자를 찾을 수 없습니다."),
+  INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "INVALID_CREDENTIALS", "이메일 또는 비밀번호가 올바르지 않습니다."),
+  USER_NOT_OWNED(HttpStatus.FORBIDDEN, "USER_NOT_OWNED", "본인의 사용자 정보만 수정할 수 있습니다.");
 
-    private final HttpStatus httpStatus;
-    private final String code;
-    private final String message;
+  private final HttpStatus httpStatus;
+  private final String code;
+  private final String message;
 }

--- a/src/main/java/com/springboot/monew/users/exception/UserException.java
+++ b/src/main/java/com/springboot/monew/users/exception/UserException.java
@@ -2,11 +2,11 @@ package com.springboot.monew.users.exception;
 
 import com.springboot.monew.common.exception.ErrorCode;
 import com.springboot.monew.common.exception.MonewException;
-
 import java.util.Map;
 
 public class UserException extends MonewException {
-    public UserException(ErrorCode errorCode, Map<String, Object> details) {
-        super(errorCode, details);
-    }
+
+  public UserException(ErrorCode errorCode, Map<String, Object> details) {
+    super(errorCode, details);
+  }
 }

--- a/src/main/java/com/springboot/monew/users/mapper/UserMapper.java
+++ b/src/main/java/com/springboot/monew/users/mapper/UserMapper.java
@@ -6,5 +6,6 @@ import org.mapstruct.Mapper;
 
 @Mapper(componentModel = "spring")
 public interface UserMapper {
-    UserDto toDto(User user);
+
+  UserDto toDto(User user);
 }

--- a/src/main/java/com/springboot/monew/users/repository/UserRepository.java
+++ b/src/main/java/com/springboot/monew/users/repository/UserRepository.java
@@ -1,9 +1,13 @@
 package com.springboot.monew.users.repository;
 
 import com.springboot.monew.users.entity.User;
+import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -14,4 +18,14 @@ public interface UserRepository extends JpaRepository<User, UUID> {
   boolean existsByNickname(String nickname);
 
   Optional<User> findByEmail(String email);
+
+  // 논리 삭제된 user들 중에서 현재 시간에서 24시간을 뺀 시간인, cutoff보다 더 과거에 deletedAt이 찍힌 user들을 조회
+  @Query("""
+          select  u
+          from User u
+          where u.deletedAt is not null
+            and u.deletedAt < :cutoff
+      """)
+  List<User> findUsersDeletedBefore(@Param("cutoff") Instant cutoff);
+
 }

--- a/src/main/java/com/springboot/monew/users/repository/UserRepository.java
+++ b/src/main/java/com/springboot/monew/users/repository/UserRepository.java
@@ -1,18 +1,17 @@
 package com.springboot.monew.users.repository;
 
 import com.springboot.monew.users.entity.User;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, UUID> {
 
-    boolean existsByEmail(String email);
+  boolean existsByEmail(String email);
 
-    boolean existsByNickname(String nickname);
+  boolean existsByNickname(String nickname);
 
-    Optional<User> findByEmail(String email);
+  Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/springboot/monew/users/repository/UserRepository.java
+++ b/src/main/java/com/springboot/monew/users/repository/UserRepository.java
@@ -10,7 +10,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-@Repository
 public interface UserRepository extends JpaRepository<User, UUID> {
 
   boolean existsByEmail(String email);

--- a/src/main/java/com/springboot/monew/users/repository/UserRepository.java
+++ b/src/main/java/com/springboot/monew/users/repository/UserRepository.java
@@ -23,7 +23,7 @@ public interface UserRepository extends JpaRepository<User, UUID> {
           select  u
           from User u
           where u.deletedAt is not null
-            and u.deletedAt < :cutoff
+            and u.deletedAt <= :cutoff
       """)
   List<User> findUsersDeletedBefore(@Param("cutoff") Instant cutoff);
 

--- a/src/main/java/com/springboot/monew/users/scheduler/UserCleanUpScheduler.java
+++ b/src/main/java/com/springboot/monew/users/scheduler/UserCleanUpScheduler.java
@@ -1,0 +1,28 @@
+package com.springboot.monew.users.scheduler;
+
+import com.springboot.monew.users.service.UserService;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class UserCleanUpScheduler {
+
+  private final UserService userService;
+
+  // 매 정각마다 스케줄러가 실행된다. (1시간 마다 실행됨.)
+  @Scheduled(cron = "0 0 * * * *")
+  public void purgeDeletedUsers() {
+    // 지금 기준으로 24시간 전 시각을 계산해서 cutoff로 만든다.
+    Instant cutoff = Instant.now().minus(24, ChronoUnit.HOURS);
+
+    int deletedCount = userService.purgeDeletedUsersOlderThan(cutoff);
+
+    log.info("사용자 자동 물리 삭제 스케줄 완료 - deletedCount={}", deletedCount);
+  }
+}

--- a/src/main/java/com/springboot/monew/users/service/UserService.java
+++ b/src/main/java/com/springboot/monew/users/service/UserService.java
@@ -9,6 +9,8 @@ import com.springboot.monew.users.exception.UserErrorCode;
 import com.springboot.monew.users.exception.UserException;
 import com.springboot.monew.users.mapper.UserMapper;
 import com.springboot.monew.users.repository.UserRepository;
+import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +27,7 @@ public class UserService {
   private final UserRepository userRepository;
   private final UserMapper userMapper;
 
+  // 사용자 회원가입
   @Transactional
   public UserDto register(UserRegisterRequest request) {
     validateDuplicateEmail(request.email());
@@ -41,6 +44,7 @@ public class UserService {
     return userMapper.toDto(savedUser);
   }
 
+  // 사용자 로그인
   public UserDto login(UserLoginRequest request) {
     User user = userRepository.findByEmail(request.email())
         .orElseThrow(() -> {
@@ -71,6 +75,7 @@ public class UserService {
     return userMapper.toDto(user);
   }
 
+  // 닉네임 수정
   @Transactional
   public UserDto update(UUID userId, UUID requestUserId, UserUpdateRequest request) {
     // 다른 개발자 도구로 닉네임 수정을 막기 위해 '수정 대상 사용자'와 '요청을 보낸 사용자'가 같은지 검사
@@ -107,6 +112,7 @@ public class UserService {
     return userMapper.toDto(user);
   }
 
+  // 논리 삭제
   @Transactional
   public void delete(UUID userId, UUID requestUserId) {
     validateOwner(userId, requestUserId);
@@ -130,6 +136,40 @@ public class UserService {
 
     user.delete();
     log.info("사용자 탈퇴 완료 - userId={}", user.getId());
+  }
+
+  // 수동 물리 삭제
+  @Transactional
+  public void hardDelete(UUID userId, UUID requestUserId) {
+    validateOwner(userId, requestUserId);
+
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> {
+          log.warn("사용자 물리 삭제 실패: 사용자를 찾을 수 없음 - userId={}", userId);
+          return new UserException(
+              UserErrorCode.USER_NOT_FOUND,
+              Map.of("userId", userId)
+          );
+        });
+
+    userRepository.delete(user);
+    log.info("사용자 물리 삭제 완료 - userId={}", userId);
+  }
+
+  // 24시간 후 자동 물리 삭제, 몇 명이 삭제되었는지 확인할 수 있도록 반환 타입을 int로 설정
+  @Transactional
+  public int purgeDeletedUsersOlderThan(Instant cutoff) {
+    List<User> users = userRepository.findUsersDeletedBefore(cutoff);
+
+    if (users.isEmpty()) {
+      log.info("물리 삭제 대상 사용자 없음 - cutoff={}", cutoff);
+      return 0;
+    }
+
+    userRepository.deleteAll(users);
+
+    log.info("논리 삭제 후 24시간 경과 사용자 물리 삭제 완료 - count={}, cutoff={}", users.size(), cutoff);
+    return users.size();
   }
 
   private void validateDuplicateEmail(String email) {

--- a/src/main/java/com/springboot/monew/users/service/UserService.java
+++ b/src/main/java/com/springboot/monew/users/service/UserService.java
@@ -9,13 +9,12 @@ import com.springboot.monew.users.exception.UserErrorCode;
 import com.springboot.monew.users.exception.UserException;
 import com.springboot.monew.users.mapper.UserMapper;
 import com.springboot.monew.users.repository.UserRepository;
+import java.util.Map;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Map;
-import java.util.UUID;
 
 @Service
 @Slf4j
@@ -23,143 +22,143 @@ import java.util.UUID;
 @Transactional(readOnly = true)
 public class UserService {
 
-    private final UserRepository userRepository;
-    private final UserMapper userMapper;
+  private final UserRepository userRepository;
+  private final UserMapper userMapper;
 
-    @Transactional
-    public UserDto register(UserRegisterRequest request) {
-        validateDuplicateEmail(request.email());
-        validateDuplicateNickname(request.nickname());
+  @Transactional
+  public UserDto register(UserRegisterRequest request) {
+    validateDuplicateEmail(request.email());
+    validateDuplicateNickname(request.nickname());
 
-        User user = new User(
-                request.email(),
-                request.nickname(),
-                request.password()
-        );
+    User user = new User(
+        request.email(),
+        request.nickname(),
+        request.password()
+    );
 
-        User savedUser = userRepository.save(user);
-        log.info("회원가입 완료 - userId={}, email={}", savedUser.getId(), savedUser.getEmail());
-        return userMapper.toDto(savedUser);
+    User savedUser = userRepository.save(user);
+    log.info("회원가입 완료 - userId={}, email={}", savedUser.getId(), savedUser.getEmail());
+    return userMapper.toDto(savedUser);
+  }
+
+  public UserDto login(UserLoginRequest request) {
+    User user = userRepository.findByEmail(request.email())
+        .orElseThrow(() -> {
+          log.warn("로그인 실패: 사용자를 찾을 수 없음 - email={}", request.email());
+          return new UserException(
+              UserErrorCode.USER_NOT_FOUND,
+              Map.of("email", request.email())
+          );
+        });
+
+    if (user.isDeleted()) {
+      log.warn("로그인 실패: 탈퇴한 사용자 - email={}", request.email());
+      throw new UserException(
+          UserErrorCode.USER_NOT_FOUND,
+          Map.of("email", request.email())
+      );
     }
 
-    public UserDto login(UserLoginRequest request) {
-        User user = userRepository.findByEmail(request.email())
-                .orElseThrow(() -> {
-                    log.warn("로그인 실패: 사용자를 찾을 수 없음 - email={}", request.email());
-                    return new UserException(
-                            UserErrorCode.USER_NOT_FOUND,
-                            Map.of("email", request.email())
-                    );
-                });
-
-        if (user.isDeleted()) {
-            log.warn("로그인 실패: 탈퇴한 사용자 - email={}", request.email());
-            throw new UserException(
-                    UserErrorCode.USER_NOT_FOUND,
-                    Map.of("email", request.email())
-            );
-        }
-
-        if (!user.getPassword().equals(request.password())) {
-            log.info("로그인 실패: 비밀번호 불일치 - email={}", request.email());
-            throw new UserException(
-                    UserErrorCode.INVALID_CREDENTIALS,
-                    Map.of("email", request.email())
-            );
-        }
-
-        log.info("로그인 완료 - userId={}, email={}", user.getId(), user.getEmail());
-        return userMapper.toDto(user);
+    if (!user.getPassword().equals(request.password())) {
+      log.info("로그인 실패: 비밀번호 불일치 - email={}", request.email());
+      throw new UserException(
+          UserErrorCode.INVALID_CREDENTIALS,
+          Map.of("email", request.email())
+      );
     }
 
-    @Transactional
-    public UserDto update(UUID userId, UUID requestUserId, UserUpdateRequest request) {
-        // 다른 개발자 도구로 닉네임 수정을 막기 위해 '수정 대상 사용자'와 '요청을 보낸 사용자'가 같은지 검사
-        validateOwner(userId, requestUserId);
+    log.info("로그인 완료 - userId={}, email={}", user.getId(), user.getEmail());
+    return userMapper.toDto(user);
+  }
 
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> {
-                    log.warn("닉네임 수정 실패: 사용자를 찾을 수 없음 - userId={}", userId);
-                    return new UserException(
-                            UserErrorCode.USER_NOT_FOUND,
-                            Map.of("userId", userId)
-                    );
-                });
+  @Transactional
+  public UserDto update(UUID userId, UUID requestUserId, UserUpdateRequest request) {
+    // 다른 개발자 도구로 닉네임 수정을 막기 위해 '수정 대상 사용자'와 '요청을 보낸 사용자'가 같은지 검사
+    validateOwner(userId, requestUserId);
 
-        if(user.isDeleted()) {
-            log.warn("닉네임 수정 실패: 탈퇴한 사용자 - userId={}", userId);
-            throw new UserException(
-                    UserErrorCode.USER_NOT_FOUND,
-                    Map.of("userId", userId)
-            );
-        }
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> {
+          log.warn("닉네임 수정 실패: 사용자를 찾을 수 없음 - userId={}", userId);
+          return new UserException(
+              UserErrorCode.USER_NOT_FOUND,
+              Map.of("userId", userId)
+          );
+        });
 
-        if(!user.getNickname().equals(request.nickname())
-                && userRepository.existsByNickname(request.nickname())) {
-            log.warn("닉네임 수정 실패: 닉네임 중복 - nickname={}", request.nickname());
-            throw new UserException(
-                    UserErrorCode.DUPLICATE_NICKNAME,
-                    Map.of("nickname", request.nickname())
-            );
-        }
-
-        user.updateNickname(request.nickname());
-        log.info("닉네임 수정 완료 - userId={}, nickname={}", user.getId(), user.getNickname());
-        return userMapper.toDto(user);
+    if (user.isDeleted()) {
+      log.warn("닉네임 수정 실패: 탈퇴한 사용자 - userId={}", userId);
+      throw new UserException(
+          UserErrorCode.USER_NOT_FOUND,
+          Map.of("userId", userId)
+      );
     }
 
-    @Transactional
-    public void delete(UUID userId, UUID requestUserId) {
-        validateOwner(userId, requestUserId);
-
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> {
-                    log.warn("사용자 탈퇴 실패: 사용자를 찾을 수 없음 - userId={}", userId);
-                    return new UserException(
-                            UserErrorCode.USER_NOT_FOUND,
-                            Map.of("userId", userId)
-                    );
-                });
-
-        if (user.isDeleted()) {
-            log.warn("사용자 탈퇴 실패: 탈퇴한 사용자 - userId={}", userId);
-            throw new UserException(
-                    UserErrorCode.USER_NOT_FOUND,
-                    Map.of("userId", userId)
-            );
-        }
-
-        user.delete();
-        log.info("사용자 탈퇴 완료 - userId={}", user.getId());
+    if (!user.getNickname().equals(request.nickname())
+        && userRepository.existsByNickname(request.nickname())) {
+      log.warn("닉네임 수정 실패: 닉네임 중복 - nickname={}", request.nickname());
+      throw new UserException(
+          UserErrorCode.DUPLICATE_NICKNAME,
+          Map.of("nickname", request.nickname())
+      );
     }
 
-    private void validateDuplicateEmail(String email) {
-        if (userRepository.existsByEmail(email)) {
-            log.warn("회원가입 실패 - email={}", email);
-            throw new UserException(
-                    UserErrorCode.DUPLICATE_EMAIL,
-                    Map.of("email", email)
-            );
-        }
+    user.updateNickname(request.nickname());
+    log.info("닉네임 수정 완료 - userId={}, nickname={}", user.getId(), user.getNickname());
+    return userMapper.toDto(user);
+  }
+
+  @Transactional
+  public void delete(UUID userId, UUID requestUserId) {
+    validateOwner(userId, requestUserId);
+
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> {
+          log.warn("사용자 탈퇴 실패: 사용자를 찾을 수 없음 - userId={}", userId);
+          return new UserException(
+              UserErrorCode.USER_NOT_FOUND,
+              Map.of("userId", userId)
+          );
+        });
+
+    if (user.isDeleted()) {
+      log.warn("사용자 탈퇴 실패: 탈퇴한 사용자 - userId={}", userId);
+      throw new UserException(
+          UserErrorCode.USER_NOT_FOUND,
+          Map.of("userId", userId)
+      );
     }
 
-    private void validateDuplicateNickname(String nickname) {
-        if (userRepository.existsByNickname(nickname)) {
-            log.warn("회원가입 실패 - nickname={}", nickname);
-            throw new UserException(
-                    UserErrorCode.DUPLICATE_NICKNAME,
-                    Map.of("nickname", nickname)
-            );
-        }
-    }
+    user.delete();
+    log.info("사용자 탈퇴 완료 - userId={}", user.getId());
+  }
 
-    private void validateOwner(UUID userId, UUID requestUserId) {
-        if(!userId.equals(requestUserId)) {
-            log.warn("사용자 권한 검증 실패: 사용자 불일치 - userId={}, requestUserId={}", userId, requestUserId);
-            throw new UserException(
-                    UserErrorCode.USER_NOT_OWNED,
-                    Map.of("userId", userId, "requestUserId", requestUserId)
-            );
-        }
+  private void validateDuplicateEmail(String email) {
+    if (userRepository.existsByEmail(email)) {
+      log.warn("회원가입 실패 - email={}", email);
+      throw new UserException(
+          UserErrorCode.DUPLICATE_EMAIL,
+          Map.of("email", email)
+      );
     }
+  }
+
+  private void validateDuplicateNickname(String nickname) {
+    if (userRepository.existsByNickname(nickname)) {
+      log.warn("회원가입 실패 - nickname={}", nickname);
+      throw new UserException(
+          UserErrorCode.DUPLICATE_NICKNAME,
+          Map.of("nickname", nickname)
+      );
+    }
+  }
+
+  private void validateOwner(UUID userId, UUID requestUserId) {
+    if (!userId.equals(requestUserId)) {
+      log.warn("사용자 권한 검증 실패: 사용자 불일치 - userId={}, requestUserId={}", userId, requestUserId);
+      throw new UserException(
+          UserErrorCode.USER_NOT_OWNED,
+          Map.of("userId", userId, "requestUserId", requestUserId)
+      );
+    }
+  }
 }

--- a/src/test/java/com/springboot/monew/users/controller/UserControllerTest.java
+++ b/src/test/java/com/springboot/monew/users/controller/UserControllerTest.java
@@ -1,10 +1,10 @@
 package com.springboot.monew.users.controller;
 
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -60,8 +60,7 @@ public class UserControllerTest {
         createdAt
     );
 
-    // Mockito.when을 클래스명 없이 간단히 사용하기 위해 static import를 하였음.
-    when(userService.register(any(UserRegisterRequest.class))).thenReturn(response);
+    given(userService.register(any(UserRegisterRequest.class))).willReturn(response);
 
     // when & then
     mockMvc.perform(post("/api/users")
@@ -120,7 +119,7 @@ public class UserControllerTest {
         createdAt
     );
 
-    when(userService.login(any(UserLoginRequest.class))).thenReturn(expected);
+    given(userService.login(any(UserLoginRequest.class))).willReturn(expected);
 
     // when & then
     mockMvc.perform(post("/api/users/login")
@@ -171,8 +170,7 @@ public class UserControllerTest {
         createdAt
     );
 
-    when(userService.update(eq(userId), eq(userId), any(UserUpdateRequest.class))).thenReturn(
-        expected);
+    given(userService.update(eq(userId), eq(userId), any(UserUpdateRequest.class))).willReturn(expected);
 
     // when & then
     mockMvc.perform(patch("/api/users/{userId}", userId)

--- a/src/test/java/com/springboot/monew/users/controller/UserControllerTest.java
+++ b/src/test/java/com/springboot/monew/users/controller/UserControllerTest.java
@@ -1,217 +1,238 @@
 package com.springboot.monew.users.controller;
 
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.springboot.monew.users.dto.UserDto;
 import com.springboot.monew.users.dto.UserLoginRequest;
 import com.springboot.monew.users.dto.UserRegisterRequest;
 import com.springboot.monew.users.dto.UserUpdateRequest;
 import com.springboot.monew.users.service.UserService;
+import java.time.Instant;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentMatchers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.time.Instant;
-import java.util.UUID;
-
-import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
 @WebMvcTest(UserController.class)
 public class UserControllerTest {
 
-    @Autowired
-    private MockMvc mockMvc;
+  @Autowired
+  private MockMvc mockMvc;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+  @Autowired
+  private ObjectMapper objectMapper;
 
-    @MockitoBean
-    private UserService userService;
+  @MockitoBean
+  private UserService userService;
 
-    @Test
-    @DisplayName("정상 회원가입 요청 시 201 Created와 사용자 정보를 반환한다")
-    void register_success() throws Exception {
-        // given
-        UserRegisterRequest request = new UserRegisterRequest(
-                "test@example.com",
-                "monew123",
-                "ab12!@"
-        );
+  @Test
+  @DisplayName("정상 회원가입 요청 시 201 Created와 사용자 정보를 반환한다")
+  void register_success() throws Exception {
+    // given
+    UserRegisterRequest request = new UserRegisterRequest(
+        "test@example.com",
+        "monew123",
+        "ab12!@"
+    );
 
-        UUID userId = UUID.randomUUID();
-        Instant createdAt = Instant.parse("2026-04-17T01:46:03.003Z");
+    UUID userId = UUID.randomUUID();
+    Instant createdAt = Instant.parse("2026-04-17T01:46:03.003Z");
 
-        UserDto response = new UserDto(
-                userId,
-                "test@example.com",
-                "monew123",
-                createdAt
-        );
+    UserDto response = new UserDto(
+        userId,
+        "test@example.com",
+        "monew123",
+        createdAt
+    );
 
-        // Mockito.when을 클래스명 없이 간단히 사용하기 위해 static import를 하였음.
-        when(userService.register(any(UserRegisterRequest.class))).thenReturn(response);
+    // Mockito.when을 클래스명 없이 간단히 사용하기 위해 static import를 하였음.
+    when(userService.register(any(UserRegisterRequest.class))).thenReturn(response);
 
-        // when & then
-        mockMvc.perform(post("/api/users")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isCreated())
-                .andExpect(header().string("Location", "/api/users/" + userId))
-                .andExpect(jsonPath("$.email").value("test@example.com"))
-                .andExpect(jsonPath("$.nickname").value("monew123"))
-                .andExpect(jsonPath("$.createdAt").value("2026-04-17T01:46:03.003Z"));
+    // when & then
+    mockMvc.perform(post("/api/users")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isCreated())
+        .andExpect(header().string("Location", "/api/users/" + userId))
+        .andExpect(jsonPath("$.email").value("test@example.com"))
+        .andExpect(jsonPath("$.nickname").value("monew123"))
+        .andExpect(jsonPath("$.createdAt").value("2026-04-17T01:46:03.003Z"));
 
-        // 컨트롤러가 실제로 register을 호출했는지 검증하기 위해 추가
-        verify(userService).register(any(UserRegisterRequest.class));
-    }
+    // 컨트롤러가 실제로 register을 호출했는지 검증하기 위해 추가
+    verify(userService).register(any(UserRegisterRequest.class));
+  }
 
-    @Test
-    @DisplayName("유효하지 않은 회원가입 요청이면 400 Bad Request를 반환한다")
-    void register_validationFail() throws Exception {
-        // given
-        UserRegisterRequest request = new UserRegisterRequest(
-                "invalid-email",
-                "",
-                "1234"
-        );
+  @Test
+  @DisplayName("유효하지 않은 회원가입 요청이면 400 Bad Request를 반환한다")
+  void register_validationFail() throws Exception {
+    // given
+    UserRegisterRequest request = new UserRegisterRequest(
+        "invalid-email",
+        "",
+        "1234"
+    );
 
-        // when & then
-        mockMvc.perform(post("/api/users")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status").value(400))
-                .andExpect(jsonPath("$.details.email").isArray())
-                .andExpect(jsonPath("$.details.nickname").isArray())
-                .andExpect(jsonPath("$.details.password").isArray());
+    // when & then
+    mockMvc.perform(post("/api/users")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.status").value(400))
+        .andExpect(jsonPath("$.details.email").isArray())
+        .andExpect(jsonPath("$.details.nickname").isArray())
+        .andExpect(jsonPath("$.details.password").isArray());
 
-        // 컨트롤러가 실제로 register을 호출을 안했는지 검증하기 위해 추가
-        verify(userService, never()).register(any(UserRegisterRequest.class));
-    }
+    // 컨트롤러가 실제로 register을 호출을 안했는지 검증하기 위해 추가
+    verify(userService, never()).register(any(UserRegisterRequest.class));
+  }
 
-    @Test
-    @DisplayName("정상 로그인 요청이면 200 OK와 사용자 정보를 반환한다")
-    void login_success() throws Exception {
-        // given
-        UserLoginRequest request = new UserLoginRequest(
-                "test@example.com",
-                "password123"
-        );
+  @Test
+  @DisplayName("정상 로그인 요청이면 200 OK와 사용자 정보를 반환한다")
+  void login_success() throws Exception {
+    // given
+    UserLoginRequest request = new UserLoginRequest(
+        "test@example.com",
+        "password123"
+    );
 
-        UUID userId = UUID.randomUUID();
-        Instant createdAt = Instant.parse("2026-04-17T01:46:03.003Z");
+    UUID userId = UUID.randomUUID();
+    Instant createdAt = Instant.parse("2026-04-17T01:46:03.003Z");
 
-        UserDto expected = new UserDto(
-                userId,
-                "test@example.com",
-                "monew123",
-                createdAt
-        );
+    UserDto expected = new UserDto(
+        userId,
+        "test@example.com",
+        "monew123",
+        createdAt
+    );
 
-        when(userService.login(any(UserLoginRequest.class))).thenReturn(expected);
+    when(userService.login(any(UserLoginRequest.class))).thenReturn(expected);
 
-        // when & then
-        mockMvc.perform(post("/api/users/login")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.email").value(expected.email()))
-                .andExpect(jsonPath("$.nickname").value(expected.nickname()))
-                .andExpect(jsonPath("$.createdAt").value("2026-04-17T01:46:03.003Z"));
+    // when & then
+    mockMvc.perform(post("/api/users/login")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.email").value(expected.email()))
+        .andExpect(jsonPath("$.nickname").value(expected.nickname()))
+        .andExpect(jsonPath("$.createdAt").value("2026-04-17T01:46:03.003Z"));
 
-        verify(userService).login(any(UserLoginRequest.class));
-    }
+    verify(userService).login(any(UserLoginRequest.class));
+  }
 
-    @Test
-    @DisplayName("유효하지 않은 로그인 요청이면 400 Bad Request를 반환한다")
-    void login_validationFail() throws Exception {
-        //given
-        UserLoginRequest request = new UserLoginRequest(
-                "invalid-email",
-                ""
-        );
+  @Test
+  @DisplayName("유효하지 않은 로그인 요청이면 400 Bad Request를 반환한다")
+  void login_validationFail() throws Exception {
+    //given
+    UserLoginRequest request = new UserLoginRequest(
+        "invalid-email",
+        ""
+    );
 
-        // when & then
-        mockMvc.perform(post("/api/users/login")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status").value(400))
-                .andExpect(jsonPath("$.details.email").isArray())
-                .andExpect(jsonPath("$.details.password").isArray());
+    // when & then
+    mockMvc.perform(post("/api/users/login")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.status").value(400))
+        .andExpect(jsonPath("$.details.email").isArray())
+        .andExpect(jsonPath("$.details.password").isArray());
 
-        verify(userService, never()).login(any(UserLoginRequest.class));
-    }
+    verify(userService, never()).login(any(UserLoginRequest.class));
+  }
 
-    @Test
-    @DisplayName("정상 사용자 정보 수정 요청이면 200 OK와 수정된 사용자 정보를 반환한다")
-    void update_success() throws Exception {
-        // given
-        UUID userId = UUID.randomUUID();
+  @Test
+  @DisplayName("정상 사용자 정보 수정 요청이면 200 OK와 수정된 사용자 정보를 반환한다")
+  void update_success() throws Exception {
+    // given
+    UUID userId = UUID.randomUUID();
 
-        UserUpdateRequest request = new UserUpdateRequest("newNickname");
-        Instant createdAt = Instant.parse("2026-04-17T01:46:03.003Z");
+    UserUpdateRequest request = new UserUpdateRequest("newNickname");
+    Instant createdAt = Instant.parse("2026-04-17T01:46:03.003Z");
 
-        UserDto expected = new UserDto(
-                userId,
-                "test@example.com",
-                "monew123",
-                createdAt
-        );
+    UserDto expected = new UserDto(
+        userId,
+        "test@example.com",
+        "monew123",
+        createdAt
+    );
 
-        when(userService.update(eq(userId), eq(userId), any(UserUpdateRequest.class))).thenReturn(expected);
+    when(userService.update(eq(userId), eq(userId), any(UserUpdateRequest.class))).thenReturn(
+        expected);
 
-        // when & then
-        mockMvc.perform(patch("/api/users/{userId}", userId)
-                    .header("MoNew-Request-User-ID", userId)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id").value(userId.toString()))
-                .andExpect(jsonPath("$.email").value(expected.email()))
-                .andExpect(jsonPath("$.nickname").value(expected.nickname()))
-                .andExpect(jsonPath("$.createdAt").value("2026-04-17T01:46:03.003Z"));
+    // when & then
+    mockMvc.perform(patch("/api/users/{userId}", userId)
+            .header("MoNew-Request-User-ID", userId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(userId.toString()))
+        .andExpect(jsonPath("$.email").value(expected.email()))
+        .andExpect(jsonPath("$.nickname").value(expected.nickname()))
+        .andExpect(jsonPath("$.createdAt").value("2026-04-17T01:46:03.003Z"));
 
-        verify(userService).update(eq(userId), eq(userId), any(UserUpdateRequest.class));
-    }
+    verify(userService).update(eq(userId), eq(userId), any(UserUpdateRequest.class));
+  }
 
-    @Test
-    @DisplayName("유효하지 않은 사용자 정보 수정 요청이면 400 Bad Request를 반환한다")
-    void update_validationFail() throws Exception {
-        // given
-        UUID userId = UUID.randomUUID();
+  @Test
+  @DisplayName("유효하지 않은 사용자 정보 수정 요청이면 400 Bad Request를 반환한다")
+  void update_validationFail() throws Exception {
+    // given
+    UUID userId = UUID.randomUUID();
 
-        UserUpdateRequest request = new UserUpdateRequest("");
+    UserUpdateRequest request = new UserUpdateRequest("");
 
-        // when & then
-        mockMvc.perform(patch("/api/users/{userId}", userId)
-                    .header("MoNew-Request-User-ID", userId)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status").value(400))
-                .andExpect(jsonPath("$.details.nickname").isArray());
+    // when & then
+    mockMvc.perform(patch("/api/users/{userId}", userId)
+            .header("MoNew-Request-User-ID", userId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.status").value(400))
+        .andExpect(jsonPath("$.details.nickname").isArray());
 
-        verify(userService, never()).update(eq(userId), eq(userId), any(UserUpdateRequest.class));
-    }
+    verify(userService, never()).update(eq(userId), eq(userId), any(UserUpdateRequest.class));
+  }
 
-    @Test
-    @DisplayName("정상 사용자 삭제 요청이면 204 No Content를 반환한다")
-    void delete_success() throws Exception {
-        // given
-        UUID userId = UUID.randomUUID();
+  @Test
+  @DisplayName("정상 사용자 논리 삭제 요청이면 204 No Content를 반환한다")
+  void delete_success() throws Exception {
+    // given
+    UUID userId = UUID.randomUUID();
 
-        // when & then
-        mockMvc.perform(delete("/api/users/{userId}", userId)
-                    .header("MoNew-Request-User-ID", userId))
-                .andExpect(status().isNoContent());
+    // when & then
+    mockMvc.perform(delete("/api/users/{userId}", userId)
+            .header("MoNew-Request-User-ID", userId))
+        .andExpect(status().isNoContent());
 
-        verify(userService).delete(userId, userId);
-    }
+    verify(userService).delete(userId, userId);
+  }
+
+  @Test
+  @DisplayName("정상 사용자 물리 삭제 요청이면 204 No Content를 반환한다")
+  void hardDelete_success() throws Exception {
+    // given
+    UUID userId = UUID.randomUUID();
+
+    // when & then
+    mockMvc.perform(delete("/api/users/{userId}/hard", userId)
+            .header("MoNew-Request-User-ID", userId))
+        .andExpect(status().isNoContent());
+
+    verify(userService).hardDelete(userId, userId);
+  }
 }

--- a/src/test/java/com/springboot/monew/users/dto/UserRegisterRequestTest.java
+++ b/src/test/java/com/springboot/monew/users/dto/UserRegisterRequestTest.java
@@ -175,7 +175,7 @@ public class UserRegisterRequestTest {
     void validateNickname_fail_whenTooLong() {
         // given
         UserRegisterRequest request =
-                new UserRegisterRequest("test@example.com", "a".repeat(21), "ab12!@");
+            new UserRegisterRequest("test@example.com", "a".repeat(21), "ab12!@");
 
         // when
         Set<ConstraintViolation<UserRegisterRequest>> violations = validator.validate(request);

--- a/src/test/java/com/springboot/monew/users/dto/UserUpdateRequestTest.java
+++ b/src/test/java/com/springboot/monew/users/dto/UserUpdateRequestTest.java
@@ -1,129 +1,133 @@
 package com.springboot.monew.users.dto;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import jakarta.validation.ValidatorFactory;
-import org.junit.jupiter.api.*;
-
 import java.util.Set;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 public class UserUpdateRequestTest {
-    private static ValidatorFactory factory;
-    private Validator validator;
 
-    @BeforeAll
-    static void setUpFactory() {
-        factory = Validation.buildDefaultValidatorFactory();
-    }
+  private static ValidatorFactory factory;
+  private Validator validator;
 
-    @BeforeEach
-    void setUp() {
-        validator = factory.getValidator();
-    }
+  @BeforeAll
+  static void setUpFactory() {
+    factory = Validation.buildDefaultValidatorFactory();
+  }
 
-    @AfterAll
-    static void tearDown() {
-        factory.close();
-    }
+  @BeforeEach
+  void setUp() {
+    validator = factory.getValidator();
+  }
 
-    @Test
-    @DisplayName("닉네임 형태가 올바르면 검증에 성공한다")
-    void validateNickname_success() {
-        // given
-        UserUpdateRequest request =
-                new UserUpdateRequest("모뉴monew123");
+  @AfterAll
+  static void tearDown() {
+    factory.close();
+  }
 
-        // when
-        Set<ConstraintViolation<UserUpdateRequest>> violations = validator.validate(request);
+  @Test
+  @DisplayName("닉네임 형태가 올바르면 검증에 성공한다")
+  void validateNickname_success() {
+    // given
+    UserUpdateRequest request =
+        new UserUpdateRequest("모뉴monew123");
 
-        // then
-        assertThat(violations).isEmpty();
-    }
+    // when
+    Set<ConstraintViolation<UserUpdateRequest>> violations = validator.validate(request);
 
-    @Test
-    @DisplayName("닉네임이 null이면 검증에 실패한다")
-    void validateNickname_fail_whenNull() {
-        // given
-        UserUpdateRequest request =
-                new UserUpdateRequest(null);
+    // then
+    assertThat(violations).isEmpty();
+  }
 
-        // when
-        Set<ConstraintViolation<UserUpdateRequest>> violations = validator.validate(request);
+  @Test
+  @DisplayName("닉네임이 null이면 검증에 실패한다")
+  void validateNickname_fail_whenNull() {
+    // given
+    UserUpdateRequest request =
+        new UserUpdateRequest(null);
 
-        // then
-        assertThat(violations).isNotEmpty();
-    }
+    // when
+    Set<ConstraintViolation<UserUpdateRequest>> violations = validator.validate(request);
 
-    @Test
-    @DisplayName("닉네임이 비어 있으면 검증에 실패한다")
-    void validateNickname_fail_whenBlank() {
-        // given
-        UserUpdateRequest request =
-                new UserUpdateRequest("");
+    // then
+    assertThat(violations).isNotEmpty();
+  }
 
-        // when
-        Set<ConstraintViolation<UserUpdateRequest>> violations = validator.validate(request);
+  @Test
+  @DisplayName("닉네임이 비어 있으면 검증에 실패한다")
+  void validateNickname_fail_whenBlank() {
+    // given
+    UserUpdateRequest request =
+        new UserUpdateRequest("");
 
-        // then
-        assertThat(violations).isNotEmpty();
-    }
+    // when
+    Set<ConstraintViolation<UserUpdateRequest>> violations = validator.validate(request);
 
-    @Test
-    @DisplayName("닉네임이 공백만 있으면 검증에 실패한다")
-    void validateNickname_fail_whenOnlyWhiteSpace() {
-        // given
-        UserUpdateRequest request =
-                new UserUpdateRequest("   ");
+    // then
+    assertThat(violations).isNotEmpty();
+  }
 
-        // when
-        Set<ConstraintViolation<UserUpdateRequest>> violations = validator.validate(request);
+  @Test
+  @DisplayName("닉네임이 공백만 있으면 검증에 실패한다")
+  void validateNickname_fail_whenOnlyWhiteSpace() {
+    // given
+    UserUpdateRequest request =
+        new UserUpdateRequest("   ");
 
-        // then
-        assertThat(violations).isNotEmpty();
-    }
+    // when
+    Set<ConstraintViolation<UserUpdateRequest>> violations = validator.validate(request);
 
-    @Test
-    @DisplayName("닉네임에 공백이 포함되면 검증에 실패한다")
-    void validateNickname_fail_whenContainsWhitespace() {
-        // given
-        UserUpdateRequest request =
-                new UserUpdateRequest("ab c");
+    // then
+    assertThat(violations).isNotEmpty();
+  }
 
-        // when
-        Set<ConstraintViolation<UserUpdateRequest>> violations = validator.validate(request);
+  @Test
+  @DisplayName("닉네임에 공백이 포함되면 검증에 실패한다")
+  void validateNickname_fail_whenContainsWhitespace() {
+    // given
+    UserUpdateRequest request =
+        new UserUpdateRequest("ab c");
 
-        // then
-        assertThat(violations).isNotEmpty();
-    }
+    // when
+    Set<ConstraintViolation<UserUpdateRequest>> violations = validator.validate(request);
 
-    @Test
-    @DisplayName("닉네임에 특수문자가 포함되면 검증에 실패한다")
-    void validateNickname_fail_whenContainsSpecialCharacter() {
-        // given
-        UserUpdateRequest request =
-                new UserUpdateRequest("ab@c");
+    // then
+    assertThat(violations).isNotEmpty();
+  }
 
-        // when
-        Set<ConstraintViolation<UserUpdateRequest>> violations = validator.validate(request);
+  @Test
+  @DisplayName("닉네임에 특수문자가 포함되면 검증에 실패한다")
+  void validateNickname_fail_whenContainsSpecialCharacter() {
+    // given
+    UserUpdateRequest request =
+        new UserUpdateRequest("ab@c");
 
-        // then
-        assertThat(violations).isNotEmpty();
-    }
+    // when
+    Set<ConstraintViolation<UserUpdateRequest>> violations = validator.validate(request);
 
-    @Test
-    @DisplayName("닉네임이 20자를 초과하면 검증에 실패한다")
-    void validateNickname_fail_whenTooLong() {
-        // given
-        UserUpdateRequest request =
-                new UserUpdateRequest("a".repeat(21));
+    // then
+    assertThat(violations).isNotEmpty();
+  }
 
-        // when
-        Set<ConstraintViolation<UserUpdateRequest>> violations = validator.validate(request);
+  @Test
+  @DisplayName("닉네임이 20자를 초과하면 검증에 실패한다")
+  void validateNickname_fail_whenTooLong() {
+    // given
+    UserUpdateRequest request =
+        new UserUpdateRequest("a".repeat(21));
 
-        // then
-        assertThat(violations).isNotEmpty();
-    }
+    // when
+    Set<ConstraintViolation<UserUpdateRequest>> violations = validator.validate(request);
+
+    // then
+    assertThat(violations).isNotEmpty();
+  }
 }

--- a/src/test/java/com/springboot/monew/users/service/UserServiceTest.java
+++ b/src/test/java/com/springboot/monew/users/service/UserServiceTest.java
@@ -2,12 +2,12 @@ package com.springboot.monew.users.service;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyList;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import com.springboot.monew.users.dto.UserDto;
 import com.springboot.monew.users.dto.UserLoginRequest;
@@ -52,7 +52,7 @@ public class UserServiceTest {
         "ab12!@"
     );
 
-    when(userRepository.existsByEmail(request.email())).thenReturn(true);
+    given(userRepository.existsByEmail(request.email())).willReturn(true);
 
     // when & then
         /*
@@ -83,8 +83,8 @@ public class UserServiceTest {
         "ab12!@"
     );
 
-    when(userRepository.existsByEmail(request.email())).thenReturn(false);
-    when(userRepository.existsByNickname(request.nickname())).thenReturn(true);
+    given(userRepository.existsByEmail(request.email())).willReturn(false);
+    given(userRepository.existsByNickname(request.nickname())).willReturn(true);
 
     // when & then
     assertThatThrownBy(() -> userService.register(request))
@@ -118,10 +118,10 @@ public class UserServiceTest {
         Instant.parse("2026-04-18T00:00:00Z")
     );
 
-    when(userRepository.existsByEmail(request.email())).thenReturn(false);
-    when(userRepository.existsByNickname(request.nickname())).thenReturn(false);
-    when(userRepository.save(any(User.class))).thenReturn(savedUser);
-    when(userMapper.toDto(savedUser)).thenReturn(expected);
+    given(userRepository.existsByEmail(request.email())).willReturn(false);
+    given(userRepository.existsByNickname(request.nickname())).willReturn(false);
+    given(userRepository.save(any(User.class))).willReturn(savedUser);
+    given(userMapper.toDto(savedUser)).willReturn(expected);
 
     // when
     UserDto result = userService.register(request);
@@ -148,8 +148,8 @@ public class UserServiceTest {
         Instant.parse("2026-04-18T00:00:00Z")
     );
 
-    when(userRepository.findByEmail(request.email())).thenReturn(Optional.of(user));
-    when(userMapper.toDto(user)).thenReturn(expected);
+    given(userRepository.findByEmail(request.email())).willReturn(Optional.of(user));
+    given(userMapper.toDto(user)).willReturn(expected);
 
     // when
     UserDto result = userService.login(request);
@@ -166,7 +166,7 @@ public class UserServiceTest {
     // given
     UserLoginRequest request = new UserLoginRequest("missing@example.com", "password123");
 
-    when(userRepository.findByEmail("missing@example.com")).thenReturn(Optional.empty());
+    given(userRepository.findByEmail("missing@example.com")).willReturn(Optional.empty());
 
     // when & then
     assertThatThrownBy(() -> userService.login(request))
@@ -187,7 +187,7 @@ public class UserServiceTest {
     UserLoginRequest request = new UserLoginRequest("test@example.com", "wrong-password");
     User user = new User("test@example.com", "monew123", "password123");
 
-    when(userRepository.findByEmail(request.email())).thenReturn(Optional.of(user));
+    given(userRepository.findByEmail(request.email())).willReturn(Optional.of(user));
 
     // when & then
     assertThatThrownBy(() -> userService.login(request))
@@ -209,7 +209,7 @@ public class UserServiceTest {
     User deletedUser = new User("deleted@example.com", "monew123", "password123");
     deletedUser.delete();
 
-    when(userRepository.findByEmail("deleted@example.com")).thenReturn(Optional.of(deletedUser));
+    given(userRepository.findByEmail("deleted@example.com")).willReturn(Optional.of(deletedUser));
 
     // when & then
     assertThatThrownBy(() -> userService.login(request))
@@ -238,9 +238,9 @@ public class UserServiceTest {
         Instant.parse("2026-04-18T00:00:00Z")
     );
 
-    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-    when(userRepository.existsByNickname(request.nickname())).thenReturn(false);
-    when(userMapper.toDto(user)).thenReturn(expected);
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+    given(userRepository.existsByNickname(request.nickname())).willReturn(false);
+    given(userMapper.toDto(user)).willReturn(expected);
 
     // when
     UserDto result = userService.update(userId, userId, request);
@@ -282,7 +282,7 @@ public class UserServiceTest {
     UUID userId = UUID.randomUUID();
     UserUpdateRequest request = new UserUpdateRequest("newNickname");
 
-    when(userRepository.findById(userId)).thenReturn(Optional.empty());
+    given(userRepository.findById(userId)).willReturn(Optional.empty());
 
     // when & then
     assertThatThrownBy(() -> userService.update(userId, userId, request))
@@ -306,7 +306,7 @@ public class UserServiceTest {
     User deletedUser = new User("deleted@example.com", "monew123", "password123");
     deletedUser.delete();
 
-    when(userRepository.findById(userId)).thenReturn(Optional.of(deletedUser));
+    given(userRepository.findById(userId)).willReturn(Optional.of(deletedUser));
 
     // when & then
     assertThatThrownBy(() -> userService.update(userId, userId, request))
@@ -329,8 +329,8 @@ public class UserServiceTest {
     User user = new User("test@example.com", "oldNickname", "password123");
 
     // given
-    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-    when(userRepository.existsByNickname(request.nickname())).thenReturn(true);
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+    given(userRepository.existsByNickname(request.nickname())).willReturn(true);
 
     // when & then
     assertThatThrownBy(() -> userService.update(userId, userId, request))
@@ -360,8 +360,8 @@ public class UserServiceTest {
         Instant.parse("2026-04-18T00:00:00Z")
     );
 
-    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-    when(userMapper.toDto(user)).thenReturn(expected);
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+    given(userMapper.toDto(user)).willReturn(expected);
 
     // when
     UserDto result = userService.update(userId, userId, request);
@@ -381,7 +381,7 @@ public class UserServiceTest {
     UUID userId = UUID.randomUUID();
     User user = new User("test@example.com", "monew123", "password123");
 
-    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
     // 삭제 되기 전 확인 검증용
     assertThat(user.isDeleted()).isFalse();
 
@@ -419,7 +419,7 @@ public class UserServiceTest {
     // given
     UUID userId = UUID.randomUUID();
 
-    when(userRepository.findById(userId)).thenReturn(Optional.empty());
+    given(userRepository.findById(userId)).willReturn(Optional.empty());
 
     // when & then
     assertThatThrownBy(() -> userService.delete(userId, userId))
@@ -440,7 +440,7 @@ public class UserServiceTest {
     User deletedUser = new User("deleted@example.com", "monew123", "password123");
     deletedUser.delete();
 
-    when(userRepository.findById(userId)).thenReturn(Optional.of(deletedUser));
+    given(userRepository.findById(userId)).willReturn(Optional.of(deletedUser));
 
     // when & then
     assertThatThrownBy(() -> userService.delete(userId, userId))
@@ -461,7 +461,7 @@ public class UserServiceTest {
     UUID userId = UUID.randomUUID();
     User user = new User("test@example.com", "monew123", "password123");
 
-    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
 
     // when
     userService.hardDelete(userId, userId);
@@ -497,7 +497,7 @@ public class UserServiceTest {
     // given
     UUID userId = UUID.randomUUID();
 
-    when(userRepository.findById(userId)).thenReturn(Optional.empty());
+    given(userRepository.findById(userId)).willReturn(Optional.empty());
 
     // when & then
     assertThatThrownBy(() -> userService.hardDelete(userId, userId))
@@ -522,7 +522,7 @@ public class UserServiceTest {
     User user2 = new User("deleted2@example.com", "monew123", "password123");
     List<User> users = List.of(user1, user2);
 
-    when(userRepository.findUsersDeletedBefore(cutoff)).thenReturn(users);
+    given(userRepository.findUsersDeletedBefore(cutoff)).willReturn(users);
 
     // when
     int result = userService.purgeDeletedUsersOlderThan(cutoff);
@@ -539,7 +539,7 @@ public class UserServiceTest {
     // given
     Instant cutoff = Instant.parse("2026-04-20T00:00:00Z");
 
-    when(userRepository.findUsersDeletedBefore(cutoff)).thenReturn(List.of());
+    given(userRepository.findUsersDeletedBefore(cutoff)).willReturn(List.of());
 
     // when
     int result = userService.purgeDeletedUsersOlderThan(cutoff);

--- a/src/test/java/com/springboot/monew/users/service/UserServiceTest.java
+++ b/src/test/java/com/springboot/monew/users/service/UserServiceTest.java
@@ -1,5 +1,14 @@
 package com.springboot.monew.users.service;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyList;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.springboot.monew.users.dto.UserDto;
 import com.springboot.monew.users.dto.UserLoginRequest;
 import com.springboot.monew.users.dto.UserRegisterRequest;
@@ -9,6 +18,11 @@ import com.springboot.monew.users.exception.UserErrorCode;
 import com.springboot.monew.users.exception.UserException;
 import com.springboot.monew.users.mapper.UserMapper;
 import com.springboot.monew.users.repository.UserRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,435 +30,523 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.Instant;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
-
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.mockito.Mockito.*;
-
 @ExtendWith(MockitoExtension.class)
 public class UserServiceTest {
 
-    @Mock
-    private UserRepository userRepository;
+  @Mock
+  private UserRepository userRepository;
 
-    @Mock
-    private UserMapper userMapper;
+  @Mock
+  private UserMapper userMapper;
 
-    @InjectMocks
-    private UserService userService;
+  @InjectMocks
+  private UserService userService;
 
-    @Test
-    @DisplayName("이메일이 중복되면 DUPLICATE_EMAIL 예외가 발생한다")
-    void register_duplicateEmail() {
-        // given
-        UserRegisterRequest request = new UserRegisterRequest(
-                "test@example.com",
-                "monew123",
-                "ab12!@"
-        );
+  @Test
+  @DisplayName("이메일이 중복되면 DUPLICATE_EMAIL 예외가 발생한다")
+  void register_duplicateEmail() {
+    // given
+    UserRegisterRequest request = new UserRegisterRequest(
+        "test@example.com",
+        "monew123",
+        "ab12!@"
+    );
 
-        when(userRepository.existsByEmail(request.email())).thenReturn(true);
+    when(userRepository.existsByEmail(request.email())).thenReturn(true);
 
-        // when & then
+    // when & then
         /*
             초기에는 catchThrowableOfType을 사용했지만, 현재는 AssertJ에서 권장하는 방식인 assertThatThrownBy를 사용했다.
             catchThrowableOfType은 예외를 먼저 변수로 받아서 검증하는 구조라 코드가 분리되는 반면,
             assertThatThrownBy는 예외 발생과 검증을 하나의 체이닝 형태로 이어서 작성할 수 있어 가독성과 확장성이 더 좋다.
          */
-        assertThatThrownBy(() -> userService.register(request))
-                .isInstanceOf(UserException.class)
-                .satisfies(throwable -> {
-                    UserException exception = (UserException) throwable;
-                    assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.DUPLICATE_EMAIL);
-                    assertThat(exception.getDetails()).isEqualTo(Map.of("email", request.email()));
-                });
-        verify(userRepository).existsByEmail(request.email());
-        verify(userRepository, never()).existsByNickname(anyString());
-        verify(userRepository, never()).save(any());
-        verify(userMapper, never()).toDto(any());
-    }
+    assertThatThrownBy(() -> userService.register(request))
+        .isInstanceOf(UserException.class)
+        .satisfies(throwable -> {
+          UserException exception = (UserException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.DUPLICATE_EMAIL);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("email", request.email()));
+        });
+    verify(userRepository).existsByEmail(request.email());
+    verify(userRepository, never()).existsByNickname(anyString());
+    verify(userRepository, never()).save(any());
+    verify(userMapper, never()).toDto(any());
+  }
 
-    @Test
-    @DisplayName("닉네임이 중복되면 DUPLICATE_NICKNAME 예외가 발생한다")
-    void register_duplicateNickname() {
-        // given
-        UserRegisterRequest request = new UserRegisterRequest(
-                "test@example.com",
-                "monew123",
-                "ab12!@"
-        );
+  @Test
+  @DisplayName("닉네임이 중복되면 DUPLICATE_NICKNAME 예외가 발생한다")
+  void register_duplicateNickname() {
+    // given
+    UserRegisterRequest request = new UserRegisterRequest(
+        "test@example.com",
+        "monew123",
+        "ab12!@"
+    );
 
-        when(userRepository.existsByEmail(request.email())).thenReturn(false);
-        when(userRepository.existsByNickname(request.nickname())).thenReturn(true);
+    when(userRepository.existsByEmail(request.email())).thenReturn(false);
+    when(userRepository.existsByNickname(request.nickname())).thenReturn(true);
 
-        // when & then
-        assertThatThrownBy(() -> userService.register(request))
-                .isInstanceOf(UserException.class)
-                .satisfies(throwable -> {
-                    UserException exception = (UserException) throwable;
-                    assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.DUPLICATE_NICKNAME);
-                    assertThat(exception.getDetails()).isEqualTo(Map.of("nickname", request.nickname()));
-                });
-        verify(userRepository).existsByEmail(request.email());
-        verify(userRepository).existsByNickname(request.nickname());
-        verify(userRepository, never()).save(any());
-        verify(userMapper, never()).toDto(any());
-    }
+    // when & then
+    assertThatThrownBy(() -> userService.register(request))
+        .isInstanceOf(UserException.class)
+        .satisfies(throwable -> {
+          UserException exception = (UserException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.DUPLICATE_NICKNAME);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("nickname", request.nickname()));
+        });
+    verify(userRepository).existsByEmail(request.email());
+    verify(userRepository).existsByNickname(request.nickname());
+    verify(userRepository, never()).save(any());
+    verify(userMapper, never()).toDto(any());
+  }
 
-    @Test
-    @DisplayName("회원가입 성공 시 사용자를 저장한 뒤 UserDto를 반환한다")
-    void register_success() {
-        // given
-        UserRegisterRequest request = new UserRegisterRequest(
-                "test@example.com",
-                "monew123",
-                "ab12!@"
-        );
+  @Test
+  @DisplayName("회원가입 성공 시 사용자를 저장한 뒤 UserDto를 반환한다")
+  void register_success() {
+    // given
+    UserRegisterRequest request = new UserRegisterRequest(
+        "test@example.com",
+        "monew123",
+        "ab12!@"
+    );
 
-        User savedUser = new User("test@example.com", "monew123", "ab12!@");
-        UserDto expected = new UserDto(
-                UUID.randomUUID(),
-                "test@example.com",
-                "monew123",
-                Instant.parse("2026-04-18T00:00:00Z")
-        );
+    User savedUser = new User("test@example.com", "monew123", "ab12!@");
+    UserDto expected = new UserDto(
+        UUID.randomUUID(),
+        "test@example.com",
+        "monew123",
+        Instant.parse("2026-04-18T00:00:00Z")
+    );
 
-        when(userRepository.existsByEmail(request.email())).thenReturn(false);
-        when(userRepository.existsByNickname(request.nickname())).thenReturn(false);
-        when(userRepository.save(any(User.class))).thenReturn(savedUser);
-        when(userMapper.toDto(savedUser)).thenReturn(expected);
+    when(userRepository.existsByEmail(request.email())).thenReturn(false);
+    when(userRepository.existsByNickname(request.nickname())).thenReturn(false);
+    when(userRepository.save(any(User.class))).thenReturn(savedUser);
+    when(userMapper.toDto(savedUser)).thenReturn(expected);
 
-        // when
-        UserDto result = userService.register(request);
+    // when
+    UserDto result = userService.register(request);
 
-        // then
-        assertThat(result).isEqualTo(expected);
-        verify(userRepository).existsByEmail(request.email());
-        verify(userRepository).existsByNickname(request.nickname());
-        verify(userRepository).save(any(User.class));
-        verify(userMapper).toDto(savedUser);
-    }
+    // then
+    assertThat(result).isEqualTo(expected);
+    verify(userRepository).existsByEmail(request.email());
+    verify(userRepository).existsByNickname(request.nickname());
+    verify(userRepository).save(any(User.class));
+    verify(userMapper).toDto(savedUser);
+  }
 
-    @Test
-    @DisplayName("정상 로그인 시 사용자 정보를 반환한다")
-    void login_success() {
-        // given
-        UserLoginRequest request = new UserLoginRequest("test@example.com", "password123");
-        User user = new User("test@example.com", "monew123", "password123");
+  @Test
+  @DisplayName("정상 로그인 시 사용자 정보를 반환한다")
+  void login_success() {
+    // given
+    UserLoginRequest request = new UserLoginRequest("test@example.com", "password123");
+    User user = new User("test@example.com", "monew123", "password123");
 
-        UserDto expected = new UserDto(
-                UUID.randomUUID(),
-                "test@example.com",
-                "monew123",
-                Instant.parse("2026-04-18T00:00:00Z")
-        );
+    UserDto expected = new UserDto(
+        UUID.randomUUID(),
+        "test@example.com",
+        "monew123",
+        Instant.parse("2026-04-18T00:00:00Z")
+    );
 
-        when(userRepository.findByEmail(request.email())).thenReturn(Optional.of(user));
-        when(userMapper.toDto(user)).thenReturn(expected);
+    when(userRepository.findByEmail(request.email())).thenReturn(Optional.of(user));
+    when(userMapper.toDto(user)).thenReturn(expected);
 
-        // when
-        UserDto result = userService.login(request);
+    // when
+    UserDto result = userService.login(request);
 
-        // then
-        assertThat(result).isEqualTo(expected);
-        verify(userRepository).findByEmail(request.email());
-        verify(userMapper).toDto(user);
-    }
+    // then
+    assertThat(result).isEqualTo(expected);
+    verify(userRepository).findByEmail(request.email());
+    verify(userMapper).toDto(user);
+  }
 
-    @Test
-    @DisplayName("존재하지 않는 사용자로 로그인하면 USER_NOT_FOUND 예외가 발생한다")
-    void login_userNotFound() {
-        // given
-        UserLoginRequest request = new UserLoginRequest("missing@example.com", "password123");
+  @Test
+  @DisplayName("존재하지 않는 사용자로 로그인하면 USER_NOT_FOUND 예외가 발생한다")
+  void login_userNotFound() {
+    // given
+    UserLoginRequest request = new UserLoginRequest("missing@example.com", "password123");
 
-        when(userRepository.findByEmail("missing@example.com")).thenReturn(Optional.empty());
+    when(userRepository.findByEmail("missing@example.com")).thenReturn(Optional.empty());
 
-        // when & then
-        assertThatThrownBy(() -> userService.login(request))
-                .isInstanceOf(UserException.class)
-                .satisfies(throwable -> {
-                    UserException exception = (UserException) throwable;
-                    assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
-                    assertThat(exception.getDetails()).isEqualTo(Map.of("email", "missing@example.com"));
-                });
-        verify(userRepository).findByEmail("missing@example.com");
-        verify(userMapper, never()).toDto(any());
-    }
+    // when & then
+    assertThatThrownBy(() -> userService.login(request))
+        .isInstanceOf(UserException.class)
+        .satisfies(throwable -> {
+          UserException exception = (UserException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("email", "missing@example.com"));
+        });
+    verify(userRepository).findByEmail("missing@example.com");
+    verify(userMapper, never()).toDto(any());
+  }
 
-    @Test
-    @DisplayName("비밀번호가 일치하지 않으면 INVALID_CREDENTIALS 예외가 발생한다")
-    void login_invalidPassword() {
-        // given
-        UserLoginRequest request = new UserLoginRequest("test@example.com", "wrong-password");
-        User user = new User("test@example.com", "monew123", "password123");
+  @Test
+  @DisplayName("비밀번호가 일치하지 않으면 INVALID_CREDENTIALS 예외가 발생한다")
+  void login_invalidPassword() {
+    // given
+    UserLoginRequest request = new UserLoginRequest("test@example.com", "wrong-password");
+    User user = new User("test@example.com", "monew123", "password123");
 
-        when(userRepository.findByEmail(request.email())).thenReturn(Optional.of(user));
+    when(userRepository.findByEmail(request.email())).thenReturn(Optional.of(user));
 
-        // when & then
-        assertThatThrownBy(() -> userService.login(request))
-                .isInstanceOf(UserException.class)
-                .satisfies(throwable -> {
-                    UserException exception = (UserException) throwable;
-                    assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.INVALID_CREDENTIALS);
-                    assertThat(exception.getDetails()).isEqualTo(Map.of("email", request.email()));
-                });
-        verify(userRepository).findByEmail(request.email());
-        verify(userMapper, never()).toDto(any());
-    }
+    // when & then
+    assertThatThrownBy(() -> userService.login(request))
+        .isInstanceOf(UserException.class)
+        .satisfies(throwable -> {
+          UserException exception = (UserException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.INVALID_CREDENTIALS);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("email", request.email()));
+        });
+    verify(userRepository).findByEmail(request.email());
+    verify(userMapper, never()).toDto(any());
+  }
 
-    @Test
-    @DisplayName("삭제된 사용자는 로그인할 수 없고 USER_NOT_FOUND 예외가 발생한다")
-    void login_deletedUser() {
-        // given
-        UserLoginRequest request = new UserLoginRequest("deleted@example.com", "password123");
-        User deletedUser = new User("deleted@example.com", "monew123", "password123");
-        deletedUser.delete();
+  @Test
+  @DisplayName("삭제된 사용자는 로그인할 수 없고 USER_NOT_FOUND 예외가 발생한다")
+  void login_deletedUser() {
+    // given
+    UserLoginRequest request = new UserLoginRequest("deleted@example.com", "password123");
+    User deletedUser = new User("deleted@example.com", "monew123", "password123");
+    deletedUser.delete();
 
-        when(userRepository.findByEmail("deleted@example.com")).thenReturn(Optional.of(deletedUser));
+    when(userRepository.findByEmail("deleted@example.com")).thenReturn(Optional.of(deletedUser));
 
-        // when & then
-        assertThatThrownBy(() -> userService.login(request))
-                .isInstanceOf(UserException.class)
-                .satisfies(throwable -> {
-                    UserException exception = (UserException) throwable;
-                    assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
-                    assertThat(exception.getDetails()).isEqualTo(Map.of("email", "deleted@example.com"));
-                });
-        verify(userRepository).findByEmail("deleted@example.com");
-        verify(userMapper, never()).toDto(any());
-    }
+    // when & then
+    assertThatThrownBy(() -> userService.login(request))
+        .isInstanceOf(UserException.class)
+        .satisfies(throwable -> {
+          UserException exception = (UserException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("email", "deleted@example.com"));
+        });
+    verify(userRepository).findByEmail("deleted@example.com");
+    verify(userMapper, never()).toDto(any());
+  }
 
-    @Test
-    @DisplayName("닉네임 수정에 성공하면 수정된 사용자 정보를 반환한다")
-    void update_success() {
-        // given
-        UUID userId = UUID.randomUUID();
-        UserUpdateRequest request = new UserUpdateRequest("newNickname");
-        User user = new User("test@example.com",  "oldNickname", "password123");
+  @Test
+  @DisplayName("닉네임 수정에 성공하면 수정된 사용자 정보를 반환한다")
+  void update_success() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UserUpdateRequest request = new UserUpdateRequest("newNickname");
+    User user = new User("test@example.com", "oldNickname", "password123");
 
-        UserDto expected = new UserDto(
-                userId,
-                "test@example.com",
-                "newNickname",
-                Instant.parse("2026-04-18T00:00:00Z")
-        );
+    UserDto expected = new UserDto(
+        userId,
+        "test@example.com",
+        "newNickname",
+        Instant.parse("2026-04-18T00:00:00Z")
+    );
 
-        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-        when(userRepository.existsByNickname(request.nickname())).thenReturn(false);
-        when(userMapper.toDto(user)).thenReturn(expected);
+    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+    when(userRepository.existsByNickname(request.nickname())).thenReturn(false);
+    when(userMapper.toDto(user)).thenReturn(expected);
 
-        // when
-        UserDto result = userService.update(userId, userId, request);
+    // when
+    UserDto result = userService.update(userId, userId, request);
 
-        // then
-        assertThat(result).isEqualTo(expected);
-        assertThat(user.getNickname()).isEqualTo(request.nickname());
-        verify(userRepository).findById(userId);
-        verify(userRepository).existsByNickname(request.nickname());
-        verify(userMapper).toDto(user);
-    }
+    // then
+    assertThat(result).isEqualTo(expected);
+    assertThat(user.getNickname()).isEqualTo(request.nickname());
+    verify(userRepository).findById(userId);
+    verify(userRepository).existsByNickname(request.nickname());
+    verify(userMapper).toDto(user);
+  }
 
-    @Test
-    @DisplayName("요청 사용자와 수정 대상 사용자가 다르면 USER_NOT_OWNED 예외가 발생한다.")
-    void update_userNotOwned() {
-        // given
-        UUID userId = UUID.randomUUID();
-        UUID requestUserId = UUID.randomUUID();
-        UserUpdateRequest request = new UserUpdateRequest("newNickname");
+  @Test
+  @DisplayName("요청 사용자와 수정 대상 사용자가 다르면 USER_NOT_OWNED 예외가 발생한다.")
+  void update_userNotOwned() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID requestUserId = UUID.randomUUID();
+    UserUpdateRequest request = new UserUpdateRequest("newNickname");
 
-        // when & then
-        assertThatThrownBy(() -> userService.update(userId, requestUserId, request))
-                .isInstanceOf(UserException.class)
-                .satisfies(throwable -> {
-                    UserException exception = (UserException) throwable;
-                    assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_OWNED);
-                    assertThat(exception.getDetails()).isEqualTo(
-                            Map.of("userId", userId, "requestUserId", requestUserId));
-                });
-        verify(userRepository, never()).findById(any());
-        verify(userRepository, never()).existsByNickname(anyString());
-        verify(userMapper, never()).toDto(any());
-    }
+    // when & then
+    assertThatThrownBy(() -> userService.update(userId, requestUserId, request))
+        .isInstanceOf(UserException.class)
+        .satisfies(throwable -> {
+          UserException exception = (UserException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_OWNED);
+          assertThat(exception.getDetails()).isEqualTo(
+              Map.of("userId", userId, "requestUserId", requestUserId));
+        });
+    verify(userRepository, never()).findById(any());
+    verify(userRepository, never()).existsByNickname(anyString());
+    verify(userMapper, never()).toDto(any());
+  }
 
-    @Test
-    @DisplayName("존재하지 않는 사용자의 닉네임을 수정하면 USER_NOT_FOUND 예외가 발생한다")
-    void update_userNotFound() {
-        // given
-        UUID userId = UUID.randomUUID();
-        UserUpdateRequest request = new UserUpdateRequest("newNickname");
+  @Test
+  @DisplayName("존재하지 않는 사용자의 닉네임을 수정하면 USER_NOT_FOUND 예외가 발생한다")
+  void update_userNotFound() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UserUpdateRequest request = new UserUpdateRequest("newNickname");
 
-        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+    when(userRepository.findById(userId)).thenReturn(Optional.empty());
 
-        // when & then
-        assertThatThrownBy(() -> userService.update(userId, userId, request))
-                .isInstanceOf(UserException.class)
-                .satisfies(throwable -> {
-                    UserException exception = (UserException) throwable;
-                    assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
-                    assertThat(exception.getDetails()).isEqualTo(Map.of("userId", userId));
-                });
-        verify(userRepository).findById(userId);
-        verify(userRepository, never()).existsByNickname(anyString());
-        verify(userMapper, never()).toDto(any());
-    }
+    // when & then
+    assertThatThrownBy(() -> userService.update(userId, userId, request))
+        .isInstanceOf(UserException.class)
+        .satisfies(throwable -> {
+          UserException exception = (UserException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("userId", userId));
+        });
+    verify(userRepository).findById(userId);
+    verify(userRepository, never()).existsByNickname(anyString());
+    verify(userMapper, never()).toDto(any());
+  }
 
-    @Test
-    @DisplayName("삭제된 사용자의 닉네임을 수정하면 USER_NOT_FOUND 예외가 발생한다.")
-    void update_deletedUser() {
-        // given
-        UUID userId = UUID.randomUUID();
-        UserUpdateRequest request = new UserUpdateRequest("newNickname");
-        User deletedUser = new User("deleted@example.com", "monew123", "password123");
-        deletedUser.delete();
+  @Test
+  @DisplayName("삭제된 사용자의 닉네임을 수정하면 USER_NOT_FOUND 예외가 발생한다.")
+  void update_deletedUser() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UserUpdateRequest request = new UserUpdateRequest("newNickname");
+    User deletedUser = new User("deleted@example.com", "monew123", "password123");
+    deletedUser.delete();
 
-        when(userRepository.findById(userId)).thenReturn(Optional.of(deletedUser));
+    when(userRepository.findById(userId)).thenReturn(Optional.of(deletedUser));
 
-        // when & then
-        assertThatThrownBy(() -> userService.update(userId, userId, request))
-                .isInstanceOf(UserException.class)
-                .satisfies(throwable -> {
-                    UserException exception = (UserException) throwable;
-                    assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
-                    assertThat(exception.getDetails()).isEqualTo(Map.of("userId", userId));
-                });
+    // when & then
+    assertThatThrownBy(() -> userService.update(userId, userId, request))
+        .isInstanceOf(UserException.class)
+        .satisfies(throwable -> {
+          UserException exception = (UserException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("userId", userId));
+        });
 
-        verify(userRepository).findById(userId);
-        verify(userRepository, never()).existsByNickname(anyString());
-    }
+    verify(userRepository).findById(userId);
+    verify(userRepository, never()).existsByNickname(anyString());
+  }
 
-    @Test
-    @DisplayName("이미 사용 중인 닉네임으로 수정하면 DUPLICATE_NICKNAME 예외가 발생한다")
-    void update_duplicateNickname() {
-        UUID userId = UUID.randomUUID();
-        UserUpdateRequest request = new UserUpdateRequest("duplicateNickname");
-        User user = new User("test@example.com",  "oldNickname", "password123");
+  @Test
+  @DisplayName("이미 사용 중인 닉네임으로 수정하면 DUPLICATE_NICKNAME 예외가 발생한다")
+  void update_duplicateNickname() {
+    UUID userId = UUID.randomUUID();
+    UserUpdateRequest request = new UserUpdateRequest("duplicateNickname");
+    User user = new User("test@example.com", "oldNickname", "password123");
 
-        // given
-        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-        when(userRepository.existsByNickname(request.nickname())).thenReturn(true);
+    // given
+    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+    when(userRepository.existsByNickname(request.nickname())).thenReturn(true);
 
-        // when & then
-        assertThatThrownBy(() -> userService.update(userId, userId, request))
-                .isInstanceOf(UserException.class)
-                .satisfies(throwable -> {
-                    UserException exception = (UserException) throwable;
-                    assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.DUPLICATE_NICKNAME);
-                    assertThat(exception.getDetails()).isEqualTo(Map.of("nickname", request.nickname()));
-                });
-        verify(userRepository).findById(userId);
-        verify(userRepository).existsByNickname(request.nickname());
-        verify(userMapper, never()).toDto(any());
-    }
+    // when & then
+    assertThatThrownBy(() -> userService.update(userId, userId, request))
+        .isInstanceOf(UserException.class)
+        .satisfies(throwable -> {
+          UserException exception = (UserException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.DUPLICATE_NICKNAME);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("nickname", request.nickname()));
+        });
+    verify(userRepository).findById(userId);
+    verify(userRepository).existsByNickname(request.nickname());
+    verify(userMapper, never()).toDto(any());
+  }
 
-    @Test
-    @DisplayName("기존 닉네임으로 수정 요청하면 중복 닉네임 조회 없이 성공한다")
-    void update_sameNickname() {
-        // given
-        UUID userId = UUID.randomUUID();
-        UserUpdateRequest request = new UserUpdateRequest("sameNickname");
-        User user = new User("test@example.com",  "sameNickname", "password123");
+  @Test
+  @DisplayName("기존 닉네임으로 수정 요청하면 중복 닉네임 조회 없이 성공한다")
+  void update_sameNickname() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UserUpdateRequest request = new UserUpdateRequest("sameNickname");
+    User user = new User("test@example.com", "sameNickname", "password123");
 
-        UserDto expected = new UserDto(
-                userId,
-                "test@example.com",
-                "sameNickname",
-                Instant.parse("2026-04-18T00:00:00Z")
-        );
+    UserDto expected = new UserDto(
+        userId,
+        "test@example.com",
+        "sameNickname",
+        Instant.parse("2026-04-18T00:00:00Z")
+    );
 
-        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-        when(userMapper.toDto(user)).thenReturn(expected);
+    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+    when(userMapper.toDto(user)).thenReturn(expected);
 
-        // when
-        UserDto result = userService.update(userId, userId, request);
+    // when
+    UserDto result = userService.update(userId, userId, request);
 
-        // then
-        assertThat(result).isEqualTo(expected);
-        assertThat(user.getNickname()).isEqualTo(request.nickname());
-        verify(userRepository).findById(userId);
-        verify(userRepository, never()).existsByNickname(anyString());
-        verify(userMapper).toDto(user);
-    }
+    // then
+    assertThat(result).isEqualTo(expected);
+    assertThat(user.getNickname()).isEqualTo(request.nickname());
+    verify(userRepository).findById(userId);
+    verify(userRepository, never()).existsByNickname(anyString());
+    verify(userMapper).toDto(user);
+  }
 
-    @Test
-    @DisplayName("사용자 삭제에 성공하면 deletedAt이 설정된다")
-    void delete_success() {
-        // given
-        UUID userId = UUID.randomUUID();
-        User user = new User("test@example.com", "monew123", "password123");
+  @Test
+  @DisplayName("사용자 삭제에 성공하면 deletedAt이 설정된다")
+  void delete_success() {
+    // given
+    UUID userId = UUID.randomUUID();
+    User user = new User("test@example.com", "monew123", "password123");
 
-        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-        // 삭제 되기 전 확인 검증용
-        assertThat(user.isDeleted()).isFalse();
+    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+    // 삭제 되기 전 확인 검증용
+    assertThat(user.isDeleted()).isFalse();
 
-        // when
-        userService.delete(userId, userId);
+    // when
+    userService.delete(userId, userId);
 
-        // then
-        assertThat(user.isDeleted()).isTrue();
-        verify(userRepository).findById(userId);
-    }
+    // then
+    assertThat(user.isDeleted()).isTrue();
+    verify(userRepository).findById(userId);
+  }
 
-    @Test
-    @DisplayName("요청 사용자와 삭제 대상 사용자가 다르면 USER_NOT_OWNED 예외가 발생한다")
-    void delete_userNotOwned() {
-        // given
-        UUID userId = UUID.randomUUID();
-        UUID requestUserId = UUID.randomUUID();
+  @Test
+  @DisplayName("요청 사용자와 삭제 대상 사용자가 다르면 USER_NOT_OWNED 예외가 발생한다")
+  void delete_userNotOwned() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID requestUserId = UUID.randomUUID();
 
-        // when & then
-        assertThatThrownBy(() -> userService.delete(userId, requestUserId))
-                .isInstanceOf(UserException.class)
-                .satisfies(throwable -> {
-                    UserException exception = (UserException) throwable;
-                    assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_OWNED);
-                    assertThat(exception.getDetails()).isEqualTo(Map.of("userId", userId, "requestUserId", requestUserId));
-                });
-        verify(userRepository, never()).findById(any());
-        verify(userMapper, never()).toDto(any());
-    }
+    // when & then
+    assertThatThrownBy(() -> userService.delete(userId, requestUserId))
+        .isInstanceOf(UserException.class)
+        .satisfies(throwable -> {
+          UserException exception = (UserException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_OWNED);
+          assertThat(exception.getDetails()).isEqualTo(
+              Map.of("userId", userId, "requestUserId", requestUserId));
+        });
+    verify(userRepository, never()).findById(any());
+    verify(userMapper, never()).toDto(any());
+  }
 
-    @Test
-    @DisplayName("존재하지 않는 사용자를 삭제하면 USER_NOT_FOUND 예외가 발생한다")
-    void delete_userNotFound() {
-        // given
-        UUID userId = UUID.randomUUID();
+  @Test
+  @DisplayName("존재하지 않는 사용자를 삭제하면 USER_NOT_FOUND 예외가 발생한다")
+  void delete_userNotFound() {
+    // given
+    UUID userId = UUID.randomUUID();
 
-        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+    when(userRepository.findById(userId)).thenReturn(Optional.empty());
 
-        // when & then
-        assertThatThrownBy(() -> userService.delete(userId, userId))
-                .isInstanceOf(UserException.class)
-                .satisfies(throwable -> {
-                    UserException exception = (UserException) throwable;
-                    assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
-                    assertThat(exception.getDetails()).isEqualTo(Map.of("userId", userId));
-                });
-        verify(userRepository).findById(userId);
-    }
+    // when & then
+    assertThatThrownBy(() -> userService.delete(userId, userId))
+        .isInstanceOf(UserException.class)
+        .satisfies(throwable -> {
+          UserException exception = (UserException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("userId", userId));
+        });
+    verify(userRepository).findById(userId);
+  }
 
-    @Test
-    @DisplayName("이미 삭제된 사용자를 삭제하면 USER_NOT_FOUND 예외가 발생한다")
-    void delete_deletedUser() {
-        // given
-        UUID userId = UUID.randomUUID();
-        User deletedUser = new User("deleted@example.com", "monew123", "password123");
-        deletedUser.delete();
+  @Test
+  @DisplayName("이미 삭제된 사용자를 삭제하면 USER_NOT_FOUND 예외가 발생한다")
+  void delete_deletedUser() {
+    // given
+    UUID userId = UUID.randomUUID();
+    User deletedUser = new User("deleted@example.com", "monew123", "password123");
+    deletedUser.delete();
 
-        when(userRepository.findById(userId)).thenReturn(Optional.of(deletedUser));
+    when(userRepository.findById(userId)).thenReturn(Optional.of(deletedUser));
 
-        // when & then
-        assertThatThrownBy(() -> userService.delete(userId, userId))
-                .isInstanceOf(UserException.class)
-                .satisfies(throwable -> {
-                    UserException exception = (UserException) throwable;
-                    assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
-                    assertThat(exception.getDetails()).isEqualTo(Map.of("userId", userId));
-                });
-        verify(userRepository).findById(userId);
-        assertThat(deletedUser.isDeleted()).isTrue();
-    }
+    // when & then
+    assertThatThrownBy(() -> userService.delete(userId, userId))
+        .isInstanceOf(UserException.class)
+        .satisfies(throwable -> {
+          UserException exception = (UserException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("userId", userId));
+        });
+    verify(userRepository).findById(userId);
+    assertThat(deletedUser.isDeleted()).isTrue();
+  }
+
+  @Test
+  @DisplayName("사용자 물리 삭제에 성공하면 사용자 엔티티를 삭제한다.")
+  void hardDelete_success() {
+    // given
+    UUID userId = UUID.randomUUID();
+    User user = new User("test@example.com", "monew123", "password123");
+
+    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+    // when
+    userService.hardDelete(userId, userId);
+
+    // then
+    verify(userRepository).findById(userId);
+    verify(userRepository).delete(user);
+  }
+
+  @Test
+  @DisplayName("요청 사용자와 물리 삭제 대상 사용자가 다르면 USER_NOT_OWNED 예외가 발생한다")
+  void hardDelete_userNotOwned() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID requestUserId = UUID.randomUUID();
+
+    // when & then
+    assertThatThrownBy(() -> userService.hardDelete(userId, requestUserId))
+        .isInstanceOf(UserException.class)
+        .satisfies(throwable -> {
+          UserException exception = (UserException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_OWNED);
+          assertThat(exception.getDetails()).isEqualTo(
+              Map.of("userId", userId, "requestUserId", requestUserId));
+        });
+
+    verify(userRepository, never()).findById(any());
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 사용자를 물리 삭제하면 USER_NOT_FOUND 예외가 발생한다")
+  void hardDelete_userNotFound() {
+    // given
+    UUID userId = UUID.randomUUID();
+
+    when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> userService.hardDelete(userId, userId))
+        .isInstanceOf(UserException.class)
+        .satisfies(throwable -> {
+          UserException exception = (UserException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("userId", userId));
+        });
+
+    verify(userRepository).findById(userId);
+    verify(userRepository, never()).delete(any());
+  }
+
+  @Test
+  @DisplayName("기준 시각 이전에 논리 삭제된 사용자를 모두 물리 삭제한다")
+  void purgeDeletedUsersOlderThan_success() {
+    // given
+    Instant cutoff = Instant.parse("2026-04-20T00:00:00Z");
+
+    User user1 = new User("deleted1@example.com", "monew123", "password123");
+    User user2 = new User("deleted2@example.com", "monew123", "password123");
+    List<User> users = List.of(user1, user2);
+
+    when(userRepository.findUsersDeletedBefore(cutoff)).thenReturn(users);
+
+    // when
+    int result = userService.purgeDeletedUsersOlderThan(cutoff);
+
+    // then
+    verify(userRepository).findUsersDeletedBefore(cutoff);
+    verify(userRepository).deleteAll(users);
+    assertThat(result).isEqualTo(2);
+  }
+
+  @Test
+  @DisplayName("물리 삭제 대상 사용자가 없으면 삭제를 수행하지 않고 0을 반환한다")
+  void purgeDeletedUsersOlderThan_empty() {
+    // given
+    Instant cutoff = Instant.parse("2026-04-20T00:00:00Z");
+
+    when(userRepository.findUsersDeletedBefore(cutoff)).thenReturn(List.of());
+
+    // when
+    int result = userService.purgeDeletedUsersOlderThan(cutoff);
+
+    // then
+    verify(userRepository).findUsersDeletedBefore(cutoff);
+    verify(userRepository, never()).deleteAll(anyList());
+    assertThat(result).isEqualTo(0);
+  }
 }


### PR DESCRIPTION
## 📌 해당 이슈카드

Closes #11 #73 #75 #76

## 📌 작업 내용

- 사용자 수동 물리 삭제 API 구현
- 논리 삭제 후 24시간이 지난 사용자 자동 물리 삭제 로직 구현
- 사용자 물리 삭제 관련 테스트 코드 추가

## 🔧 변경 사항

  - `DELETE /api/users/{userId}/hard` API 추가
  - `MoNew-Request-User-ID` 헤더 기반 본인 요청 검증 후 사용자 물리 삭제 처리
  - `deletedAt` 기준 24시간 경과 사용자 조회 JPQL 추가
  - 스케줄러를 통해 만료된 논리 삭제 사용자 주기적 물리 삭제 처리
  - 사용자 삭제 시 연관 데이터는 기존 DB `ON DELETE CASCADE` 제약 조건에 따라 삭제

## 반영 브랜치
`feature/#11/user hard delete` -> `dev`

## 💬 기타 참고 사항
- 코드 포멧팅 때문에 여러 파일들이 변동 되긴 했는데, 그 중에
`UserService`, `UserApiDocs`, 'UserController'은 사용자 물리 삭제 api 및 기능 구현,
`SchedulingConfig`, `UserRepository`, `UserCleanUpScheduler`는 자동 물리 삭제 스케줄러 구현,
`UserControllerTest`와 `UserServiceTest`는 hardDelete_success()부터 테스트 코드를 작성하였습니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 사용자 로그인 엔드포인트 추가
  * 물리적 삭제(hard delete) 옵션 추가
  * 24시간 경과한 논리 삭제 사용자 자동 정리(스케줄러) 및 스케줄링 활성화

* **개선**
  * 사용자 정보 수정 흐름 정리 및 API 문서 보강

* **버그 수정**
  * 요청 헤더 이름 표준화 및 일관성 개선

* **테스트**
  * 하드 삭제 및 정리 작업에 대한 테스트 커버리지 확장
<!-- end of auto-generated comment: release notes by coderabbit.ai -->