### PR TITLE
[feat] 알림 서비스 구현 및 유닛 테스트 작성

### DIFF
--- a/src/main/java/com/springboot/monew/common/dto/CursorPageResponse.java
+++ b/src/main/java/com/springboot/monew/common/dto/CursorPageResponse.java
@@ -1,0 +1,17 @@
+package com.springboot.monew.common.dto;
+
+import java.io.Serializable;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record CursorPageResponse<T>(
+    List<T> content,
+    String nextCursor,
+    String nextAfter,
+    int size,
+    long totalElements,
+    boolean hasNext)
+    implements Serializable {
+
+}

--- a/src/main/java/com/springboot/monew/common/mapper/BaseMapper.java
+++ b/src/main/java/com/springboot/monew/common/mapper/BaseMapper.java
@@ -1,10 +1,13 @@
 package com.springboot.monew.common.mapper;
 
 import java.util.List;
+import org.mapstruct.IterableMapping;
+import org.mapstruct.NullValueMappingStrategy;
 
 public interface BaseMapper<T, R> {
 
   R toDto(T entity);
 
+  @IterableMapping(nullValueMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT)
   List<R> toDto(List<T> entities);
 }

--- a/src/main/java/com/springboot/monew/common/utils/TimeConverter.java
+++ b/src/main/java/com/springboot/monew/common/utils/TimeConverter.java
@@ -1,0 +1,15 @@
+package com.springboot.monew.common.utils;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class TimeConverter {
+
+  public static LocalDateTime toDatetime(Instant time) {
+    return LocalDateTime.ofInstant(time, ZoneId.systemDefault());
+  }
+}

--- a/src/main/java/com/springboot/monew/interest/entity/Interest.java
+++ b/src/main/java/com/springboot/monew/interest/entity/Interest.java
@@ -4,10 +4,12 @@ import com.springboot.monew.common.entity.BaseUpdatableEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Table(
@@ -28,6 +30,10 @@ public class Interest extends BaseUpdatableEntity {
 
   @Column(name = "subscriber_count", nullable = false)
   private long subscriberCount;
+
+  @Setter
+  @Transient
+  private long articleCount;
 
   public Interest(String name) {
     this.name = name;

--- a/src/main/java/com/springboot/monew/interest/repository/InterestRepository.java
+++ b/src/main/java/com/springboot/monew/interest/repository/InterestRepository.java
@@ -1,12 +1,13 @@
 package com.springboot.monew.interest.repository;
 
 import com.springboot.monew.interest.entity.Interest;
+import com.springboot.monew.interest.repository.qdsl.InterestQDSLRepository;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-public interface InterestRepository extends JpaRepository<Interest, UUID> {
+public interface InterestRepository extends JpaRepository<Interest, UUID>, InterestQDSLRepository {
 
   boolean existsByName(String name);
 

--- a/src/main/java/com/springboot/monew/interest/repository/qdsl/InterestQDSLRepository.java
+++ b/src/main/java/com/springboot/monew/interest/repository/qdsl/InterestQDSLRepository.java
@@ -1,0 +1,10 @@
+package com.springboot.monew.interest.repository.qdsl;
+
+import com.springboot.monew.interest.entity.Interest;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface InterestQDSLRepository {
+
+  Optional<Interest> findByIdWithArticleCount(UUID id);
+}

--- a/src/main/java/com/springboot/monew/interest/repository/qdsl/InterestQDSLRepositoryImpl.java
+++ b/src/main/java/com/springboot/monew/interest/repository/qdsl/InterestQDSLRepositoryImpl.java
@@ -1,0 +1,38 @@
+package com.springboot.monew.interest.repository.qdsl;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.springboot.monew.interest.entity.Interest;
+import com.springboot.monew.interest.entity.QInterest;
+import com.springboot.monew.newsarticles.entity.QArticleInterest;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class InterestQDSLRepositoryImpl implements InterestQDSLRepository {
+  private final JPAQueryFactory queryFactory;
+  private final QInterest qInterest = QInterest.interest;
+  private final QArticleInterest qArticleInterest = QArticleInterest.articleInterest;
+
+  @Override
+  public Optional<Interest> findByIdWithArticleCount(UUID id) {
+    Tuple result = queryFactory.select(qInterest, qArticleInterest.count())
+        .from(qInterest)
+        .leftJoin(qInterest, qArticleInterest.interest)
+        .where(qInterest.id.eq(id))
+        .groupBy(qInterest)
+        .fetchOne();
+
+    if (result == null) {
+      return Optional.empty();
+    }
+    Interest interest = Objects.requireNonNull(result.get(qInterest));
+    Long articleCount = Objects.requireNonNull(result.get(qArticleInterest.count()));
+    interest.setArticleCount(articleCount);
+    return Optional.of(interest);
+  }
+}

--- a/src/main/java/com/springboot/monew/notification/dto/NotificationDto.java
+++ b/src/main/java/com/springboot/monew/notification/dto/NotificationDto.java
@@ -11,9 +11,15 @@ import lombok.Builder;
  * DTO for {@link Notification}
  */
 @Builder
-public record NotificationDto(UUID id, Instant createdAt, Instant updatedAt, Boolean confirmed,
-                              String content,
-                              ResourceType resourceType, UUID userId, UUID resourceId) implements
-    Serializable {
+public record NotificationDto(
+    UUID id,
+    Instant createdAt,
+    Instant updatedAt,
+    Boolean confirmed,
+    String content,
+    ResourceType resourceType,
+    UUID userId,
+    UUID resourceId)
+    implements Serializable {
 
 }

--- a/src/main/java/com/springboot/monew/notification/dto/NotificationFindRequest.java
+++ b/src/main/java/com/springboot/monew/notification/dto/NotificationFindRequest.java
@@ -1,5 +1,33 @@
 package com.springboot.monew.notification.dto;
 
-public class NotificationFindRequest {
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Getter;
+import org.springframework.format.annotation.DateTimeFormat;
 
+@Getter
+public final class NotificationFindRequest {
+
+  private final UUID cursor;
+  @DateTimeFormat
+  private final LocalDateTime after;
+  @Min(1)
+  @NotNull
+  private final int limit;
+  @NotNull
+  private final UUID userId;
+
+  public NotificationFindRequest(
+      @JsonProperty("cursor") UUID cursor,
+      @JsonProperty("after") LocalDateTime after,
+      @JsonProperty("limit") int limit,
+      @JsonProperty("Monew-Request-User-ID") UUID userId) {
+    this.cursor = cursor;
+    this.after = after;
+    this.limit = limit;
+    this.userId = userId;
+  }
 }

--- a/src/main/java/com/springboot/monew/notification/dto/NotificationFindRequest.java
+++ b/src/main/java/com/springboot/monew/notification/dto/NotificationFindRequest.java
@@ -3,6 +3,7 @@ package com.springboot.monew.notification.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.Getter;
@@ -12,8 +13,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 public final class NotificationFindRequest {
 
   private final UUID cursor;
-  @DateTimeFormat
-  private final LocalDateTime after;
+  private final Instant after;
   @Min(1)
   @NotNull
   private final int limit;
@@ -22,7 +22,7 @@ public final class NotificationFindRequest {
 
   public NotificationFindRequest(
       @JsonProperty("cursor") UUID cursor,
-      @JsonProperty("after") LocalDateTime after,
+      @JsonProperty("after") Instant after,
       @JsonProperty("limit") int limit,
       @JsonProperty("Monew-Request-User-ID") UUID userId) {
     this.cursor = cursor;

--- a/src/main/java/com/springboot/monew/notification/dto/NotificationFindRequest.java
+++ b/src/main/java/com/springboot/monew/notification/dto/NotificationFindRequest.java
@@ -1,0 +1,5 @@
+package com.springboot.monew.notification.dto;
+
+public class NotificationFindRequest {
+
+}

--- a/src/main/java/com/springboot/monew/notification/entity/Notification.java
+++ b/src/main/java/com/springboot/monew/notification/entity/Notification.java
@@ -58,24 +58,24 @@ public class Notification extends BaseEntity {
   private CommentLike commentLike;
 
   @Builder
-  public Notification(String content,
-      ResourceType resourceType,
+  public Notification(ResourceType resourceType,
       User user,
       Interest interest,
       CommentLike commentLike) {
-    this.content = content;
     this.resourceType = resourceType;
     this.user = user;
     this.interest = interest;
     this.commentLike = commentLike;
+    validateDomainConstraint();
+    initContent();
   }
 
   @Transient
   public UUID getResourceId() {
-    if (resourceType == ResourceType.COMMENT && commentLike != null) {
+    if (isCommentLikeNotification()) {
       return commentLike.getId();
     }
-    if (resourceType == ResourceType.INTEREST && interest != null) {
+    if (isInterestNotification()) {
       return interest.getId();
     }
     Map<String, Object> details = new HashMap<>();
@@ -101,5 +101,37 @@ public class Notification extends BaseEntity {
     }
     confirmed = true;
     this.updatedAt = updatedAt;
+  }
+
+  private void initContent() {
+    String commentLikeMessage = "%s님이 나의 댓글을 좋아합니다.";
+    String interestMessage = "%s와 관련된 기사가 %s건 등록되었습니다.";
+    if (isInterestNotification()) {
+      content = interestMessage.formatted(interest.getName(), interest.getArticleCount());
+      return;
+    }
+    content = commentLikeMessage.formatted(commentLike.getUser().getNickname());
+  }
+
+  private void validateDomainConstraint() {
+    if (user == null) {
+      throw new NotificationException(NotificationErrorCode.MISSING_REQUIRED_FIELD,
+          "User를 찾을 수 없습니다");
+    }
+    if (isInterestNotification()) {
+      return;
+    }
+    if (isCommentLikeNotification()) {
+      return;
+    }
+    throw new NotificationException(NotificationErrorCode.DOMAIN_CONSTRAINT_VIOLATED);
+  }
+
+  private boolean isInterestNotification() {
+    return resourceType == ResourceType.INTEREST && interest != null && commentLike == null;
+  }
+
+  private boolean isCommentLikeNotification() {
+    return resourceType == ResourceType.COMMENT && commentLike != null && interest == null;
   }
 }

--- a/src/main/java/com/springboot/monew/notification/event/CommentLikeNotificationEvent.java
+++ b/src/main/java/com/springboot/monew/notification/event/CommentLikeNotificationEvent.java
@@ -1,0 +1,16 @@
+package com.springboot.monew.notification.event;
+
+import com.springboot.monew.comment.entity.CommentLike;
+import com.springboot.monew.notification.entity.ResourceType;
+import com.springboot.monew.users.entity.User;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public final class CommentLikeNotificationEvent {
+
+  private final ResourceType resourceType = ResourceType.COMMENT;
+  private final User user;
+  private final CommentLike commentLike;
+}

--- a/src/main/java/com/springboot/monew/notification/event/InterestNotificationEvent.java
+++ b/src/main/java/com/springboot/monew/notification/event/InterestNotificationEvent.java
@@ -1,0 +1,16 @@
+package com.springboot.monew.notification.event;
+
+import com.springboot.monew.interest.entity.Interest;
+import com.springboot.monew.notification.entity.ResourceType;
+import com.springboot.monew.users.entity.User;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public final class InterestNotificationEvent {
+
+  private final ResourceType resourceType = ResourceType.INTEREST;
+  private final User user;
+  private final Interest interest;
+}

--- a/src/main/java/com/springboot/monew/notification/exception/NotificationErrorCode.java
+++ b/src/main/java/com/springboot/monew/notification/exception/NotificationErrorCode.java
@@ -8,9 +8,14 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum NotificationErrorCode implements ErrorCode {
-  INVALID_DATA(HttpStatus.INTERNAL_SERVER_ERROR, "N001", "유효한 데이터가 아닙니다"),
-  ALREADY_CONFIRMED(HttpStatus.BAD_REQUEST, "N002", "이미 확인한 알람입니다"),
-  ;
+
+  // 5xx
+  INVALID_DATA(HttpStatus.INTERNAL_SERVER_ERROR, "N001", "DB에 저장된 알림 데이터가 손상되었거나 유효하지 않습니다."),
+  DOMAIN_CONSTRAINT_VIOLATED(HttpStatus.INTERNAL_SERVER_ERROR, "N002", "알림 타입(ResourceType)과 연결된 객체가 일치하지 않습니다."),
+  MISSING_REQUIRED_FIELD(HttpStatus.INTERNAL_SERVER_ERROR, "N003", "알림 생성에 필요한 필수 객체가 누락되었습니다."), // USER_NOT_FOUND 대신 명확하게 표현
+
+  // 4xx
+  ALREADY_CONFIRMED(HttpStatus.BAD_REQUEST, "N004", "이미 읽음 처리된 알림입니다.");
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/src/main/java/com/springboot/monew/notification/exception/NotificationErrorCode.java
+++ b/src/main/java/com/springboot/monew/notification/exception/NotificationErrorCode.java
@@ -10,12 +10,12 @@ import org.springframework.http.HttpStatus;
 public enum NotificationErrorCode implements ErrorCode {
 
   // 5xx
-  INVALID_DATA(HttpStatus.INTERNAL_SERVER_ERROR, "N001", "DB에 저장된 알림 데이터가 손상되었거나 유효하지 않습니다."),
-  DOMAIN_CONSTRAINT_VIOLATED(HttpStatus.INTERNAL_SERVER_ERROR, "N002", "알림 타입(ResourceType)과 연결된 객체가 일치하지 않습니다."),
-  MISSING_REQUIRED_FIELD(HttpStatus.INTERNAL_SERVER_ERROR, "N003", "알림 생성에 필요한 필수 객체가 누락되었습니다."), // USER_NOT_FOUND 대신 명확하게 표현
+  INVALID_DATA(HttpStatus.INTERNAL_SERVER_ERROR, "NT01", "DB에 저장된 알림 데이터가 손상되었거나 유효하지 않습니다."),
+  DOMAIN_CONSTRAINT_VIOLATED(HttpStatus.INTERNAL_SERVER_ERROR, "NT02", "알림 타입(ResourceType)과 연결된 객체가 일치하지 않습니다."),
+  MISSING_REQUIRED_FIELD(HttpStatus.INTERNAL_SERVER_ERROR, "NT03", "알림 생성에 필요한 필수 객체가 누락되었습니다."),
 
   // 4xx
-  ALREADY_CONFIRMED(HttpStatus.BAD_REQUEST, "N004", "이미 읽음 처리된 알림입니다.");
+  ALREADY_CONFIRMED(HttpStatus.BAD_REQUEST, "NT04", "이미 읽음 처리된 알림입니다.");
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/src/main/java/com/springboot/monew/notification/exception/NotificationErrorCode.java
+++ b/src/main/java/com/springboot/monew/notification/exception/NotificationErrorCode.java
@@ -13,6 +13,7 @@ public enum NotificationErrorCode implements ErrorCode {
   INVALID_DATA(HttpStatus.INTERNAL_SERVER_ERROR, "NT01", "DB에 저장된 알림 데이터가 손상되었거나 유효하지 않습니다."),
   DOMAIN_CONSTRAINT_VIOLATED(HttpStatus.INTERNAL_SERVER_ERROR, "NT02", "알림 타입(ResourceType)과 연결된 객체가 일치하지 않습니다."),
   MISSING_REQUIRED_FIELD(HttpStatus.INTERNAL_SERVER_ERROR, "NT03", "알림 생성에 필요한 필수 객체가 누락되었습니다."),
+  NOTIFICATION_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "NT05", "알림을 찾을 수 없습니다."),
 
   // 4xx
   ALREADY_CONFIRMED(HttpStatus.BAD_REQUEST, "NT04", "이미 읽음 처리된 알림입니다.");

--- a/src/main/java/com/springboot/monew/notification/exception/NotificationException.java
+++ b/src/main/java/com/springboot/monew/notification/exception/NotificationException.java
@@ -14,4 +14,12 @@ public class NotificationException extends MonewException {
   public NotificationException(ErrorCode errorCode, UUID id) {
     this(errorCode, Map.of("id", id));
   }
+
+  public NotificationException(ErrorCode errorCode) {
+    this(errorCode, Map.of());
+  }
+
+  public NotificationException(ErrorCode errorCode, String detailMessage) {
+    this(errorCode, Map.of("detailMessage", detailMessage));
+  }
 }

--- a/src/main/java/com/springboot/monew/notification/mapper/NotificationMapper.java
+++ b/src/main/java/com/springboot/monew/notification/mapper/NotificationMapper.java
@@ -4,6 +4,8 @@ import com.springboot.monew.common.mapper.BaseMapper;
 import com.springboot.monew.common.mapper.CommonMapperConfig;
 import com.springboot.monew.notification.dto.NotificationDto;
 import com.springboot.monew.notification.entity.Notification;
+import com.springboot.monew.notification.event.CommentLikeNotificationEvent;
+import com.springboot.monew.notification.event.InterestNotificationEvent;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
@@ -13,4 +15,8 @@ public interface NotificationMapper extends BaseMapper<Notification, Notificatio
   @Override
   @Mapping(target = "userId", source = "user.id")
   NotificationDto toDto(Notification entity);
+
+  Notification toEntityFrom(InterestNotificationEvent event);
+
+  Notification toEntityFrom(CommentLikeNotificationEvent event);
 }

--- a/src/main/java/com/springboot/monew/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/springboot/monew/notification/repository/NotificationRepository.java
@@ -3,7 +3,6 @@ package com.springboot.monew.notification.repository;
 import com.springboot.monew.notification.entity.Notification;
 import java.time.Instant;
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -39,8 +38,8 @@ public interface NotificationRepository extends JpaRepository<Notification, UUID
   @Modifying(clearAutomatically = true)
   @Query("update Notification n "
       + "set n.confirmed = true, n.updatedAt = :updatedAt "
-      + "where n.id in :ids and n.user.id = :userId")
-  int updateConfirmed(List<UUID> ids, UUID userId, Instant updatedAt);
+      + "where n.user.id = :userId")
+  int updateConfirmed(UUID userId, Instant updatedAt);
 
   long countAllByUser_IdAndConfirmedIsFalse(UUID userId);
 }

--- a/src/main/java/com/springboot/monew/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/springboot/monew/notification/repository/NotificationRepository.java
@@ -2,7 +2,6 @@ package com.springboot.monew.notification.repository;
 
 import com.springboot.monew.notification.entity.Notification;
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -25,7 +24,7 @@ public interface NotificationRepository extends JpaRepository<Notification, UUID
       "ORDER BY n.createdAt DESC, n.id ASC")
   Slice<Notification> findByCursor(
       @Param("cursor") UUID cursor,
-      @Param("after") LocalDateTime after,
+      @Param("after") Instant after,
       @Param("userId") UUID userId,
       Pageable pageable);
 

--- a/src/main/java/com/springboot/monew/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/springboot/monew/notification/repository/NotificationRepository.java
@@ -2,6 +2,7 @@ package com.springboot.monew.notification.repository;
 
 import com.springboot.monew.notification.entity.Notification;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
@@ -25,7 +26,7 @@ public interface NotificationRepository extends JpaRepository<Notification, UUID
       "ORDER BY n.createdAt DESC, n.id ASC")
   Slice<Notification> findByCursor(
       @Param("cursor") UUID cursor,
-      @Param("after") Instant after,
+      @Param("after") LocalDateTime after,
       @Param("userId") UUID userId,
       Pageable pageable);
 
@@ -40,4 +41,6 @@ public interface NotificationRepository extends JpaRepository<Notification, UUID
       + "set n.confirmed = true, n.updatedAt = :updatedAt "
       + "where n.id in :ids and n.user.id = :userId")
   int updateConfirmed(List<UUID> ids, UUID userId, Instant updatedAt);
+
+  long countAllByUser_IdAndConfirmedIsFalse(UUID userId);
 }

--- a/src/main/java/com/springboot/monew/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/springboot/monew/notification/repository/NotificationRepository.java
@@ -2,6 +2,7 @@ package com.springboot.monew.notification.repository;
 
 import com.springboot.monew.notification.entity.Notification;
 import java.time.Instant;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -31,14 +32,8 @@ public interface NotificationRepository extends JpaRepository<Notification, UUID
   @Modifying(clearAutomatically = true)
   @Query("update Notification n "
       + "set n.confirmed = true, n.updatedAt = :updatedAt "
-      + "where n.id = :id and n.user.id = :userId")
-  int updateConfirmed(UUID id, UUID userId, Instant updatedAt);
-
-  @Modifying(clearAutomatically = true)
-  @Query("update Notification n "
-      + "set n.confirmed = true, n.updatedAt = :updatedAt "
-      + "where n.user.id = :userId")
-  int updateConfirmed(UUID userId, Instant updatedAt);
+      + "where n.user.id = :userId and n.confirmed = false")
+  int bulkUpdateConfirmed(UUID userId, Instant updatedAt);
 
   long countAllByUser_IdAndConfirmedIsFalse(UUID userId);
 }

--- a/src/main/java/com/springboot/monew/notification/service/NotificationService.java
+++ b/src/main/java/com/springboot/monew/notification/service/NotificationService.java
@@ -1,0 +1,33 @@
+package com.springboot.monew.notification.service;
+
+import com.springboot.monew.comment.entity.CommentLike;
+import com.springboot.monew.interest.entity.Interest;
+import com.springboot.monew.notification.dto.NotificationDto;
+import com.springboot.monew.notification.dto.NotificationFindRequest;
+import com.springboot.monew.notification.entity.Notification;
+import com.springboot.monew.notification.entity.ResourceType;
+import com.springboot.monew.notification.mapper.NotificationMapper;
+import com.springboot.monew.notification.repository.NotificationRepository;
+import com.springboot.monew.users.entity.User;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+@Transactional
+public class NotificationService {
+  private final NotificationRepository notificationRepository;
+  private final NotificationMapper notificationMapper;
+
+  public Notification create(String content, ResourceType resourceType, User user,
+      Interest interest, CommentLike commentLike) {
+    return null;
+  }
+
+  public List<NotificationDto> find(NotificationFindRequest request, UUID userId) {
+    return null;
+  }
+}

--- a/src/main/java/com/springboot/monew/notification/service/NotificationService.java
+++ b/src/main/java/com/springboot/monew/notification/service/NotificationService.java
@@ -1,17 +1,21 @@
 package com.springboot.monew.notification.service;
 
-import com.springboot.monew.comment.entity.CommentLike;
-import com.springboot.monew.interest.entity.Interest;
+import com.springboot.monew.common.dto.CursorPageResponse;
+import com.springboot.monew.common.utils.TimeConverter;
 import com.springboot.monew.notification.dto.NotificationDto;
 import com.springboot.monew.notification.dto.NotificationFindRequest;
 import com.springboot.monew.notification.entity.Notification;
-import com.springboot.monew.notification.entity.ResourceType;
+import com.springboot.monew.notification.event.CommentLikeNotificationEvent;
+import com.springboot.monew.notification.event.InterestNotificationEvent;
 import com.springboot.monew.notification.mapper.NotificationMapper;
 import com.springboot.monew.notification.repository.NotificationRepository;
-import com.springboot.monew.users.entity.User;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,15 +23,54 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional
 public class NotificationService {
+
   private final NotificationRepository notificationRepository;
   private final NotificationMapper notificationMapper;
 
-  public Notification create(String content, ResourceType resourceType, User user,
-      Interest interest, CommentLike commentLike) {
-    return null;
+  public NotificationDto create(InterestNotificationEvent event) {
+    Notification notification = notificationMapper.toEntityFrom(event);
+    notificationRepository.save(notification);
+    return notificationMapper.toDto(notification);
   }
 
-  public List<NotificationDto> find(NotificationFindRequest request, UUID userId) {
-    return null;
+  public NotificationDto create(CommentLikeNotificationEvent event) {
+    Notification notification = notificationMapper.toEntityFrom(event);
+    notificationRepository.save(notification);
+    return notificationMapper.toDto(notification);
+  }
+
+  @Transactional(readOnly = true)
+  public CursorPageResponse<NotificationDto> find(NotificationFindRequest request, UUID userId) {
+    Pageable pageable = PageRequest.of(0, request.getLimit());
+    Slice<Notification> results = notificationRepository.findByCursor(request.getCursor(),
+        request.getAfter(), userId, pageable);
+    return toCursorPage(results);
+  }
+
+  private CursorPageResponse<NotificationDto> toCursorPage(Slice<Notification> results) {
+    boolean hasNext = results.hasNext();
+    List<Notification> entities = List.of();
+    String nextCursor = null;
+    String nextAfter = null;
+    int size = 0;
+    long totalElements = 0;
+    if (hasNext) {
+      entities = results.getContent();
+      size = entities.size();
+      Notification lastNotification = entities.get(size - 1);
+      nextCursor = lastNotification.getId().toString();
+      Instant createdAt = lastNotification.getCreatedAt();
+      nextAfter = TimeConverter.toDatetime(createdAt).toString();
+      totalElements = notificationRepository.countAllByUser_IdAndConfirmedIsFalse(
+          lastNotification.getUser().getId());
+    }
+    return new CursorPageResponse<>(
+        notificationMapper.toDto(entities),
+        nextCursor,
+        nextAfter,
+        size,
+        totalElements,
+        hasNext
+    );
   }
 }

--- a/src/main/java/com/springboot/monew/notification/service/NotificationService.java
+++ b/src/main/java/com/springboot/monew/notification/service/NotificationService.java
@@ -47,6 +47,14 @@ public class NotificationService {
     return toCursorPage(results);
   }
 
+  public void update(UUID id, UUID userId) {
+    notificationRepository.updateConfirmed(id, userId, Instant.now());
+  }
+
+  public void update(UUID userId) {
+    notificationRepository.updateConfirmed(userId, Instant.now());
+  }
+
   private CursorPageResponse<NotificationDto> toCursorPage(Slice<Notification> results) {
     boolean hasNext = results.hasNext();
     List<Notification> entities = List.of();

--- a/src/main/java/com/springboot/monew/notification/service/NotificationService.java
+++ b/src/main/java/com/springboot/monew/notification/service/NotificationService.java
@@ -7,6 +7,8 @@ import com.springboot.monew.notification.dto.NotificationFindRequest;
 import com.springboot.monew.notification.entity.Notification;
 import com.springboot.monew.notification.event.CommentLikeNotificationEvent;
 import com.springboot.monew.notification.event.InterestNotificationEvent;
+import com.springboot.monew.notification.exception.NotificationErrorCode;
+import com.springboot.monew.notification.exception.NotificationException;
 import com.springboot.monew.notification.mapper.NotificationMapper;
 import com.springboot.monew.notification.repository.NotificationRepository;
 import java.time.Instant;
@@ -44,33 +46,32 @@ public class NotificationService {
     Pageable pageable = PageRequest.of(0, request.getLimit());
     Slice<Notification> results = notificationRepository.findByCursor(request.getCursor(),
         request.getAfter(), userId, pageable);
-    return toCursorPage(results);
+    return toCursorPage(results, userId);
   }
 
   public void update(UUID id, UUID userId) {
-    notificationRepository.updateConfirmed(id, userId, Instant.now());
+    Notification notification = notificationRepository.findById(id).orElseThrow(
+        () -> new NotificationException(NotificationErrorCode.NOTIFICATION_NOT_FOUND, id)
+    );
+    notification.updateConfirmed(Instant.now());
   }
 
   public void update(UUID userId) {
-    notificationRepository.updateConfirmed(userId, Instant.now());
+    notificationRepository.bulkUpdateConfirmed(userId, Instant.now());
   }
 
-  private CursorPageResponse<NotificationDto> toCursorPage(Slice<Notification> results) {
+  private CursorPageResponse<NotificationDto> toCursorPage(Slice<Notification> results,
+      UUID userId) {
+    List<Notification> entities = results.getContent();
     boolean hasNext = results.hasNext();
-    List<Notification> entities = List.of();
     String nextCursor = null;
     String nextAfter = null;
-    int size = 0;
-    long totalElements = 0;
-    if (hasNext) {
-      entities = results.getContent();
-      size = entities.size();
+    int size = entities.size();
+    long totalElements = notificationRepository.countAllByUser_IdAndConfirmedIsFalse(userId);
+    if (hasNext && !entities.isEmpty()) {
       Notification lastNotification = entities.get(size - 1);
       nextCursor = lastNotification.getId().toString();
-      Instant createdAt = lastNotification.getCreatedAt();
-      nextAfter = TimeConverter.toDatetime(createdAt).toString();
-      totalElements = notificationRepository.countAllByUser_IdAndConfirmedIsFalse(
-          lastNotification.getUser().getId());
+      nextAfter = TimeConverter.toDatetime(lastNotification.getCreatedAt()).toString();
     }
     return new CursorPageResponse<>(
         notificationMapper.toDto(entities),

--- a/src/test/java/com/springboot/monew/common/fixture/NotificationFixtureBuilder.java
+++ b/src/test/java/com/springboot/monew/common/fixture/NotificationFixtureBuilder.java
@@ -49,7 +49,6 @@ public class NotificationFixtureBuilder {
     api.ignore(field(Notification::getId))
         .ignore(field(Notification::getCreatedAt))
         .ignore(field(Notification::getUpdatedAt))
-        .ignore(field(Notification::getContent))
         .set(field(Notification::getConfirmed), false)
         .set(field(Notification::getResourceType), this.resourceType);
 

--- a/src/test/java/com/springboot/monew/common/fixture/NotificationFixtureBuilder.java
+++ b/src/test/java/com/springboot/monew/common/fixture/NotificationFixtureBuilder.java
@@ -14,7 +14,7 @@ public class NotificationFixtureBuilder {
 
   private int size = 10;
   private ResourceType resourceType = ResourceType.INTEREST;
-  private User user; // 💡 공유할 유저를 받을 필드 추가!
+  private User user;
 
   private NotificationFixtureBuilder() {}
 
@@ -32,7 +32,6 @@ public class NotificationFixtureBuilder {
     return this;
   }
 
-  // 💡 팩토리로부터 유저를 전달받는 메서드!
   public NotificationFixtureBuilder user(User user) {
     this.user = user;
     return this;
@@ -50,10 +49,10 @@ public class NotificationFixtureBuilder {
     api.ignore(field(Notification::getId))
         .ignore(field(Notification::getCreatedAt))
         .ignore(field(Notification::getUpdatedAt))
+        .ignore(field(Notification::getContent))
         .set(field(Notification::getConfirmed), false)
         .set(field(Notification::getResourceType), this.resourceType);
 
-    // 💡 팩토리에서 유저를 넘겨줬다면, 모든 알림에 그 유저를 강제 주입!
     if (this.user != null) {
       api.set(field(Notification::getUser), this.user);
     }

--- a/src/test/java/com/springboot/monew/notification/entity/NotificationTest.java
+++ b/src/test/java/com/springboot/monew/notification/entity/NotificationTest.java
@@ -6,6 +6,7 @@ import com.springboot.monew.comment.entity.CommentLike;
 import com.springboot.monew.common.fixture.EntityFixtureFactory;
 import com.springboot.monew.interest.entity.Interest;
 import com.springboot.monew.notification.exception.NotificationException;
+import com.springboot.monew.users.entity.User;
 import java.time.Instant;
 import java.util.UUID;
 import org.assertj.core.api.Assertions;
@@ -67,6 +68,124 @@ class NotificationTest {
     // when & then
     Assertions.assertThatThrownBy(() -> notification.updateConfirmed(updatedAt))
         .isInstanceOf(NotificationException.class)
-        .hasMessageContaining("이미 확인한 알람입니다");
+        .hasMessageContaining("이미 읽음 처리된 알림입니다");
+  }
+
+  @Test
+  @DisplayName("""
+      Interest를 주입받아 객체 생성 성공
+      도메인 제약 조건 통과
+      content는 '{관심사 이름}와 관련된 기사가 {관심사와 관련된 기사 갯수}건 등록되었습니다.' 포맷을 가져야 한다""")
+  void successToInitWithInterest() {
+    // given
+    Interest interest = EntityFixtureFactory.get(Interest.class);
+    User user = EntityFixtureFactory.get(User.class);
+
+    // when
+    Notification entity = Notification.builder()
+        .resourceType(ResourceType.INTEREST)
+        .user(user)
+        .interest(interest)
+        .build();
+
+    // then
+    String interestMessage = "%s와 관련된 기사가 %s건 등록되었습니다.";
+    Assertions.assertThat(entity)
+        .extracting("content")
+        .isEqualTo(interestMessage.formatted(interest.getName(), interest.getArticleCount()));
+  }
+
+  @Test
+  @DisplayName("""
+      CommentLike를 주입받아 객체 생성 성공
+      도메인 제약 조건 통과
+      content는 '{좋아요를 누른 유저 닉네임}님이 나의 댓글을 좋아합니다.' 포맷을 가져야 한다""")
+  void successToInitWithCommentLike() {
+    // given
+    CommentLike commentLike = EntityFixtureFactory.get(CommentLike.class);
+    User user = EntityFixtureFactory.get(User.class);
+
+    // when
+    Notification entity = Notification.builder()
+        .resourceType(ResourceType.COMMENT)
+        .user(user)
+        .commentLike(commentLike)
+        .build();
+
+    // then
+    String interestMessage = "%s님이 나의 댓글을 좋아합니다.";
+    Assertions.assertThat(entity)
+        .extracting("content")
+        .isEqualTo(interestMessage.formatted(commentLike.getUser().getNickname()));
+  }
+
+  @Test
+  @DisplayName("Interest를 주입받았지만 ResourceType=COMMENT로 인해 객체 생성 실패")
+  void failToInitWithInterestDueToInconsistentResourceType() {
+    // given
+    Interest interest = EntityFixtureFactory.get(Interest.class);
+    User user = EntityFixtureFactory.get(User.class);
+
+    // when & then
+    Assertions.assertThatThrownBy(() ->
+            Notification.builder()
+                .user(user)
+                .interest(interest)
+                .resourceType(ResourceType.COMMENT)
+                .build())
+        .isInstanceOf(NotificationException.class);
+  }
+
+  @Test
+  @DisplayName("CommentLike를 주입받았지만 ResourceType=INTEREST로 인해 객체 생성 실패")
+  void failToInitWithCommentLikeDueToInconsistentResourceType() {
+    // given
+    CommentLike commentLike = EntityFixtureFactory.get(CommentLike.class);
+    User user = EntityFixtureFactory.get(User.class);
+
+    // when & then
+    Assertions.assertThatThrownBy(() ->
+            Notification.builder()
+                .user(user)
+                .commentLike(commentLike)
+                .resourceType(ResourceType.INTEREST)
+                .build())
+        .isInstanceOf(NotificationException.class);
+  }
+
+  @Test
+  @DisplayName("User=null 이면 객체 생성 실패")
+  void failToInitWithoutUser() {
+    // given
+    CommentLike commentLike = EntityFixtureFactory.get(CommentLike.class);
+    User user = null;
+
+    // when & then
+    Assertions.assertThatThrownBy(() ->
+            Notification.builder()
+                .user(user)
+                .commentLike(commentLike)
+                .resourceType(ResourceType.INTEREST)
+                .build())
+        .isInstanceOf(NotificationException.class);
+  }
+
+  @Test
+  @DisplayName("Interest, CommentLike 둘 다 null이 아닌 객체를 입력 받으면 객체 생성 실패")
+  void failToInitWithInterestAndCommentLike() {
+    // given
+    User user = EntityFixtureFactory.get(User.class);
+    CommentLike commentLike = EntityFixtureFactory.get(CommentLike.class);
+    Interest interest = EntityFixtureFactory.get(Interest.class);
+
+    // when & then
+    Assertions.assertThatThrownBy(() ->
+            Notification.builder()
+                .user(user)
+                .commentLike(commentLike)
+                .interest(interest)
+                .resourceType(ResourceType.INTEREST)
+                .build())
+        .isInstanceOf(NotificationException.class);
   }
 }

--- a/src/test/java/com/springboot/monew/notification/entity/NotificationTest.java
+++ b/src/test/java/com/springboot/monew/notification/entity/NotificationTest.java
@@ -165,7 +165,7 @@ class NotificationTest {
             Notification.builder()
                 .user(user)
                 .commentLike(commentLike)
-                .resourceType(ResourceType.INTEREST)
+                .resourceType(ResourceType.COMMENT)
                 .build())
         .isInstanceOf(NotificationException.class);
   }

--- a/src/test/java/com/springboot/monew/notification/repository/NotificationRepositoryTest.java
+++ b/src/test/java/com/springboot/monew/notification/repository/NotificationRepositoryTest.java
@@ -7,7 +7,6 @@ import com.springboot.monew.notification.entity.ResourceType;
 import com.springboot.monew.users.entity.User;
 import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -292,7 +291,7 @@ public class NotificationRepositoryTest extends BaseRepositoryTest {
     // when
     List<UUID> ids = getIds(expected);
     UUID userId = expected.get(0).getUser().getId();
-    int updatedSuccessCount = notificationRepository.updateConfirmed(ids, userId, updatedAt);
+    int updatedSuccessCount = notificationRepository.updateConfirmed(userId, updatedAt);
     ensureQueryCount(1);
     printQueries();
 

--- a/src/test/java/com/springboot/monew/notification/repository/NotificationRepositoryTest.java
+++ b/src/test/java/com/springboot/monew/notification/repository/NotificationRepositoryTest.java
@@ -258,31 +258,6 @@ public class NotificationRepositoryTest extends BaseRepositoryTest {
   }
 
   @Test
-  @DisplayName("알람 객체 업데이트 성공\n"
-      + "confirmed=false -> true, updatedAt=Instant.now()")
-  void successToUpdateConfirmed() {
-    // given
-    Instant updatedAt = Instant.now();
-    Notification expected = testEntityManager.generateNotification();
-    expected.updateConfirmed(updatedAt);
-    clear();
-
-    // when
-    notificationRepository.updateConfirmed(expected.getId(), expected.getUser().getId(),
-        updatedAt);
-    ensureQueryCount(1);
-    printQueries();
-
-    // then
-    Notification actual = notificationRepository.findById(expected.getId()).orElseThrow();
-    Assertions.assertThat(actual)
-        .usingRecursiveComparison()
-        .ignoringFields("user", "interest")
-        .withEqualsForType(this::compareInstant, Instant.class)
-        .isEqualTo(expected);
-  }
-
-  @Test
   @DisplayName("알람 벌크 업데이트 성공\n"
       + "confirmed=false -> true, updatedAt=Instant.now()")
   void successToBulkUpdateConfirmed() {
@@ -296,7 +271,7 @@ public class NotificationRepositoryTest extends BaseRepositoryTest {
     // when
     List<UUID> ids = getIds(expected);
     UUID userId = expected.get(0).getUser().getId();
-    int updatedSuccessCount = notificationRepository.updateConfirmed(userId, updatedAt);
+    int updatedSuccessCount = notificationRepository.bulkUpdateConfirmed(userId, updatedAt);
     ensureQueryCount(1);
     printQueries();
 

--- a/src/test/java/com/springboot/monew/notification/repository/NotificationRepositoryTest.java
+++ b/src/test/java/com/springboot/monew/notification/repository/NotificationRepositoryTest.java
@@ -1,10 +1,13 @@
 package com.springboot.monew.notification.repository;
 
 import com.springboot.monew.common.repository.BaseRepositoryTest;
+import com.springboot.monew.common.utils.TimeConverter;
 import com.springboot.monew.notification.entity.Notification;
 import com.springboot.monew.notification.entity.ResourceType;
 import com.springboot.monew.users.entity.User;
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -35,7 +38,6 @@ public class NotificationRepositoryTest extends BaseRepositoryTest {
   void successToCreateByInterestAndFind() {
     // given
     Notification expected = Notification.builder()
-        .content("successToCreateByInterestAndFind")
         .resourceType(ResourceType.INTEREST)
         .user(testEntityManager.generateUser())
         .interest(testEntityManager.generateInterest())
@@ -65,7 +67,6 @@ public class NotificationRepositoryTest extends BaseRepositoryTest {
   void failToCreateWithNonExistingUser() {
     // given
     Notification expected = Notification.builder()
-        .content("failToCreateWithNonExistingUser")
         .user(testEntityManager.getProxyUser())
         .interest(testEntityManager.generateInterest())
         .resourceType(ResourceType.INTEREST)
@@ -85,7 +86,6 @@ public class NotificationRepositoryTest extends BaseRepositoryTest {
   void failToCreateWithNonExistingInterest() {
     // given
     Notification expected = Notification.builder()
-        .content("failToCreateWithNonExistingInterest")
         .user(testEntityManager.generateUser())
         .interest(testEntityManager.getProxyInterest())
         .resourceType(ResourceType.INTEREST)
@@ -105,7 +105,6 @@ public class NotificationRepositoryTest extends BaseRepositoryTest {
   void successToCreateWithCommentLikeAndFind() {
     // given
     Notification expected = Notification.builder()
-        .content("successToCreateWithCommentLikeAndFind")
         .user(testEntityManager.generateUser())
         .commentLike(testEntityManager.generateCommentLike())
         .resourceType(ResourceType.COMMENT)
@@ -135,7 +134,6 @@ public class NotificationRepositoryTest extends BaseRepositoryTest {
   void failToCreateWithNonExistingCommentLike() {
     // given
     Notification expected = Notification.builder()
-        .content("failToCreateWithNonExistingCommentLike")
         .user(testEntityManager.generateUser())
         .commentLike(testEntityManager.getProxyCommentLike())
         .resourceType(ResourceType.COMMENT)
@@ -155,7 +153,6 @@ public class NotificationRepositoryTest extends BaseRepositoryTest {
   void failToCreateDueToMismatchResourceType() {
     // given
     Notification expected = Notification.builder()
-        .content("failToCreateDueToMismatchResourceType")
         .user(testEntityManager.generateUser())
         .commentLike(testEntityManager.generateCommentLike())
         .resourceType(ResourceType.INTEREST)
@@ -223,7 +220,7 @@ public class NotificationRepositoryTest extends BaseRepositoryTest {
     clear();
 
     UUID cursor = null;
-    Instant after = null;
+    LocalDateTime after = null;
     List<UUID> allFetchedIds = new ArrayList<>();
     boolean hasNext = true;
 
@@ -246,7 +243,7 @@ public class NotificationRepositoryTest extends BaseRepositoryTest {
       hasNext = result.hasNext();
       if (hasNext && !actual.isEmpty()) {
         cursor = actual.get(actual.size() - 1).getId();
-        after = actual.get(actual.size() - 1).getCreatedAt();
+        after = TimeConverter.toDatetime(actual.get(actual.size() - 1).getCreatedAt());
       }
     }
 

--- a/src/test/java/com/springboot/monew/notification/repository/NotificationRepositoryTest.java
+++ b/src/test/java/com/springboot/monew/notification/repository/NotificationRepositoryTest.java
@@ -1,16 +1,17 @@
 package com.springboot.monew.notification.repository;
 
+import com.springboot.monew.comment.entity.CommentLike;
 import com.springboot.monew.common.repository.BaseRepositoryTest;
-import com.springboot.monew.common.utils.TimeConverter;
+import com.springboot.monew.interest.entity.Interest;
 import com.springboot.monew.notification.entity.Notification;
 import com.springboot.monew.notification.entity.ResourceType;
 import com.springboot.monew.users.entity.User;
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import org.assertj.core.api.Assertions;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,6 +20,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.test.util.ReflectionTestUtils;
 
 public class NotificationRepositoryTest extends BaseRepositoryTest {
 
@@ -86,7 +88,7 @@ public class NotificationRepositoryTest extends BaseRepositoryTest {
     // given
     Notification expected = Notification.builder()
         .user(testEntityManager.generateUser())
-        .interest(testEntityManager.getProxyInterest())
+        .interest(Instancio.create(Interest.class))
         .resourceType(ResourceType.INTEREST)
         .build();
 
@@ -134,7 +136,7 @@ public class NotificationRepositoryTest extends BaseRepositoryTest {
     // given
     Notification expected = Notification.builder()
         .user(testEntityManager.generateUser())
-        .commentLike(testEntityManager.getProxyCommentLike())
+        .commentLike(Instancio.create(CommentLike.class))
         .resourceType(ResourceType.COMMENT)
         .build();
 
@@ -148,14 +150,17 @@ public class NotificationRepositoryTest extends BaseRepositoryTest {
 
   @Test
   @DisplayName("comment_like_id가 존재하면 resource_type은 'COMMENT'이어야 한다\n"
-      + "domain integrity violation")
+      + "domain integrity violation\n"
+      + "객체 생성 단계에서 위 과정을 검사한다\n"
+      + "그래서 객체를 만들고 reflection으로 값을 주입 하겠다")
   void failToCreateDueToMismatchResourceType() {
     // given
     Notification expected = Notification.builder()
         .user(testEntityManager.generateUser())
         .commentLike(testEntityManager.generateCommentLike())
-        .resourceType(ResourceType.INTEREST)
+        .resourceType(ResourceType.COMMENT)
         .build();
+    ReflectionTestUtils.setField(expected, "resourceType", ResourceType.INTEREST);
 
     // when & then
     Assertions.assertThatThrownBy(() -> notificationRepository.saveAndFlush(expected))
@@ -219,7 +224,7 @@ public class NotificationRepositoryTest extends BaseRepositoryTest {
     clear();
 
     UUID cursor = null;
-    LocalDateTime after = null;
+    Instant after = null;
     List<UUID> allFetchedIds = new ArrayList<>();
     boolean hasNext = true;
 
@@ -242,7 +247,7 @@ public class NotificationRepositoryTest extends BaseRepositoryTest {
       hasNext = result.hasNext();
       if (hasNext && !actual.isEmpty()) {
         cursor = actual.get(actual.size() - 1).getId();
-        after = TimeConverter.toDatetime(actual.get(actual.size() - 1).getCreatedAt());
+        after = actual.get(actual.size() - 1).getCreatedAt();
       }
     }
 

--- a/src/test/java/com/springboot/monew/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/springboot/monew/notification/service/NotificationServiceTest.java
@@ -1,0 +1,110 @@
+package com.springboot.monew.notification.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.springboot.monew.comment.entity.CommentLike;
+import com.springboot.monew.common.fixture.EntityFixtureFactory;
+import com.springboot.monew.interest.entity.Interest;
+import com.springboot.monew.notification.dto.NotificationFindRequest;
+import com.springboot.monew.notification.entity.Notification;
+import com.springboot.monew.notification.entity.ResourceType;
+import com.springboot.monew.notification.mapper.NotificationMapper;
+import com.springboot.monew.notification.mapper.NotificationMapperImpl;
+import com.springboot.monew.notification.repository.NotificationRepository;
+import com.springboot.monew.users.entity.User;
+import java.util.UUID;
+import org.instancio.Instancio;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+  @Spy
+  private final NotificationMapper mapper = new NotificationMapperImpl();
+  @Mock
+  private NotificationRepository repository;
+  @InjectMocks
+  private NotificationService service;
+
+  @Test
+  @DisplayName("관심사에 의해 알람 생성 성공")
+  void successToCreateWithInterest() {
+    // given
+    String content = "asd";
+    ResourceType resourceType = ResourceType.INTEREST;
+    User user = EntityFixtureFactory.get(User.class);
+    Interest interest = EntityFixtureFactory.get(Interest.class);
+    CommentLike commentLike = null;
+    Notification entity = new Notification(content, resourceType, user, interest, commentLike);
+    given(repository.save(any(Notification.class)))
+        .willReturn(entity);
+
+    // when
+    service.create(content, resourceType, user, interest, commentLike);
+
+    // verify
+    verify(repository, times(1)).save(any(Notification.class));
+  }
+
+  @Test
+  @DisplayName("댓글 좋아요에 의해 알람 생성 성공")
+  void successToCreateWithCommentLike() {
+    // given
+    String content = "asd";
+    ResourceType resourceType = ResourceType.COMMENT;
+    User user = EntityFixtureFactory.get(User.class);
+    Interest interest = null;
+    CommentLike commentLike = EntityFixtureFactory.get(CommentLike.class);
+    Notification entity = new Notification(content, resourceType, user, interest, commentLike);
+    given(repository.save(any(Notification.class)))
+        .willReturn(entity);
+
+    // when
+    service.create(content, resourceType, user, interest, commentLike);
+
+    // verify
+    verify(repository, times(1)).save(any(Notification.class));
+  }
+
+  @Test
+  @DisplayName("알람 객체 조회 성공\n"
+      + "전달 받은 parameter 수정하지 않고 pageable 생성하여 repository 전달")
+  void successToFindByCursor() {
+    // given
+    NotificationFindRequest request = Instancio.create(NotificationFindRequest.class);
+    UUID userId = UUID.randomUUID();
+    given(repository.findByCursor(request.getCursor(), request.getAfter(), request.getUserId(),
+        any(Pageable.class)))
+        .willReturn(any());
+
+    // when
+    service.find(request, userId);
+
+    // verify
+    verify(repository, times(1)).findByCursor(request.getCursor(), request.getAfter(),
+        request.getUserId(), any(Pageable.class));
+  }
+
+  @Test
+  @DisplayName("한 유저의 확인하지 않은 모든 알람 중 단일 알람 확인 성공")
+  void successToUpdateConfirmed() {
+
+  }
+
+  @Test
+  @DisplayName("한 유저의 확인하지 않은 모든 알람 확인 성공")
+  void successToBulkUpdateConfirmed() {
+
+  }
+
+}

--- a/src/test/java/com/springboot/monew/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/springboot/monew/notification/service/NotificationServiceTest.java
@@ -1,30 +1,43 @@
 package com.springboot.monew.notification.service;
 
+import static org.instancio.Select.field;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.springboot.monew.comment.entity.CommentLike;
+import com.springboot.monew.common.dto.CursorPageResponse;
 import com.springboot.monew.common.fixture.EntityFixtureFactory;
+import com.springboot.monew.common.utils.TimeConverter;
 import com.springboot.monew.interest.entity.Interest;
+import com.springboot.monew.notification.dto.NotificationDto;
 import com.springboot.monew.notification.dto.NotificationFindRequest;
 import com.springboot.monew.notification.entity.Notification;
 import com.springboot.monew.notification.entity.ResourceType;
+import com.springboot.monew.notification.event.CommentLikeNotificationEvent;
+import com.springboot.monew.notification.event.InterestNotificationEvent;
 import com.springboot.monew.notification.mapper.NotificationMapper;
 import com.springboot.monew.notification.mapper.NotificationMapperImpl;
 import com.springboot.monew.notification.repository.NotificationRepository;
 import com.springboot.monew.users.entity.User;
+import java.util.List;
 import java.util.UUID;
+import org.assertj.core.api.Assertions;
 import org.instancio.Instancio;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 
 @ExtendWith(MockitoExtension.class)
 class NotificationServiceTest {
@@ -37,62 +50,101 @@ class NotificationServiceTest {
   private NotificationService service;
 
   @Test
-  @DisplayName("관심사에 의해 알람 생성 성공")
-  void successToCreateWithInterest() {
+  @DisplayName("관심사 알림 생성 이벤트를 이용해 알림 생성 및 저장하고 dto 반환")
+  void successToCreateByInterest() {
     // given
-    String content = "asd";
-    ResourceType resourceType = ResourceType.INTEREST;
     User user = EntityFixtureFactory.get(User.class);
     Interest interest = EntityFixtureFactory.get(Interest.class);
-    CommentLike commentLike = null;
-    Notification entity = new Notification(content, resourceType, user, interest, commentLike);
-    given(repository.save(any(Notification.class)))
-        .willReturn(entity);
+    InterestNotificationEvent event = new InterestNotificationEvent(user, interest);
+    Notification expected = Notification.builder()
+        .resourceType(ResourceType.INTEREST)
+        .user(user)
+        .interest(interest)
+        .build();
+    NotificationDto expectedDto = mapper.toDto(expected);
+
+    given(repository.save(any(Notification.class))).willReturn(expected);
 
     // when
-    service.create(content, resourceType, user, interest, commentLike);
+    NotificationDto actualDto = service.create(event);
 
-    // verify
-    verify(repository, times(1)).save(any(Notification.class));
+    // then
+    Assertions.assertThat(actualDto).isEqualTo(expectedDto);
+
+    ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
+    verify(repository, times(1)).save(captor.capture());
+
+    Notification actual = captor.getValue();
+    Assertions.assertThat(actual)
+        .extracting("user", "interest", "resourceType")
+        .contains(expected.getUser(), expected.getInterest(), expected.getResourceType());
   }
 
   @Test
-  @DisplayName("댓글 좋아요에 의해 알람 생성 성공")
+  @DisplayName("댓글 좋아요 알림 생성 이벤트를 이용해 알림 생성 및 저장 후 dto 반환")
   void successToCreateWithCommentLike() {
     // given
-    String content = "asd";
-    ResourceType resourceType = ResourceType.COMMENT;
     User user = EntityFixtureFactory.get(User.class);
-    Interest interest = null;
     CommentLike commentLike = EntityFixtureFactory.get(CommentLike.class);
-    Notification entity = new Notification(content, resourceType, user, interest, commentLike);
-    given(repository.save(any(Notification.class)))
-        .willReturn(entity);
+    CommentLikeNotificationEvent event = new CommentLikeNotificationEvent(user, commentLike);
+    Notification expected = Notification.builder()
+        .resourceType(ResourceType.COMMENT)
+        .user(user)
+        .commentLike(commentLike)
+        .build();
+    NotificationDto expectedDto = mapper.toDto(expected);
+
+    given(repository.save(any(Notification.class))).willReturn(expected);
 
     // when
-    service.create(content, resourceType, user, interest, commentLike);
+    NotificationDto actualDto = service.create(event);
 
-    // verify
-    verify(repository, times(1)).save(any(Notification.class));
+    // then
+    Assertions.assertThat(actualDto).isEqualTo(expectedDto);
+
+    ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
+    verify(repository, times(1)).save(captor.capture());
+
+    Notification actual = captor.getValue();
+    Assertions.assertThat(actual)
+        .extracting("user", "commentLike", "resourceType")
+        .contains(expected.getUser(), expected.getCommentLike(), expected.getResourceType());
   }
 
   @Test
-  @DisplayName("알람 객체 조회 성공\n"
-      + "전달 받은 parameter 수정하지 않고 pageable 생성하여 repository 전달")
-  void successToFindByCursor() {
+  @DisplayName("알람 객체 cursor pagination 조회 성공\n"
+      + "hasNext=true, nextCursor, nextAfter를 반환한다")
+  void successToFindByCursorAndHasNext() {
     // given
-    NotificationFindRequest request = Instancio.create(NotificationFindRequest.class);
-    UUID userId = UUID.randomUUID();
-    given(repository.findByCursor(request.getCursor(), request.getAfter(), request.getUserId(),
-        any(Pageable.class)))
-        .willReturn(any());
+    int size = 3;
+    long totalElements = 5L;
+    boolean hasNext = true;
+    User user = EntityFixtureFactory.get(User.class);
+    UUID userId = user.getId();
+    NotificationFindRequest request = new NotificationFindRequest(null, null, size, userId);
+    Pageable pageable = PageRequest.of(0, size);
+    List<Notification> content = Instancio.ofList(Notification.class)
+        .size(size)
+        .ignore(field(Notification::getCommentLike))
+        .ignore(field(Notification::getContent))
+        .set(field(Notification::getResourceType), ResourceType.INTEREST)
+        .set(field(Notification::getConfirmed), false)
+        .set(field(Notification::getUser), user)
+        .create();
+    Slice<Notification> slice = new SliceImpl<>(content, pageable, hasNext);
+    Notification last = content.get(size - 1);
+
+    given(repository.findByCursor(any(), any(), eq(userId), any(Pageable.class))).willReturn(slice);
+    given(repository.countAllByUser_IdAndConfirmedIsFalse(userId)).willReturn(totalElements);
 
     // when
-    service.find(request, userId);
+    CursorPageResponse<NotificationDto> response = service.find(request, userId);
 
     // verify
-    verify(repository, times(1)).findByCursor(request.getCursor(), request.getAfter(),
-        request.getUserId(), any(Pageable.class));
+    Assertions.assertThat(response)
+        .extracting("size", "hasNext", "totalElements", "nextCursor", "nextAfter")
+        .contains(size, hasNext, totalElements, last.getId().toString(),
+            TimeConverter.toDatetime(last.getCreatedAt()).toString());
   }
 
   @Test

--- a/src/test/java/com/springboot/monew/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/springboot/monew/notification/service/NotificationServiceTest.java
@@ -146,17 +146,4 @@ class NotificationServiceTest {
         .contains(size, hasNext, totalElements, last.getId().toString(),
             TimeConverter.toDatetime(last.getCreatedAt()).toString());
   }
-
-  @Test
-  @DisplayName("한 유저의 확인하지 않은 모든 알람 중 단일 알람 확인 성공")
-  void successToUpdateConfirmed() {
-
-  }
-
-  @Test
-  @DisplayName("한 유저의 확인하지 않은 모든 알람 확인 성공")
-  void successToBulkUpdateConfirmed() {
-
-  }
-
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -32,5 +32,5 @@ spring:
 logging:
   level:
     com.springboot.monew: DEBUG
-    org.hibernate.SQL: DEBUG
-    org.hibernate.orm.jdbc.bind: TRACE
+    org.hibernate.SQL: WARN
+    org.hibernate.orm.jdbc.bind: WARN


### PR DESCRIPTION
## 📌 작업 내용
- 알람 서비스 구현 및 유닛 테스트 작성

## 🔧 변경 사항
- 

## 반영 브랜치


## 💬 기타 참고 사항
- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 커서 기반 페이지네이션 알림 응답 추가
  * 관심/댓글좋아요 이벤트 → 알림 생성 흐름 추가
  * 관심사별 게시물 수 조회 기능과 관련 리포지토리 확장
  * 시간 변환 유틸리티 추가

* **버그 수정 / 개선**
  * 알림 생성 시 도메인 제약 검증 강화 및 오류 코드/메시지 정비
  * 알림 일괄 읽음 처리 및 미확인 카운트 조회 기능 추가
  * 매핑/포맷팅 및 DTO 선언 정리

* **테스트**
  * 알림 서비스·레포·엔티티 단위 테스트 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->