### PR TITLE
[Feat] 활동 내역 조회 응답 DTO 구현 및 구조 변경

### DIFF
--- a/src/main/java/com/springboot/monew/users/controller/UserApiDocs.java
+++ b/src/main/java/com/springboot/monew/users/controller/UserApiDocs.java
@@ -1,10 +1,10 @@
 package com.springboot.monew.users.controller;
 
 import com.springboot.monew.common.exception.ErrorResponse;
-import com.springboot.monew.users.dto.UserDto;
-import com.springboot.monew.users.dto.UserLoginRequest;
-import com.springboot.monew.users.dto.UserRegisterRequest;
-import com.springboot.monew.users.dto.UserUpdateRequest;
+import com.springboot.monew.users.dto.response.UserDto;
+import com.springboot.monew.users.dto.request.UserLoginRequest;
+import com.springboot.monew.users.dto.request.UserRegisterRequest;
+import com.springboot.monew.users.dto.request.UserUpdateRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;

--- a/src/main/java/com/springboot/monew/users/controller/UserController.java
+++ b/src/main/java/com/springboot/monew/users/controller/UserController.java
@@ -1,9 +1,9 @@
 package com.springboot.monew.users.controller;
 
-import com.springboot.monew.users.dto.UserDto;
-import com.springboot.monew.users.dto.UserLoginRequest;
-import com.springboot.monew.users.dto.UserRegisterRequest;
-import com.springboot.monew.users.dto.UserUpdateRequest;
+import com.springboot.monew.users.dto.response.UserDto;
+import com.springboot.monew.users.dto.request.UserLoginRequest;
+import com.springboot.monew.users.dto.request.UserRegisterRequest;
+import com.springboot.monew.users.dto.request.UserUpdateRequest;
 import com.springboot.monew.users.service.UserService;
 import jakarta.validation.Valid;
 import java.net.URI;

--- a/src/main/java/com/springboot/monew/users/dto/request/UserLoginRequest.java
+++ b/src/main/java/com/springboot/monew/users/dto/request/UserLoginRequest.java
@@ -1,4 +1,4 @@
-package com.springboot.monew.users.dto;
+package com.springboot.monew.users.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;

--- a/src/main/java/com/springboot/monew/users/dto/request/UserRegisterRequest.java
+++ b/src/main/java/com/springboot/monew/users/dto/request/UserRegisterRequest.java
@@ -1,4 +1,4 @@
-package com.springboot.monew.users.dto;
+package com.springboot.monew.users.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;

--- a/src/main/java/com/springboot/monew/users/dto/request/UserUpdateRequest.java
+++ b/src/main/java/com/springboot/monew/users/dto/request/UserUpdateRequest.java
@@ -1,4 +1,4 @@
-package com.springboot.monew.users.dto;
+package com.springboot.monew.users.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/com/springboot/monew/users/dto/response/CommentActivityDto.java
+++ b/src/main/java/com/springboot/monew/users/dto/response/CommentActivityDto.java
@@ -1,0 +1,33 @@
+package com.springboot.monew.users.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+import java.util.UUID;
+
+public record CommentActivityDto(
+    @Schema(description = "댓글 ID", format = "uuid")
+    UUID id,
+
+    @Schema(description = "기사 ID", format = "uuid")
+    UUID articleId,
+
+    @Schema(description = "기사 제목")
+    String articleTitle,
+
+    @Schema(description = "작성자 ID", format = "uuid")
+    UUID userId,
+
+    @Schema(description = "작성자 닉네임")
+    String userNickname,
+
+    @Schema(description = "내용")
+    String content,
+
+    @Schema(description = "좋아요 수")
+    Long likeCount,
+
+    @Schema(description = "작성된 날짜", format = "date-time")
+    Instant createdAt
+    ) {
+
+}

--- a/src/main/java/com/springboot/monew/users/dto/response/CommentLikeActivityDto.java
+++ b/src/main/java/com/springboot/monew/users/dto/response/CommentLikeActivityDto.java
@@ -1,0 +1,40 @@
+package com.springboot.monew.users.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+import java.util.UUID;
+
+public record CommentLikeActivityDto(
+    @Schema(description = "좋아요 ID", format = "uuid")
+    UUID id,
+
+    @Schema(description = "좋아요한 날짜", format = "date-time")
+    Instant createdAt,
+
+    @Schema(description = "댓글 ID", format = "uuid")
+    UUID commentId,
+
+    @Schema(description = "기사 ID", format = "uuid")
+    UUID articleId,
+
+    @Schema(description = "기사 제목")
+    String articleTitle,
+
+    @Schema(description = "작성자 ID", format = "uuid")
+    UUID commentUserId,
+
+    @Schema(description = "작성자 닉네임")
+    String commentUserNickname,
+
+    @Schema(description = "내용")
+    String commentContent,
+
+    @Schema(description = "좋아요 수")
+    Long commentLikeCount,
+
+    @Schema(description = "작성된 날짜", format = "date-time")
+    Instant commentCreatedAt
+) {
+
+
+}

--- a/src/main/java/com/springboot/monew/users/dto/response/TemporaryArticleViewDto.java
+++ b/src/main/java/com/springboot/monew/users/dto/response/TemporaryArticleViewDto.java
@@ -1,0 +1,20 @@
+package com.springboot.monew.users.dto.response;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record TemporaryArticleViewDto(
+    UUID id,
+    UUID viewedBy,
+    Instant createdAt,
+    UUID articleId,
+    String source,
+    String sourceUrl,
+    String articleTitle,
+    Instant articlePublishedDate,
+    String articleSummary,
+    Long articleCommentCount,
+    Long articleViewCount
+) {
+
+}

--- a/src/main/java/com/springboot/monew/users/dto/response/UserActivityDto.java
+++ b/src/main/java/com/springboot/monew/users/dto/response/UserActivityDto.java
@@ -1,0 +1,37 @@
+package com.springboot.monew.users.dto.response;
+
+import com.springboot.monew.interest.dto.response.SubscriptionDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+public record UserActivityDto(
+    @Schema(description = "사용자 ID", format = "uuid")
+    UUID id,
+
+    @Schema(description = "이메일")
+    String email,
+
+    @Schema(description = "닉네임")
+    String nickname,
+
+    @Schema(description = "가입한 날짜", format = "date-time")
+    Instant createdAt,
+
+    @Schema(description = "구독 정보")
+    List<SubscriptionDto> subscriptions,
+
+    @Schema(description = "최근 작성한 댓글 (최대 10건")
+    List<CommentActivityDto> comments,
+
+    @Schema(description = "최근 좋아요를 누른 댓글(최대 10건)")
+    List<CommentLikeActivityDto> commentLikes,
+
+    @Schema(description = "최근 본 기사 (최대 10건)")
+    List<TemporaryArticleViewDto> articleViews
+) {
+
+}
+
+

--- a/src/main/java/com/springboot/monew/users/dto/response/UserActivityDto.java
+++ b/src/main/java/com/springboot/monew/users/dto/response/UserActivityDto.java
@@ -22,7 +22,7 @@ public record UserActivityDto(
     @Schema(description = "구독 정보")
     List<SubscriptionDto> subscriptions,
 
-    @Schema(description = "최근 작성한 댓글 (최대 10건")
+    @Schema(description = "최근 작성한 댓글 (최대 10건)")
     List<CommentActivityDto> comments,
 
     @Schema(description = "최근 좋아요를 누른 댓글(최대 10건)")

--- a/src/main/java/com/springboot/monew/users/dto/response/UserDto.java
+++ b/src/main/java/com/springboot/monew/users/dto/response/UserDto.java
@@ -1,4 +1,4 @@
-package com.springboot.monew.users.dto;
+package com.springboot.monew.users.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;

--- a/src/main/java/com/springboot/monew/users/mapper/UserMapper.java
+++ b/src/main/java/com/springboot/monew/users/mapper/UserMapper.java
@@ -1,6 +1,6 @@
 package com.springboot.monew.users.mapper;
 
-import com.springboot.monew.users.dto.UserDto;
+import com.springboot.monew.users.dto.response.UserDto;
 import com.springboot.monew.users.entity.User;
 import org.mapstruct.Mapper;
 

--- a/src/main/java/com/springboot/monew/users/repository/UserRepository.java
+++ b/src/main/java/com/springboot/monew/users/repository/UserRepository.java
@@ -8,7 +8,6 @@ import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.stereotype.Repository;
 
 public interface UserRepository extends JpaRepository<User, UUID> {
 

--- a/src/main/java/com/springboot/monew/users/service/UserService.java
+++ b/src/main/java/com/springboot/monew/users/service/UserService.java
@@ -1,9 +1,9 @@
 package com.springboot.monew.users.service;
 
-import com.springboot.monew.users.dto.UserDto;
-import com.springboot.monew.users.dto.UserLoginRequest;
-import com.springboot.monew.users.dto.UserRegisterRequest;
-import com.springboot.monew.users.dto.UserUpdateRequest;
+import com.springboot.monew.users.dto.request.UserLoginRequest;
+import com.springboot.monew.users.dto.request.UserRegisterRequest;
+import com.springboot.monew.users.dto.request.UserUpdateRequest;
+import com.springboot.monew.users.dto.response.UserDto;
 import com.springboot.monew.users.entity.User;
 import com.springboot.monew.users.exception.UserErrorCode;
 import com.springboot.monew.users.exception.UserException;

--- a/src/test/java/com/springboot/monew/users/controller/UserControllerTest.java
+++ b/src/test/java/com/springboot/monew/users/controller/UserControllerTest.java
@@ -13,10 +13,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.springboot.monew.users.dto.UserDto;
-import com.springboot.monew.users.dto.UserLoginRequest;
-import com.springboot.monew.users.dto.UserRegisterRequest;
-import com.springboot.monew.users.dto.UserUpdateRequest;
+import com.springboot.monew.users.dto.request.UserLoginRequest;
+import com.springboot.monew.users.dto.request.UserRegisterRequest;
+import com.springboot.monew.users.dto.request.UserUpdateRequest;
+import com.springboot.monew.users.dto.response.UserDto;
 import com.springboot.monew.users.service.UserService;
 import java.time.Instant;
 import java.util.UUID;
@@ -170,7 +170,8 @@ public class UserControllerTest {
         createdAt
     );
 
-    given(userService.update(eq(userId), eq(userId), any(UserUpdateRequest.class))).willReturn(expected);
+    given(userService.update(eq(userId), eq(userId), any(UserUpdateRequest.class))).willReturn(
+        expected);
 
     // when & then
     mockMvc.perform(patch("/api/users/{userId}", userId)

--- a/src/test/java/com/springboot/monew/users/dto/request/UserRegisterRequestTest.java
+++ b/src/test/java/com/springboot/monew/users/dto/request/UserRegisterRequestTest.java
@@ -1,4 +1,4 @@
-package com.springboot.monew.users.dto;
+package com.springboot.monew.users.dto.request;
 
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;

--- a/src/test/java/com/springboot/monew/users/dto/request/UserRegisterRequestTest.java
+++ b/src/test/java/com/springboot/monew/users/dto/request/UserRegisterRequestTest.java
@@ -1,298 +1,302 @@
 package com.springboot.monew.users.dto.request;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import jakarta.validation.ValidatorFactory;
-import org.junit.jupiter.api.*;
-
 import java.util.Set;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 public class UserRegisterRequestTest {
-    private static ValidatorFactory factory;
-    private Validator validator;
 
-    @BeforeAll
-    static void setUpFactory() {
-        factory = Validation.buildDefaultValidatorFactory();
-    }
+  private static ValidatorFactory factory;
+  private Validator validator;
 
-    @BeforeEach
-    void setUp() {
-        validator = factory.getValidator();
-    }
+  @BeforeAll
+  static void setUpFactory() {
+    factory = Validation.buildDefaultValidatorFactory();
+  }
 
-    @AfterAll
-    static void tearDown() {
-        factory.close();
-    }
+  @BeforeEach
+  void setUp() {
+    validator = factory.getValidator();
+  }
 
-    @Test
-    @DisplayName("이메일, 닉네임, 비밀번호가 모두 올바르면 검증에 성공한다")
-    void validateEmail_success() {
-        // given
-        UserRegisterRequest request =
-                new UserRegisterRequest("test@example.com", "monew123", "ab12!@");
+  @AfterAll
+  static void tearDown() {
+    factory.close();
+  }
 
-        // when
-        Set<ConstraintViolation<UserRegisterRequest>> violations = validator.validate(request);
+  @Test
+  @DisplayName("이메일, 닉네임, 비밀번호가 모두 올바르면 검증에 성공한다")
+  void validateEmail_success() {
+    // given
+    UserRegisterRequest request =
+        new UserRegisterRequest("test@example.com", "monew123", "ab12!@");
 
-        // then
-        assertThat(violations).isEmpty();
-    }
+    // when
+    Set<ConstraintViolation<UserRegisterRequest>> violations = validator.validate(request);
 
-    @Test
-    @DisplayName("이메일 형식이 아니면 검증에 실패한다")
-    void validateEmail_fail_whenInvalidFormat() {
-        // given
-        UserRegisterRequest request =
-                new UserRegisterRequest("invalid-email", "monew123", "ab12!@");
+    // then
+    assertThat(violations).isEmpty();
+  }
 
-        // when
-        Set<ConstraintViolation<UserRegisterRequest>> violations = validator.validate(request);
+  @Test
+  @DisplayName("이메일 형식이 아니면 검증에 실패한다")
+  void validateEmail_fail_whenInvalidFormat() {
+    // given
+    UserRegisterRequest request =
+        new UserRegisterRequest("invalid-email", "monew123", "ab12!@");
 
-        // then
-        assertThat(violations).isNotEmpty();
-    }
+    // when
+    Set<ConstraintViolation<UserRegisterRequest>> violations = validator.validate(request);
 
-    @Test
-    @DisplayName("이메일에 공백이 포함되면 검증에 실패한다")
-    void validateEmail_fail_whenContainsWhitespace() {
-        // given
-        UserRegisterRequest request =
-                new UserRegisterRequest("test @example.com", "monew123", "ab12!@");
+    // then
+    assertThat(violations).isNotEmpty();
+  }
 
-        // when
-        Set<ConstraintViolation<UserRegisterRequest>> violations = validator.validate(request);
+  @Test
+  @DisplayName("이메일에 공백이 포함되면 검증에 실패한다")
+  void validateEmail_fail_whenContainsWhitespace() {
+    // given
+    UserRegisterRequest request =
+        new UserRegisterRequest("test @example.com", "monew123", "ab12!@");
 
-        // then
-        assertThat(violations).isNotEmpty();
-    }
+    // when
+    Set<ConstraintViolation<UserRegisterRequest>> violations = validator.validate(request);
 
-    @Test
-    @DisplayName("이메일 길이가 5자 미만이면 검증에 실패한다")
-    void validateEmail_fail_whenTooShort() {
-        // given
-        UserRegisterRequest request =
-                new UserRegisterRequest("a@b", "monew123", "ab12!@");
+    // then
+    assertThat(violations).isNotEmpty();
+  }
 
-        // when
-        Set<ConstraintViolation<UserRegisterRequest>> violations = validator.validate(request);
+  @Test
+  @DisplayName("이메일 길이가 5자 미만이면 검증에 실패한다")
+  void validateEmail_fail_whenTooShort() {
+    // given
+    UserRegisterRequest request =
+        new UserRegisterRequest("a@b", "monew123", "ab12!@");
 
-        // then
-        assertThat(violations).isNotEmpty();
-    }
+    // when
+    Set<ConstraintViolation<UserRegisterRequest>> violations = validator.validate(request);
 
-    @Test
-    @DisplayName("이메일 길이가 100자를 초과하면 검증에 실패한다")
-    void validateEmail_fail_whenTooLong() {
-        // given
-        String longEmail = "a".repeat(95) + "@test.com";
-        UserRegisterRequest request =
-                new UserRegisterRequest(longEmail, "monew123", "ab12!@");
+    // then
+    assertThat(violations).isNotEmpty();
+  }
 
-        // when
-        Set<ConstraintViolation<UserRegisterRequest>> violations = validator.validate(request);
+  @Test
+  @DisplayName("이메일 길이가 100자를 초과하면 검증에 실패한다")
+  void validateEmail_fail_whenTooLong() {
+    // given
+    String longEmail = "a".repeat(95) + "@test.com";
+    UserRegisterRequest request =
+        new UserRegisterRequest(longEmail, "monew123", "ab12!@");
 
-        // then
-        assertThat(violations).isNotEmpty();
-    }
+    // when
+    Set<ConstraintViolation<UserRegisterRequest>> violations = validator.validate(request);
 
-    @Test
-    @DisplayName("닉네임이 null이면 검증에 실패한다")
-    void validateNickname_fail_whenNull() {
-        // given
-        UserRegisterRequest request =
-                new UserRegisterRequest("test@example.com", null, "ab12!@");
+    // then
+    assertThat(violations).isNotEmpty();
+  }
 
-        // when
-        Set<ConstraintViolation<UserRegisterRequest>> violations = validator.validate(request);
+  @Test
+  @DisplayName("닉네임이 null이면 검증에 실패한다")
+  void validateNickname_fail_whenNull() {
+    // given
+    UserRegisterRequest request =
+        new UserRegisterRequest("test@example.com", null, "ab12!@");
 
-        // then
-        assertThat(violations).isNotEmpty();
-    }
+    // when
+    Set<ConstraintViolation<UserRegisterRequest>> violations = validator.validate(request);
 
-    @Test
-    @DisplayName("닉네임이 비어 있으면 검증에 실패한다")
-    void validateNickname_fail_whenBlank() {
-        // given
-        UserRegisterRequest request =
-                new UserRegisterRequest("test@example.com", "", "ab12!@");
+    // then
+    assertThat(violations).isNotEmpty();
+  }
 
-        // when
-        Set<ConstraintViolation<UserRegisterRequest>> violations = validator.validate(request);
+  @Test
+  @DisplayName("닉네임이 비어 있으면 검증에 실패한다")
+  void validateNickname_fail_whenBlank() {
+    // given
+    UserRegisterRequest request =
+        new UserRegisterRequest("test@example.com", "", "ab12!@");
 
-        // then
-        assertThat(violations).isNotEmpty();
-    }
+    // when
+    Set<ConstraintViolation<UserRegisterRequest>> violations = validator.validate(request);
 
-    @Test
-    @DisplayName("닉네임이 공백만 있으면 검증에 실패한다")
-    void validateNickname_fail_whenOnlyWhiteSpace() {
-        // given
-        UserRegisterRequest request =
-                new UserRegisterRequest("test@example.com", "   ", "ab12!@");
+    // then
+    assertThat(violations).isNotEmpty();
+  }
 
-        // when
-        Set<ConstraintViolation<UserRegisterRequest>> violations = validator.validate(request);
+  @Test
+  @DisplayName("닉네임이 공백만 있으면 검증에 실패한다")
+  void validateNickname_fail_whenOnlyWhiteSpace() {
+    // given
+    UserRegisterRequest request =
+        new UserRegisterRequest("test@example.com", "   ", "ab12!@");
 
-        // then
-        assertThat(violations).isNotEmpty();
-    }
+    // when
+    Set<ConstraintViolation<UserRegisterRequest>> violations = validator.validate(request);
 
-    @Test
-    @DisplayName("닉네임에 공백이 포함되면 검증에 실패한다")
-    void validateNickname_fail_whenContainsWhitespace() {
-        // given
-        UserRegisterRequest request =
-                new UserRegisterRequest("test@example.com", "ab c", "ab12!@");
+    // then
+    assertThat(violations).isNotEmpty();
+  }
 
-        // when
-        Set<ConstraintViolation<UserRegisterRequest>> violations = validator.validate(request);
+  @Test
+  @DisplayName("닉네임에 공백이 포함되면 검증에 실패한다")
+  void validateNickname_fail_whenContainsWhitespace() {
+    // given
+    UserRegisterRequest request =
+        new UserRegisterRequest("test@example.com", "ab c", "ab12!@");
 
-        // then
-        assertThat(violations).isNotEmpty();
-    }
+    // when
+    Set<ConstraintViolation<UserRegisterRequest>> violations = validator.validate(request);
 
-    @Test
-    @DisplayName("닉네임에 특수문자가 포함되면 검증에 실패한다")
-    void validateNickname_fail_whenContainsSpecialCharacter() {
-        // given
-        UserRegisterRequest request =
-                new UserRegisterRequest("test@example.com", "ab@c", "ab12!@");
+    // then
+    assertThat(violations).isNotEmpty();
+  }
 
-        // when
-        Set<ConstraintViolation<UserRegisterRequest>> violations = validator.validate(request);
+  @Test
+  @DisplayName("닉네임에 특수문자가 포함되면 검증에 실패한다")
+  void validateNickname_fail_whenContainsSpecialCharacter() {
+    // given
+    UserRegisterRequest request =
+        new UserRegisterRequest("test@example.com", "ab@c", "ab12!@");
 
-        // then
-        assertThat(violations).isNotEmpty();
-    }
+    // when
+    Set<ConstraintViolation<UserRegisterRequest>> violations = validator.validate(request);
 
-    @Test
-    @DisplayName("닉네임이 20자를 초과하면 검증에 실패한다")
-    void validateNickname_fail_whenTooLong() {
-        // given
-        UserRegisterRequest request =
-            new UserRegisterRequest("test@example.com", "a".repeat(21), "ab12!@");
+    // then
+    assertThat(violations).isNotEmpty();
+  }
 
-        // when
-        Set<ConstraintViolation<UserRegisterRequest>> violations = validator.validate(request);
+  @Test
+  @DisplayName("닉네임이 20자를 초과하면 검증에 실패한다")
+  void validateNickname_fail_whenTooLong() {
+    // given
+    UserRegisterRequest request =
+        new UserRegisterRequest("test@example.com", "a".repeat(21), "ab12!@");
 
-        // then
-        assertThat(violations).isNotEmpty();
-    }
+    // when
+    Set<ConstraintViolation<UserRegisterRequest>> violations = validator.validate(request);
 
-    @Test
-    @DisplayName("비밀번호가 null이면 검증에 실패한다")
-    void validatePassword_fail_whenNull() {
-        // given
-        UserRegisterRequest request =
-                new UserRegisterRequest("test@example.com", "monew123", null);
+    // then
+    assertThat(violations).isNotEmpty();
+  }
 
-        // when
-        Set<ConstraintViolation<UserRegisterRequest>> violations = validator.validate(request);
+  @Test
+  @DisplayName("비밀번호가 null이면 검증에 실패한다")
+  void validatePassword_fail_whenNull() {
+    // given
+    UserRegisterRequest request =
+        new UserRegisterRequest("test@example.com", "monew123", null);
 
-        // then
-        assertThat(violations).isNotEmpty();
-    }
+    // when
+    Set<ConstraintViolation<UserRegisterRequest>> violations = validator.validate(request);
 
-    @Test
-    @DisplayName("비밀번호가 비어 있으면 검증에 실패한다")
-    void validatePassword_fail_whenBlank() {
-        // given
-        UserRegisterRequest request =
-                new UserRegisterRequest("test@example.com", "monew123", "");
+    // then
+    assertThat(violations).isNotEmpty();
+  }
 
-        // when
-        Set<ConstraintViolation<UserRegisterRequest>> violations = validator.validate(request);
+  @Test
+  @DisplayName("비밀번호가 비어 있으면 검증에 실패한다")
+  void validatePassword_fail_whenBlank() {
+    // given
+    UserRegisterRequest request =
+        new UserRegisterRequest("test@example.com", "monew123", "");
 
-        // then
-        assertThat(violations).isNotEmpty();
-    }
+    // when
+    Set<ConstraintViolation<UserRegisterRequest>> violations = validator.validate(request);
 
-    @Test
-    @DisplayName("비밀번호 길이가 6자 미만이면 검증에 실패한다")
-    void validatePassword_fail_whenTooShort() {
-        // given
-        UserRegisterRequest request =
-                new UserRegisterRequest("test@example.com", "monew123", "a1!b2");
+    // then
+    assertThat(violations).isNotEmpty();
+  }
 
-        // when
-        Set<ConstraintViolation<UserRegisterRequest>> violations = validator.validate(request);
+  @Test
+  @DisplayName("비밀번호 길이가 6자 미만이면 검증에 실패한다")
+  void validatePassword_fail_whenTooShort() {
+    // given
+    UserRegisterRequest request =
+        new UserRegisterRequest("test@example.com", "monew123", "a1!b2");
 
-        // then
-        assertThat(violations).isNotEmpty();
-    }
+    // when
+    Set<ConstraintViolation<UserRegisterRequest>> violations = validator.validate(request);
 
-    @Test
-    @DisplayName("비밀번호 길이가 20자를 초과하면 검증에 실패한다")
-    void validatePassword_fail_whenTooLong() {
-        // given
-        UserRegisterRequest request =
-                new UserRegisterRequest("test@example.com", "monew123", "abcd1234!@#$efgh5678x");
+    // then
+    assertThat(violations).isNotEmpty();
+  }
 
-        // when
-        Set<ConstraintViolation<UserRegisterRequest>> violations = validator.validate(request);
+  @Test
+  @DisplayName("비밀번호 길이가 20자를 초과하면 검증에 실패한다")
+  void validatePassword_fail_whenTooLong() {
+    // given
+    UserRegisterRequest request =
+        new UserRegisterRequest("test@example.com", "monew123", "abcd1234!@#$efgh5678x");
 
-        // then
-        assertThat(violations).isNotEmpty();
-    }
+    // when
+    Set<ConstraintViolation<UserRegisterRequest>> violations = validator.validate(request);
 
-    @Test
-    @DisplayName("비밀번호에 영문이 없으면 검증에 실패한다")
-    void validatePassword_fail_whenNoAlphabet() {
-        // given
-        UserRegisterRequest request =
-                new UserRegisterRequest("test@example.com", "monew123", "123456!");
+    // then
+    assertThat(violations).isNotEmpty();
+  }
 
-        // when
-        Set<ConstraintViolation<UserRegisterRequest>> violations = validator.validate(request);
+  @Test
+  @DisplayName("비밀번호에 영문이 없으면 검증에 실패한다")
+  void validatePassword_fail_whenNoAlphabet() {
+    // given
+    UserRegisterRequest request =
+        new UserRegisterRequest("test@example.com", "monew123", "123456!");
 
-        // then
-        assertThat(violations).isNotEmpty();
-    }
+    // when
+    Set<ConstraintViolation<UserRegisterRequest>> violations = validator.validate(request);
 
-    @Test
-    @DisplayName("비밀번호에 숫자가 없으면 검증에 실패한다")
-    void validatePassword_fail_whenNoNumber() {
-        // given
-        UserRegisterRequest request =
-                new UserRegisterRequest("test@example.com", "monew123", "abcdef!");
+    // then
+    assertThat(violations).isNotEmpty();
+  }
 
-        // when
-        Set<ConstraintViolation<UserRegisterRequest>> violations = validator.validate(request);
+  @Test
+  @DisplayName("비밀번호에 숫자가 없으면 검증에 실패한다")
+  void validatePassword_fail_whenNoNumber() {
+    // given
+    UserRegisterRequest request =
+        new UserRegisterRequest("test@example.com", "monew123", "abcdef!");
 
-        // then
-        assertThat(violations).isNotEmpty();
-    }
+    // when
+    Set<ConstraintViolation<UserRegisterRequest>> violations = validator.validate(request);
 
-    @Test
-    @DisplayName("비밀번호에 특수문자가 없으면 검증에 실패한다")
-    void validatePassword_fail_whenNoSpecialCharacter() {
-        // given
-        UserRegisterRequest request =
-                new UserRegisterRequest("test@example.com", "monew123", "abc123");
+    // then
+    assertThat(violations).isNotEmpty();
+  }
 
-        // when
-        Set<ConstraintViolation<UserRegisterRequest>> violations = validator.validate(request);
+  @Test
+  @DisplayName("비밀번호에 특수문자가 없으면 검증에 실패한다")
+  void validatePassword_fail_whenNoSpecialCharacter() {
+    // given
+    UserRegisterRequest request =
+        new UserRegisterRequest("test@example.com", "monew123", "abc123");
 
-        // then
-        assertThat(violations).isNotEmpty();
-    }
+    // when
+    Set<ConstraintViolation<UserRegisterRequest>> violations = validator.validate(request);
 
-    @Test
-    @DisplayName("비밀번호에 공백이 포함되면 검증에 실패한다")
-    void validatePassword_fail_whenContainsWhitespace() {
-        // given
-        UserRegisterRequest request =
-                new UserRegisterRequest("test@example.com", "monew123", "ab12 !@");
+    // then
+    assertThat(violations).isNotEmpty();
+  }
 
-        // when
-        Set<ConstraintViolation<UserRegisterRequest>> violations = validator.validate(request);
+  @Test
+  @DisplayName("비밀번호에 공백이 포함되면 검증에 실패한다")
+  void validatePassword_fail_whenContainsWhitespace() {
+    // given
+    UserRegisterRequest request =
+        new UserRegisterRequest("test@example.com", "monew123", "ab12 !@");
 
-        // then
-        assertThat(violations).isNotEmpty();
-    }
+    // when
+    Set<ConstraintViolation<UserRegisterRequest>> violations = validator.validate(request);
+
+    // then
+    assertThat(violations).isNotEmpty();
+  }
 }

--- a/src/test/java/com/springboot/monew/users/dto/request/UserUpdateRequestTest.java
+++ b/src/test/java/com/springboot/monew/users/dto/request/UserUpdateRequestTest.java
@@ -1,4 +1,4 @@
-package com.springboot.monew.users.dto;
+package com.springboot.monew.users.dto.request;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/com/springboot/monew/users/service/UserServiceTest.java
+++ b/src/test/java/com/springboot/monew/users/service/UserServiceTest.java
@@ -9,10 +9,10 @@ import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-import com.springboot.monew.users.dto.UserDto;
-import com.springboot.monew.users.dto.UserLoginRequest;
-import com.springboot.monew.users.dto.UserRegisterRequest;
-import com.springboot.monew.users.dto.UserUpdateRequest;
+import com.springboot.monew.users.dto.request.UserLoginRequest;
+import com.springboot.monew.users.dto.request.UserRegisterRequest;
+import com.springboot.monew.users.dto.request.UserUpdateRequest;
+import com.springboot.monew.users.dto.response.UserDto;
 import com.springboot.monew.users.entity.User;
 import com.springboot.monew.users.exception.UserErrorCode;
 import com.springboot.monew.users.exception.UserException;


### PR DESCRIPTION
## 📌 해당 이슈카드

Closes #105 

## 📌 작업 내용

- `CommentActivityDto`와 `CommentLikeActivityDto`, `UserActivityDto`를 구현하였습니다.
- 사용자 활동 내역 조회에 사용할 임시 dto인 `TemporaryArticleViewDto`를 구현하였습니다.
- dto 패키지 구조를 response와 request로 분리하였습니다.

## 🔧 변경 사항
- 

## 반영 브랜치
`feature/#105/user-activity-dto` -> `dev`

## 💬 기타 참고 사항
- 패키지 구조 변경 때문에 import문이 꼬여서 dto를 사용하고 있던 여러 클래스와 테스트 파일들의 import문 수정 때문에 아마 변경된 파일이 많이 나올겁니다. 
- 그중에서 작업 내용에 있는 dto만 보시면 됩니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **리팩터링**
  * 내부 DTO 패키지 구조를 요청/응답별로 재정리했습니다.

* **신규 기능**
  * 사용자 활동(댓글, 좋아요, 임시기사 조회 등) 요약 출력용 응답 포맷을 추가했습니다.

* **테스트**
  * 사용자 등록 요청 검증에 대한 포괄적인 테스트 스위트를 추가 및 테스트 파일을 재구성/이동했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->