### PR TITLE
[refactor] CommentLike Service/Controller 분리

### DIFF
--- a/src/main/java/com/springboot/monew/comment/controller/CommentApiDocs.java
+++ b/src/main/java/com/springboot/monew/comment/controller/CommentApiDocs.java
@@ -3,4 +3,6 @@ package com.springboot.monew.comment.controller;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "댓글", description = "댓글 관련 API")
-public interface CommentApiDocs {}
+public interface CommentApiDocs {
+  // Todo : 문서화 시 작업 예정
+}

--- a/src/main/java/com/springboot/monew/comment/controller/CommentController.java
+++ b/src/main/java/com/springboot/monew/comment/controller/CommentController.java
@@ -31,27 +31,6 @@ public class CommentController implements CommentApiDocs {
     return ResponseEntity.created(URI.create("/api/comments/" + commentDto.id())).body(commentDto);
   }
 
-  // 관심사 댓글 좋아요 API
-  @PostMapping("/{commentId}/comment-likes")
-  public ResponseEntity<CommentLikeDto> like(
-      @PathVariable UUID commentId, @RequestHeader("Monew-Request-User-ID") UUID userId) {
-    CommentLikeDto commentLikeDto = commentService.like(commentId, userId);
-    return ResponseEntity.created(
-            URI.create(
-                "/api/comments/"
-                    + commentLikeDto.commentId()
-                    + "/comment-likes"
-                    + commentLikeDto.id()))
-        .body(commentLikeDto);
-  }
-
-  // 댓글 좋아요 취소 API
-  @DeleteMapping("/{commentId}/comment-likes")
-  public void unlike(
-      @PathVariable UUID commentId, @RequestHeader("Monew-Request-User-ID") UUID userId) {
-    commentService.unlike(commentId, userId);
-  }
-
   // 댓글 논리 삭제 API
   @DeleteMapping("/{commentId}")
   public ResponseEntity<Void> softDelete(@PathVariable UUID commentId) {

--- a/src/main/java/com/springboot/monew/comment/controller/CommentLikeApiDocs.java
+++ b/src/main/java/com/springboot/monew/comment/controller/CommentLikeApiDocs.java
@@ -1,0 +1,5 @@
+package com.springboot.monew.comment.controller;
+
+public interface CommentLikeApiDocs {
+// Todo : 문서화 시 작업 예정
+}

--- a/src/main/java/com/springboot/monew/comment/controller/CommentLikeController.java
+++ b/src/main/java/com/springboot/monew/comment/controller/CommentLikeController.java
@@ -30,7 +30,7 @@ public class CommentLikeController {
             URI.create(
                 "/api/comments/"
                     + commentLikeDto.commentId()
-                    + "/comment-likes"
+                    + "/comment-likes/"
                     + commentLikeDto.id()))
         .body(commentLikeDto);
   }

--- a/src/main/java/com/springboot/monew/comment/controller/CommentLikeController.java
+++ b/src/main/java/com/springboot/monew/comment/controller/CommentLikeController.java
@@ -1,0 +1,44 @@
+package com.springboot.monew.comment.controller;
+
+import com.springboot.monew.comment.dto.CommentLikeDto;
+import com.springboot.monew.comment.service.CommentLikeService;
+import java.net.URI;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/comments/{commentId}/comment-likes")
+public class CommentLikeController {
+  private final CommentLikeService commentLikeService;
+
+  // 관심사 댓글 좋아요 API
+  @PostMapping
+  public ResponseEntity<CommentLikeDto> like(
+      @PathVariable UUID commentId, @RequestHeader("Monew-Request-User-ID") UUID userId) {
+    CommentLikeDto commentLikeDto = commentLikeService.like(commentId, userId);
+    return ResponseEntity.created(
+            URI.create(
+                "/api/comments/"
+                    + commentLikeDto.commentId()
+                    + "/comment-likes"
+                    + commentLikeDto.id()))
+        .body(commentLikeDto);
+  }
+
+  // 댓글 좋아요 취소 API
+  @DeleteMapping
+  public void unlike(
+      @PathVariable UUID commentId, @RequestHeader("Monew-Request-User-ID") UUID userId) {
+    commentLikeService.unlike(commentId, userId);
+  }
+}

--- a/src/main/java/com/springboot/monew/comment/dto/CommentDto.java
+++ b/src/main/java/com/springboot/monew/comment/dto/CommentDto.java
@@ -10,6 +10,6 @@ public record CommentDto(
     UUID userId,
     String userNickname,
     String content,
-    Integer likeCount,
+    Long likeCount,
     Boolean likeByMe,
     Instant createdAt) {}

--- a/src/main/java/com/springboot/monew/comment/entity/Comment.java
+++ b/src/main/java/com/springboot/monew/comment/entity/Comment.java
@@ -28,7 +28,7 @@ public class Comment extends BaseUpdatableEntity {
 
   // 좋아요 수
   @Column(name = "like_count", nullable = false)
-  private int likeCount;
+  private long likeCount;
 
   // 삭제 여부 -> 논리 삭제
   @Column(name = "is_deleted", nullable = false)

--- a/src/main/java/com/springboot/monew/comment/repository/CommentRepository.java
+++ b/src/main/java/com/springboot/monew/comment/repository/CommentRepository.java
@@ -40,9 +40,9 @@ public interface CommentRepository extends JpaRepository<Comment, UUID> {
           AND (:cursor IS NULL OR
               CASE
                   WHEN :orderBy = 'likeCount' AND :direction = 'DESC' THEN
-                      (like_count < CAST(:cursor AS INTEGER) OR (like_count = CAST(:cursor AS INTEGER) AND created_at < :after))
+                      (like_count < CAST(:cursor AS BIGINT) OR (like_count = CAST(:cursor AS INTEGER) AND created_at < :after))
                   WHEN :orderBy = 'likeCount' AND :direction = 'ASC' THEN
-                      (like_count > CAST(:cursor AS INTEGER) OR (like_count = CAST(:cursor AS INTEGER) AND created_at > :after))
+                      (like_count > CAST(:cursor AS BIGINT) OR (like_count = CAST(:cursor AS INTEGER) AND created_at > :after))
                   WHEN :direction = 'DESC' THEN
                       created_at < :after
                   ELSE

--- a/src/main/java/com/springboot/monew/comment/repository/CommentRepository.java
+++ b/src/main/java/com/springboot/monew/comment/repository/CommentRepository.java
@@ -40,9 +40,9 @@ public interface CommentRepository extends JpaRepository<Comment, UUID> {
           AND (:cursor IS NULL OR
               CASE
                   WHEN :orderBy = 'likeCount' AND :direction = 'DESC' THEN
-                      (like_count < CAST(:cursor AS BIGINT) OR (like_count = CAST(:cursor AS INTEGER) AND created_at < :after))
+                      (like_count < CAST(:cursor AS BIGINT) OR (like_count = CAST(:cursor AS BIGINT) AND created_at < :after))
                   WHEN :orderBy = 'likeCount' AND :direction = 'ASC' THEN
-                      (like_count > CAST(:cursor AS BIGINT) OR (like_count = CAST(:cursor AS INTEGER) AND created_at > :after))
+                      (like_count > CAST(:cursor AS BIGINT) OR (like_count = CAST(:cursor AS BIGINT) AND created_at > :after))
                   WHEN :direction = 'DESC' THEN
                       created_at < :after
                   ELSE

--- a/src/main/java/com/springboot/monew/comment/service/CommentLikeService.java
+++ b/src/main/java/com/springboot/monew/comment/service/CommentLikeService.java
@@ -1,0 +1,100 @@
+package com.springboot.monew.comment.service;
+
+import com.springboot.monew.comment.dto.CommentLikeDto;
+import com.springboot.monew.comment.entity.Comment;
+import com.springboot.monew.comment.entity.CommentLike;
+import com.springboot.monew.comment.exception.CommentErrorCode;
+import com.springboot.monew.comment.exception.CommentException;
+import com.springboot.monew.comment.mapper.CommentLikeMapper;
+import com.springboot.monew.comment.repository.CommentLikeRepository;
+import com.springboot.monew.comment.repository.CommentRepository;
+import com.springboot.monew.users.entity.User;
+import com.springboot.monew.users.exception.UserErrorCode;
+import com.springboot.monew.users.exception.UserException;
+import com.springboot.monew.users.repository.UserRepository;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CommentLikeService {
+  private final CommentLikeRepository commentLikeRepository;
+  private final CommentRepository commentRepository;
+  private final CommentLikeMapper commentLikeMapper;
+  private final UserRepository userRepository;
+
+  // 좋아요
+  @Transactional
+  public CommentLikeDto like(UUID commentId, UUID userId) {
+    Comment comment = getActiveComment(commentId);
+    User user = getActiveUser(userId);
+
+    // 중복 좋아요 check
+    if (commentLikeRepository.existsByCommentIdAndUserId(commentId, userId)) {
+      throw new CommentException(
+          CommentErrorCode.COMMENT_LIKE_ALREADY_EXISTS,
+          Map.of("commentId", commentId, "userId", userId));
+    }
+
+    // Todo: 알림 객체 생성
+
+    CommentLike commentLike = new CommentLike(comment, user);
+    commentLikeRepository.save(commentLike);
+    log.debug("likeCount 증가 전 - commentId: {}, likeCount: {}", commentId, comment.getLikeCount());
+    commentRepository.incrementLikeCount(comment.getId());
+    log.debug("likeCount 증가 후 - commentId: {}, likeCount: {}", commentId, comment.getLikeCount());
+    log.info("좋아요 등록 완료 - commentId: {}, userId: {}", commentId, userId);
+
+    return commentLikeMapper.toCommentLikeDto(commentLike);
+  }
+
+  // 댓글 좋아요 취소
+  @Transactional
+  public void unlike(UUID commentId, UUID userId) {
+    Comment comment = getActiveComment(commentId);
+    User user = getActiveUser(userId);
+
+    // 좋아요 존재 확인
+    CommentLike commentLike =
+        commentLikeRepository
+            .findCommentLikeByCommentAndUser(comment, user)
+            .orElseThrow(
+                () ->
+                    new CommentException(
+                        CommentErrorCode.COMMENT_LIKE_NOT_FOUND, Map.of("commentId", commentId)));
+
+    // 좋아요 삭제(하드 딜릿) -> 좋아요 취소 시 이력에서 바로 삭제되므로 하드딜릿이 맞다고 판단
+    commentLikeRepository.delete(commentLike);
+    commentRepository.decrementLikeCount(comment.getId());
+    log.info("좋아요 취소 완료 - commentId: {}, userId: {}", commentId, userId);
+  }
+
+  // 활성 댓글만 조회 (논리삭제된 것 제외)
+  private Comment getActiveComment(UUID commentId) {
+    return commentRepository
+        .findByIdAndIsDeletedFalse(commentId)
+        .orElseThrow(
+            () ->
+                new CommentException(
+                    CommentErrorCode.COMMENT_NOT_FOUND, Map.of("commentId", commentId)));
+  }
+
+  // 활성 유저 조회 (존재 + 논리삭제 체크)
+  private User getActiveUser(UUID userId) {
+    User user =
+        userRepository
+            .findById(userId)
+            .orElseThrow(
+                () -> new UserException(UserErrorCode.USER_NOT_FOUND, Map.of("userId", userId)));
+    if (user.isDeleted()) {
+      throw new UserException(UserErrorCode.USER_NOT_FOUND, Map.of("userId", userId));
+    }
+    return user;
+  }
+
+}

--- a/src/main/java/com/springboot/monew/comment/service/CommentService.java
+++ b/src/main/java/com/springboot/monew/comment/service/CommentService.java
@@ -2,10 +2,8 @@ package com.springboot.monew.comment.service;
 
 import com.springboot.monew.comment.dto.*;
 import com.springboot.monew.comment.entity.Comment;
-import com.springboot.monew.comment.entity.CommentLike;
 import com.springboot.monew.comment.exception.CommentErrorCode;
 import com.springboot.monew.comment.exception.CommentException;
-import com.springboot.monew.comment.mapper.CommentLikeMapper;
 import com.springboot.monew.comment.mapper.CommentMapper;
 import com.springboot.monew.comment.repository.CommentLikeRepository;
 import com.springboot.monew.comment.repository.CommentRepository;
@@ -31,7 +29,6 @@ public class CommentService {
   // private final ArticleRepository articleRepository;
   private final UserRepository userRepository;
   private final CommentMapper commentMapper;
-  private final CommentLikeMapper commentLikeMapper;
 
   // 댓글 등록
   @Transactional
@@ -81,31 +78,6 @@ public class CommentService {
     return commentMapper.toCommentDto(comment, likeByMe);
   }
 
-  // 댓글 좋아요
-  @Transactional
-  public CommentLikeDto like(UUID commentId, UUID userId) {
-    Comment comment = getActiveComment(commentId);
-    User user = getActiveUser(userId);
-
-    // 중복 좋아요 check
-    if (commentLikeRepository.existsByCommentIdAndUserId(commentId, userId)) {
-      throw new CommentException(
-          CommentErrorCode.COMMENT_LIKE_ALREADY_EXISTS,
-          Map.of("commentId", commentId, "userId", userId));
-    }
-
-    // Todo: 알림 객체 생성
-
-    CommentLike commentLike = new CommentLike(comment, user);
-    commentLikeRepository.save(commentLike);
-    log.debug("likeCount 증가 전 - commentId: {}, likeCount: {}", commentId, comment.getLikeCount());
-    commentRepository.incrementLikeCount(comment.getId());
-    log.debug("likeCount 증가 후 - commentId: {}, likeCount: {}", commentId, comment.getLikeCount());
-    log.info("좋아요 등록 완료 - commentId: {}, userId: {}", commentId, userId);
-
-    return commentLikeMapper.toCommentLikeDto(commentLike);
-  }
-
   // 댓글 논리 삭제
   @Transactional
   public void softDelete(UUID commentId) {
@@ -125,27 +97,6 @@ public class CommentService {
     Comment comment = getComment(commentId);
     commentRepository.delete(comment);
     log.info("댓글 물리 삭제 완료 - commentId: {}", commentId);
-  }
-
-  // 댓글 좋아요 취소
-  @Transactional
-  public void unlike(UUID commentId, UUID userId) {
-    Comment comment = getActiveComment(commentId);
-    User user = getActiveUser(userId);
-
-    // 좋아요 존재 확인
-    CommentLike commentLike =
-        commentLikeRepository
-            .findCommentLikeByCommentAndUser(comment, user)
-            .orElseThrow(
-                () ->
-                    new CommentException(
-                        CommentErrorCode.COMMENT_LIKE_NOT_FOUND, Map.of("commentId", commentId)));
-
-    // 좋아요 삭제(하드 딜릿) -> 좋아요 취소 시 이력에서 바로 삭제되므로 하드딜릿이 맞다고 판단
-    commentLikeRepository.delete(commentLike);
-    commentRepository.decrementLikeCount(comment.getId());
-    log.info("좋아요 취소 완료 - commentId: {}, userId: {}", commentId, userId);
   }
 
   // Todo: 기사의 전체 댓글 조회 -> Article 구현 끝나면 다시 체크 (고려해야할 것이 너무 많음)

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -59,7 +59,7 @@ CREATE TABLE comments
     "user_id"    UUID                  NOT NULL,
     "article_id" UUID                  NOT NULL,
     "content"    VARCHAR(200)          NOT NULL,
-    "like_count" INTEGER DEFAULT 0     NOT NULL,
+    "like_count" BIGINT DEFAULT 0     NOT NULL,
     "is_deleted" BOOLEAN DEFAULT false NOT NULL,
     "created_at" TIMESTAMPTZ           NOT NULL,
     "updated_at" TIMESTAMPTZ           NULL

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -59,7 +59,7 @@ CREATE TABLE comments
     user_id    UUID                     NOT NULL,
     article_id UUID                     NOT NULL,
     content    VARCHAR(200)             NOT NULL,
-    like_count INTEGER DEFAULT 0        NOT NULL,
+    like_count BIGINT DEFAULT 0        NOT NULL,
     is_deleted BOOLEAN DEFAULT false    NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL,
     updated_at TIMESTAMP WITH TIME ZONE NULL


### PR DESCRIPTION
## 관련 이슈 번호
Closes #212 

## 📌 작업 내용
  - `CommentLikeService`, `CommentLikeController` 분리로 댓글 좋아요 책임 분리
  - `likeCount` 타입을 `Integer` → `Long`으로 변경
  
## 🔧 변경 사항
  - `CommentLikeService` 생성 — `like()`, `unlike()` 이동
  - `CommentLikeController` 생성 — `POST/DELETE /api/comments/{id}/comment-likes` 이동
  - `CommentLikeApiDocs` 생성 (문서 작업 시에 구현할 계획)
  - `CommentService` — `like()`, `unlike()` 제거, 불필요한 import 정리
  - `CommentController` — `like()`, `unlike()` 제거
  - `CommentDto` — `Integer likeCount` → `Long likeCount`
  - `schema.sql` (main, test) — `like_count INTEGER` → `like_count BIGINT`
  - `CommentRepository` — `CAST(:cursor AS INTEGER)` → `CAST(:cursor AS BIGINT)`

  ## 반영 브랜치
  `feature/refactor-like-count-type` -> `dev`

  ## 💬 기타 참고 사항
  - 로직 수정은 없고, 책임 분리를 고려해서 구조 변경만 했습니다 이 점 참고해주시면 될 것 같습니다 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 댓글 좋아요 전용 REST API(좋아요/취소) 추가

* **리팩토링**
  * 좋아요 기능을 별도 서비스·컨트롤러로 분리해 API 책임 분리
  * 기존 댓글 서비스/컨트롤러에서 좋아요 관련 엔드포인트 제거

* **데이터베이스 / 타입 변경**
  * 댓글 좋아요 수 필드 및 스키마를 더 큰 정수 타입으로 변경

* **문서**
  * API 문서화용 주석/플레이스홀더 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->