### PR TITLE
[Test] CommentController, CommentLikeController 테스트 코드 추가

### DIFF
--- a/src/main/java/com/springboot/monew/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/springboot/monew/common/exception/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -50,6 +51,20 @@ public class GlobalExceptionHandler {
     log.warn("[MethodArgumentNotValidException] {}", ex.getMessage());
     return ResponseEntity.status(HttpStatus.BAD_REQUEST)
         .body(ErrorResponse.from(HttpStatus.BAD_REQUEST, details, ex));
+  }
+
+  /*
+  Monew-Request-User-Id 헤더 -> 인증 목적으로 사용하기에 UNAUTHORIZED가 맞다고 판단
+  - 로그인 이후 Monew-Request-User-ID 헤더로 로그인한 유저 식별
+  - 로그인/회원가입은 인증 전 단계라 헤더 없음
+  - 그 외 모든 엔드포인트는 @RequestHeader 선언 → 헤더 누락 시 MissingRequestHeaderException 발생 → 401 Unauthorized 반환
+  - 현재는 단일 헤더만 사용하는 구조라 위 방식으로 처리하지만, 추후 Spring Security로 인증 로직 이관 예정 (강사님 말씀)
+   */
+  @ExceptionHandler(MissingRequestHeaderException.class)
+  public ResponseEntity<ErrorResponse> handleMissingHeader(MissingRequestHeaderException ex) {
+    log.warn("[MissingRequestHeaderException] {}", ex.getMessage());
+    return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+        .body(ErrorResponse.from(HttpStatus.UNAUTHORIZED, ex));
   }
 
   // 클라이언트 요청 오류

--- a/src/test/java/com/springboot/monew/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/springboot/monew/comment/controller/CommentControllerTest.java
@@ -3,6 +3,7 @@ package com.springboot.monew.comment.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -18,9 +19,12 @@ import com.springboot.monew.comment.dto.CommentPageRequest;
 import com.springboot.monew.comment.dto.CommentRegisterRequest;
 import com.springboot.monew.comment.dto.CommentUpdateRequest;
 import com.springboot.monew.comment.dto.CursorPageResponseCommentDto;
+import com.springboot.monew.comment.exception.CommentErrorCode;
+import com.springboot.monew.comment.exception.CommentException;
 import com.springboot.monew.comment.service.CommentService;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -85,7 +89,7 @@ class CommentControllerTest {
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(request)))
         .andExpect(status().isBadRequest())
-        .andExpect(jsonPath("$.details.content").value("내용을 입력해주세요."));
+        .andExpect(jsonPath("$.details.content[0]").value("내용을 입력해주세요."));
 
     // 잘못된 요청일 경우 service 실행 X
     then(commentService).should(never()).create(request);
@@ -104,7 +108,20 @@ class CommentControllerTest {
     then(commentService).should().softDelete(commentId);
   }
 
-  // 논리 삭제 실패 테스트 케이스는 서비스 테스트에서 구현할 예정
+  @Test
+  @DisplayName("이미 논리 삭제가 된 댓글은 실패한다")
+  void softDelete_실패() throws Exception {
+    // given
+    UUID commentId = UUID.randomUUID();
+
+    willThrow(new CommentException(CommentErrorCode.COMMENT_ALREADY_DELETED, Map.of("commentId", commentId)))
+        .given(commentService).softDelete(commentId);
+
+    // when & then
+    mockMvc.perform(delete("/api/comments/{commentId}", commentId))
+        .andExpect(status().isBadRequest());
+
+  }
 
   @Test
   @DisplayName("댓글 수정 성공 시 200을 반환한다.")
@@ -172,6 +189,25 @@ class CommentControllerTest {
         .andExpect(status().isUnauthorized());
 
     then(commentService).should(never()).update(any(), any(), any());
+  }
+
+  @Test
+  @DisplayName("본인 댓글이 아닌 것들 수정하려고 하면 수정에 실패한다.")
+  void update_실패_본인댓글아님() throws Exception {
+    // given
+    UUID commentId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+    CommentUpdateRequest request = new CommentUpdateRequest("수정할 댓글");
+
+    willThrow(new CommentException(CommentErrorCode.COMMENT_NOT_OWNED_BY_USER, Map.of("commentId", commentId)))
+        .given(commentService).update(commentId, userId, request);
+
+    // when & then
+    mockMvc.perform(patch("/api/comments/{commentId}", commentId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .header("Monew-Request-User-ID", userId)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isForbidden());
   }
 
   @Test

--- a/src/test/java/com/springboot/monew/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/springboot/monew/comment/controller/CommentControllerTest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -67,8 +68,8 @@ class CommentControllerTest {
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(request)))
         .andExpect(status().isCreated())
-        .andExpect(jsonPath("$.id").value(response.id().toString()));
-
+        .andExpect(jsonPath("$.id").value(response.id().toString()))
+        .andExpect(header().string("Location", "/api/comments/" + response.id()));
   }
 
   @Test
@@ -155,7 +156,6 @@ class CommentControllerTest {
 
     // 잘못된 요청일 경우 service 실행 X
     then(commentService).should(never()).update(commentId, userId, request);
-    // then
   }
 
   @Test

--- a/src/test/java/com/springboot/monew/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/springboot/monew/comment/controller/CommentControllerTest.java
@@ -159,6 +159,22 @@ class CommentControllerTest {
   }
 
   @Test
+  @DisplayName("Monew-Request-User-ID 헤더 누락 시 401을 반환한다")
+  void update_실패_헤더누락() throws Exception {
+    // given
+    UUID commentId = UUID.randomUUID();
+    CommentUpdateRequest request = new CommentUpdateRequest("수정한 댓글");
+
+    // when & then
+    mockMvc.perform(patch("/api/comments/{commentId}", commentId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isUnauthorized());
+
+    then(commentService).should(never()).update(any(), any(), any());
+  }
+
+  @Test
   @DisplayName("댓글 물리 삭제 시 204를 반환한다.")
   void hardDelete_성공() throws Exception {
     // given

--- a/src/test/java/com/springboot/monew/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/springboot/monew/comment/controller/CommentControllerTest.java
@@ -1,36 +1,225 @@
 package com.springboot.monew.comment.controller;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.springboot.monew.comment.dto.CommentDto;
+import com.springboot.monew.comment.dto.CommentPageRequest;
+import com.springboot.monew.comment.dto.CommentRegisterRequest;
+import com.springboot.monew.comment.dto.CommentUpdateRequest;
+import com.springboot.monew.comment.dto.CursorPageResponseCommentDto;
+import com.springboot.monew.comment.service.CommentService;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
 
+
+@WebMvcTest(CommentController.class)
 class CommentControllerTest {
 
+  @Autowired
+  MockMvc mockMvc;
+
+  @Autowired
+  ObjectMapper objectMapper;
+
+  @MockitoBean
+  private CommentService commentService;
+
   @Test
-  void list() {
+  @DisplayName("댓글이 등록이 성공하면 201을 반환한다")
+  void create_성공() throws Exception {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID articleId = UUID.randomUUID();
+    CommentRegisterRequest request = new CommentRegisterRequest(articleId, userId, "테스트 댓글");
+
+    CommentDto response = new CommentDto(
+        UUID.randomUUID(),
+        articleId,
+        userId,
+        "테스트 유저",
+        "테스트 댓글",
+        0L,
+        false,
+        Instant.now()
+        );
+
+    given(commentService.create(request)).willReturn(response);
+    // when & then
+    mockMvc.perform(post("/api/comments")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.id").value(response.id().toString()));
+
   }
 
   @Test
-  void create() {
+  @DisplayName("댓글 내용이 없다면 등록에 실패한다")
+  void create_실패() throws Exception {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID articleId = UUID.randomUUID();
+    CommentRegisterRequest request = new CommentRegisterRequest(articleId, userId, "");
+
+    // when & then
+    mockMvc.perform(post("/api/comments")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.details.content").value("내용을 입력해주세요."));
+
+    // 잘못된 요청일 경우 service 실행 X
+    then(commentService).should(never()).create(request);
   }
 
   @Test
-  void like() {
+  @DisplayName("댓글 논리 삭제 시 204를 반환한다.")
+  void softDelete_성공() throws Exception {
+    // given
+    UUID commentId = UUID.randomUUID();
+
+    // when & then
+    mockMvc.perform(delete("/api/comments/{commentId}", commentId))
+        .andExpect(status().isNoContent());
+
+    then(commentService).should().softDelete(commentId);
+  }
+
+  // 논리 삭제 실패 테스트 케이스는 서비스 테스트에서 구현할 예정
+
+  @Test
+  @DisplayName("댓글 수정 성공 시 200을 반환한다.")
+  void update_성공() throws Exception {
+    // given
+    UUID commentId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+
+    CommentUpdateRequest request = new CommentUpdateRequest("수정한 테스트 댓글");
+
+    CommentDto response = new CommentDto(
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        userId,
+        "닉네임",
+        "수정한 테스트 댓글",
+        1L,
+        false,
+        Instant.now()
+    );
+    given(commentService.update(commentId, userId, request)).willReturn(response);
+    // when & then
+    mockMvc.perform(patch("/api/comments/{commentId}", commentId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .header("Monew-Request-User-ID", userId)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content").value("수정한 테스트 댓글"));
+
+    then(commentService).should().update(commentId, userId, request);
   }
 
   @Test
-  void unlike() {
+  @DisplayName("댓글 수정 실패 시 400을 반환한다.")
+  void update_실패() throws Exception {
+    // given
+    UUID commentId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+
+    CommentUpdateRequest request = new CommentUpdateRequest("");
+
+    // when & then
+    mockMvc.perform(patch("/api/comments/{commentId}", commentId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .header("Monew-Request-User-ID", userId)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.details.content").value("내용을 입력해주세요."));
+
+    // 잘못된 요청일 경우 service 실행 X
+    then(commentService).should(never()).update(commentId, userId, request);
+    // then
   }
 
   @Test
-  void softDelete() {
+  @DisplayName("댓글 물리 삭제 시 204를 반환한다.")
+  void hardDelete_성공() throws Exception {
+    // given
+    UUID commentId = UUID.randomUUID();
+
+    // when & then
+    mockMvc.perform(delete("/api/comments/{commentId}/hard", commentId))
+        .andExpect(status().isNoContent());
+
+    then(commentService).should().hardDelete(commentId);
+  }
+
+  // 물리 삭제 실패 test Case는 비즈니스 로직이라 서비스 테스트에서 해야한다고 판단
+
+  @Test
+  @DisplayName("댓글 목록 조회 성공")
+  void list_성공() throws Exception {
+    // given
+    UUID articleId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+    CommentDto comment1 = new CommentDto(UUID.randomUUID(), articleId, UUID.randomUUID(), "유저1",
+        "댓글1", 0L, false, Instant.now());
+    CommentDto comment2 = new CommentDto(UUID.randomUUID(), articleId, UUID.randomUUID(), "유저2",
+        "댓글2", 1L, true, Instant.now());
+
+    CursorPageResponseCommentDto<CommentDto> response = new CursorPageResponseCommentDto<>(
+        List.of(comment1, comment2), null, null, 2, 2, false
+    );
+
+    given(commentService.list(any(CommentPageRequest.class), any(UUID.class))).willReturn(response);
+
+    // when & then
+    mockMvc.perform(get("/api/comments")
+            .header("Monew-Request-User-ID", userId)
+            .param("articleId", articleId.toString())
+            .param("orderBy", "createdAt")
+            .param("direction", "DESC"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content.length()").value(2))
+        .andExpect(jsonPath("$.content[0].content").value("댓글1"))
+        .andExpect(jsonPath("$.content[1].content").value("댓글2"))
+        .andExpect(jsonPath("$.hasNext").value(false));
+
+    then(commentService).should().list(any(CommentPageRequest.class), any(UUID.class));
   }
 
   @Test
-  void update() {
-  }
+  @DisplayName("댓글 목록 조회 실패 - 잘못된 정렬 속성")
+  void list_실패() throws Exception {
+    // given
+    UUID articleId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
 
-  @Test
-  void hardDelete() {
+    // when & then
+    mockMvc.perform(get("/api/comments")
+            .header("Monew-Request-User-ID", userId)
+            .param("articleId", articleId.toString())
+            .param("orderBy", "잘못된 정렬 방향")
+            .param("direction", "DESC"))
+        .andExpect(status().isBadRequest());
+
+    then(commentService).should(never()).list(any(CommentPageRequest.class), any(UUID.class));
   }
 }

--- a/src/test/java/com/springboot/monew/comment/controller/CommentLikeControllerTest.java
+++ b/src/test/java/com/springboot/monew/comment/controller/CommentLikeControllerTest.java
@@ -1,16 +1,111 @@
 package com.springboot.monew.comment.controller;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.springboot.monew.comment.dto.CommentLikeDto;
+import com.springboot.monew.comment.service.CommentLikeService;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
 
+@WebMvcTest(CommentLikeController.class)
 class CommentLikeControllerTest {
 
+  @Autowired
+  MockMvc mockMvc;
+
+  @Autowired
+  ObjectMapper objectMapper;
+
+  @MockitoBean
+  private CommentLikeService commentLikeService;
+
   @Test
-  void like() {
+  @DisplayName("댓글 좋아요 성공 시 201을 반환한다.")
+  void like_성공() throws Exception {
+    // given
+    UUID commentId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+
+    CommentLikeDto response = new CommentLikeDto(
+        UUID.randomUUID(),
+        userId,
+        Instant.now(),
+        commentId,
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        "작성자닉네임",
+        "댓글내용",
+        0,
+        Instant.now()
+    );
+
+    given(commentLikeService.like(commentId, userId)).willReturn(response);
+    // when & then
+    mockMvc.perform(post("/api/comments/{commentId}/comment-likes", commentId)
+            .header("Monew-Request-User-ID", userId))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.id").value(response.id().toString()));
+
+    then(commentLikeService).should().like(commentId, userId);
+  }
+
+  // UserNotFoundException, CommentNotFoundException, CommentLikeAlreadyExistsException 등의
+  // 실패 테스트 케이스는 서비스에서 테스트하는 게 맞다고 판단
+
+  @Test
+  @DisplayName("Monew-Request-User-ID 헤더 누락 시 401을 반환한다")
+  void like_실패_헤더누락() throws Exception {
+    // given
+    UUID commentId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+
+    // when & then
+    mockMvc.perform(post("/api/comments/{commentId}/comment-likes", commentId))
+        .andExpect(status().isUnauthorized());
+
+    then(commentLikeService).should(never()).like(commentId, userId);
   }
 
   @Test
-  void unlike() {
+  @DisplayName("댓글 좋아요 취소 성공 시 204를 반환한다")
+  void unlike_성공() throws Exception {
+    // given
+    UUID commentId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+
+    // when & then
+    mockMvc.perform(delete("/api/comments/{commentId}/comment-likes", commentId)
+            .header("Monew-Request-User-ID", userId))
+        .andExpect(status().isOk());
+
+    then(commentLikeService).should().unlike(commentId, userId);
+  }
+
+  // UserNotFoundException, CommentNotFoundException, CommentLikeAlreadyExistsException 등의
+  // 실패 테스트 케이스는 서비스에서 테스트하는 게 맞다고 판단
+
+  @Test
+  @DisplayName("Monew-Request-User-ID 헤더 누락 시 401을 반환한다")
+  void unlike_실패_헤더누락() throws Exception {
+    // given
+    UUID commentId = UUID.randomUUID();
+
+    // when & then
+    mockMvc.perform(delete("/api/comments/{commentId}/comment-likes", commentId))
+        .andExpect(status().isUnauthorized());
   }
 }

--- a/src/test/java/com/springboot/monew/comment/controller/CommentLikeControllerTest.java
+++ b/src/test/java/com/springboot/monew/comment/controller/CommentLikeControllerTest.java
@@ -1,0 +1,16 @@
+package com.springboot.monew.comment.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class CommentLikeControllerTest {
+
+  @Test
+  void like() {
+  }
+
+  @Test
+  void unlike() {
+  }
+}

--- a/src/test/java/com/springboot/monew/comment/controller/CommentLikeControllerTest.java
+++ b/src/test/java/com/springboot/monew/comment/controller/CommentLikeControllerTest.java
@@ -2,6 +2,7 @@ package com.springboot.monew.comment.controller;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -10,8 +11,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.springboot.monew.comment.dto.CommentLikeDto;
+import com.springboot.monew.comment.exception.CommentErrorCode;
+import com.springboot.monew.comment.exception.CommentException;
 import com.springboot.monew.comment.service.CommentLikeService;
+import com.springboot.monew.users.exception.UserErrorCode;
+import com.springboot.monew.users.exception.UserException;
 import java.time.Instant;
+import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -51,6 +57,7 @@ class CommentLikeControllerTest {
     );
 
     given(commentLikeService.like(commentId, userId)).willReturn(response);
+
     // when & then
     mockMvc.perform(post("/api/comments/{commentId}/comment-likes", commentId)
             .header("Monew-Request-User-ID", userId))
@@ -60,11 +67,63 @@ class CommentLikeControllerTest {
     then(commentLikeService).should().like(commentId, userId);
   }
 
-  // UserNotFoundException, CommentNotFoundException, CommentLikeAlreadyExistsException 등의
-  // 실패 테스트 케이스는 서비스에서 테스트하는 게 맞다고 판단
+  @Test
+  @DisplayName("존재하지 않는 댓글에 좋아요 시 404를 반환한다.")
+  void like_실패_댓글없음() throws Exception {
+    // given
+    UUID commentId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+
+    given(commentLikeService.like(commentId, userId))
+        .willThrow(new CommentException(CommentErrorCode.COMMENT_NOT_FOUND, Map.of("commentId", commentId)));
+
+    // when & then
+    mockMvc.perform(post("/api/comments/{commentId}/comment-likes", commentId)
+            .header("Monew-Request-User-ID", userId))
+        .andExpect(status().isNotFound());
+
+    then(commentLikeService).should().like(commentId, userId);
+  }
 
   @Test
-  @DisplayName("Monew-Request-User-ID 헤더 누락 시 401을 반환한다")
+  @DisplayName("존재하지 않는 유저가 좋아요 시 404를 반환한다.")
+  void like_실패_유저없음() throws Exception {
+    // given
+    UUID commentId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+
+    given(commentLikeService.like(commentId, userId))
+        .willThrow(new UserException(UserErrorCode.USER_NOT_FOUND, Map.of("userId", userId)));
+
+    // when & then
+    mockMvc.perform(post("/api/comments/{commentId}/comment-likes", commentId)
+            .header("Monew-Request-User-ID", userId))
+        .andExpect(status().isNotFound());
+
+    then(commentLikeService).should().like(commentId, userId);
+  }
+
+  @Test
+  @DisplayName("중복 좋아요 시 409를 반환한다.")
+  void like_실패_중복좋아요() throws Exception {
+    // given
+    UUID commentId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+
+    given(commentLikeService.like(commentId, userId))
+        .willThrow(new CommentException(CommentErrorCode.COMMENT_LIKE_ALREADY_EXISTS,
+            Map.of("commentId", commentId, "userId", userId)));
+
+    // when & then
+    mockMvc.perform(post("/api/comments/{commentId}/comment-likes", commentId)
+            .header("Monew-Request-User-ID", userId))
+        .andExpect(status().isConflict());
+
+    then(commentLikeService).should().like(commentId, userId);
+  }
+
+  @Test
+  @DisplayName("Monew-Request-User-ID 헤더 누락 시 401을 반환한다.")
   void like_실패_헤더누락() throws Exception {
     // given
     UUID commentId = UUID.randomUUID();
@@ -78,7 +137,7 @@ class CommentLikeControllerTest {
   }
 
   @Test
-  @DisplayName("댓글 좋아요 취소 성공 시 204를 반환한다")
+  @DisplayName("댓글 좋아요 취소 성공 시 200을 반환한다.")
   void unlike_성공() throws Exception {
     // given
     UUID commentId = UUID.randomUUID();
@@ -92,17 +151,53 @@ class CommentLikeControllerTest {
     then(commentLikeService).should().unlike(commentId, userId);
   }
 
-  // UserNotFoundException, CommentNotFoundException, CommentLikeAlreadyExistsException 등의
-  // 실패 테스트 케이스는 서비스에서 테스트하는 게 맞다고 판단
+  @Test
+  @DisplayName("존재하지 않는 댓글에 좋아요 취소 시 404를 반환한다.")
+  void unlike_실패_댓글없음() throws Exception {
+    // given
+    UUID commentId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+
+    willThrow(new CommentException(CommentErrorCode.COMMENT_NOT_FOUND, Map.of("commentId", commentId)))
+        .given(commentLikeService).unlike(commentId, userId);
+
+    // when & then
+    mockMvc.perform(delete("/api/comments/{commentId}/comment-likes", commentId)
+            .header("Monew-Request-User-ID", userId))
+        .andExpect(status().isNotFound());
+
+    then(commentLikeService).should().unlike(commentId, userId);
+  }
 
   @Test
-  @DisplayName("Monew-Request-User-ID 헤더 누락 시 401을 반환한다")
+  @DisplayName("좋아요를 누르지 않은 댓글에 좋아요 취소 시 404를 반환한다.")
+  void unlike_실패_좋아요없음() throws Exception {
+    // given
+    UUID commentId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+
+    willThrow(new CommentException(CommentErrorCode.COMMENT_LIKE_NOT_FOUND, Map.of("commentId", commentId)))
+        .given(commentLikeService).unlike(commentId, userId);
+
+    // when & then
+    mockMvc.perform(delete("/api/comments/{commentId}/comment-likes", commentId)
+            .header("Monew-Request-User-ID", userId))
+        .andExpect(status().isNotFound());
+
+    then(commentLikeService).should().unlike(commentId, userId);
+  }
+
+  @Test
+  @DisplayName("Monew-Request-User-ID 헤더 누락 시 401을 반환한다.")
   void unlike_실패_헤더누락() throws Exception {
     // given
     UUID commentId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
 
     // when & then
     mockMvc.perform(delete("/api/comments/{commentId}/comment-likes", commentId))
         .andExpect(status().isUnauthorized());
+
+    then(commentLikeService).should(never()).unlike(commentId, userId);
   }
 }

--- a/src/test/java/com/springboot/monew/comment/controller/CommentLikeControllerTest.java
+++ b/src/test/java/com/springboot/monew/comment/controller/CommentLikeControllerTest.java
@@ -4,6 +4,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -133,7 +134,8 @@ class CommentLikeControllerTest {
     mockMvc.perform(post("/api/comments/{commentId}/comment-likes", commentId))
         .andExpect(status().isUnauthorized());
 
-    then(commentLikeService).should(never()).like(commentId, userId);
+    // 헤더 누락 실패 시에는 서비스 호출 X
+    verifyNoInteractions(commentLikeService);
   }
 
   @Test
@@ -198,6 +200,7 @@ class CommentLikeControllerTest {
     mockMvc.perform(delete("/api/comments/{commentId}/comment-likes", commentId))
         .andExpect(status().isUnauthorized());
 
-    then(commentLikeService).should(never()).unlike(commentId, userId);
+    // 헤더 누락 실패 시에는 서비스가 아예 호출이 되지 않아야 한다
+    verifyNoInteractions(commentLikeService);
   }
 }

--- a/src/test/java/com/springboot/monew/comment/controller/CommentLikeControllerTest.java
+++ b/src/test/java/com/springboot/monew/comment/controller/CommentLikeControllerTest.java
@@ -27,9 +27,6 @@ class CommentLikeControllerTest {
   @Autowired
   MockMvc mockMvc;
 
-  @Autowired
-  ObjectMapper objectMapper;
-
   @MockitoBean
   private CommentLikeService commentLikeService;
 


### PR DESCRIPTION
## 관련 이슈 번호
Closes #192 , #202, #206, #207, #205, #203, #204 


## 📌 작업 내용                                                                                     
  - MissingRequestHeaderException 핸들러 추가 및 CommentLikeController 테스트 작성         
           
                                                                                                      
## 🔧 변경 사항                                                                                     
  - `GlobalExceptionHandler` — `MissingRequestHeaderException` 핸들러 추가                            
    - `Monew-Request-User-ID` 헤더 누락 시 401 Unauthorized 반환                                      
    - 인증 헤더가 선언된 엔드포인트에서만 발생하므로 조건 분기 없이 401 반환                          
  - `CommentControllerTest` — 테스트 작성
    - `create_성공` : 201 반환, 응답 바디 및 Location 헤더 검증                                       
    - `create_실패` : 유효하지 않은 요청 시 400 반환 및 서비스 미호출 검증                            
    - `update_성공` : 200 반환 및 응답 바디 검증                                                      
    - `update_실패` : 유효하지 않은 요청 시 400 반환 및 서비스 미호출 검증                            
    - `update_실패_헤더누락` : 헤더 누락 시 401 반환 및 서비스 미호출 검증                            
    - `softDelete_성공` : 204 반환 및 서비스 호출 검증                                                
    - `hardDelete_성공` : 204 반환 및 서비스 호출 검증                                                
    - `list_성공` : 200 반환 및 응답 바디 검증                                                        
    - `list_실패` : 잘못된 정렬 속성 시 400 반환 및 서비스 미호출 검증                                
  - `CommentLikeControllerTest` — 테스트 작성                                                         
    - `like_성공` : 201 반환 및 응답 바디 검증                                                        
    - `like_실패_헤더누락` : 헤더 누락 시 401 반환 및 서비스 미호출 검증                              
    - `unlike_성공` : 204 반환 및 서비스 호출 검증  


## 반영 브랜치
`feature/#192/comment-controller-test` -> `dev`


## 💬 기타 참고 사항
- `Monew-Request-User-ID` 헤더는 로그인한 유저 식별 목적으로 사용하는 인증 헤더                     
  - 로그인/회원가입 등 인증 전 단계 엔드포인트는 `@RequestHeader` 미선언 → 해당 예외 자체가 발생하지  
  않음                                                                                                
  - 인증이 필요한 엔드포인트에서만 `@RequestHeader` 선언 → 누락 시 `MissingRequestHeaderException`    
  발생 → 401 반환                                                                                     
  - 추후 Spring Security 도입 시 인증 로직 이관할 수 있다고 합니다 아직 안배워서 모르겠어용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 요청 헤더 누락 시 경고 로그와 함께 401 Unauthorized 응답 반환으로 오류 처리 개선

* **테스트**
  * 댓글 엔드포인트에 대한 포괄적 웹 계층 테스트 추가 (생성/수정/삭제/목록, 페이징, 유효성 검사, 권한·금지 시나리오)
  * 댓글 좋아요 엔드포인트 테스트 추가 (좋아요/취소 성공·실패, 중복/대상 없음 처리, 인증 헤더 누락 검증)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->