### PR TITLE
feat: 확인 완료된 오래된 알림 삭제 기능 구현

### DIFF
--- a/src/main/java/com/springboot/monew/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/springboot/monew/notification/repository/NotificationRepository.java
@@ -2,7 +2,6 @@ package com.springboot.monew.notification.repository;
 
 import com.springboot.monew.notification.entity.Notification;
 import java.time.Instant;
-import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -36,4 +35,11 @@ public interface NotificationRepository extends JpaRepository<Notification, UUID
   int bulkUpdateConfirmed(UUID userId, Instant updatedAt);
 
   long countAllByUser_IdAndConfirmedIsFalse(UUID userId);
+
+  @Modifying
+  @Query(value = "delete from notifications "
+      + "where confirmed = true and updated_at < :threshold "
+      + "limit :limit",
+      nativeQuery = true)
+  long deleteOutdatedByChunk(Instant threshold, long limit);
 }

--- a/src/main/java/com/springboot/monew/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/springboot/monew/notification/repository/NotificationRepository.java
@@ -37,9 +37,11 @@ public interface NotificationRepository extends JpaRepository<Notification, UUID
   long countAllByUser_IdAndConfirmedIsFalse(UUID userId);
 
   @Modifying
-  @Query(value = "delete from notifications "
+  @Query(value = "delete from notifications where id in ("
+      + "select id "
+      + "from notifications "
       + "where confirmed = true and updated_at < :threshold "
-      + "limit :limit",
+      + "limit :limit)",
       nativeQuery = true)
   long deleteOutdatedByChunk(Instant threshold, long limit);
 }

--- a/src/main/java/com/springboot/monew/notification/service/NotificationService.java
+++ b/src/main/java/com/springboot/monew/notification/service/NotificationService.java
@@ -60,6 +60,10 @@ public class NotificationService {
     notificationRepository.bulkUpdateConfirmed(userId, Instant.now());
   }
 
+  public long deleteByChunk(Instant threshold, int chunk) {
+    return notificationRepository.deleteOutdatedByChunk(threshold, chunk);
+  }
+
   private CursorPageResponse<NotificationDto> toCursorPage(Slice<Notification> results,
       UUID userId) {
     List<Notification> entities = results.getContent();

--- a/src/test/java/com/springboot/monew/notification/repository/NotificationRepositoryTest.java
+++ b/src/test/java/com/springboot/monew/notification/repository/NotificationRepositoryTest.java
@@ -7,9 +7,11 @@ import com.springboot.monew.notification.entity.Notification;
 import com.springboot.monew.notification.entity.ResourceType;
 import com.springboot.monew.users.entity.User;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.function.Supplier;
 import org.assertj.core.api.Assertions;
 import org.instancio.Instancio;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,7 +27,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 public class NotificationRepositoryTest extends BaseRepositoryTest {
 
   @Autowired
-  private NotificationRepository notificationRepository;
+  private NotificationRepository repository;
 
   @BeforeEach
   void setUp() {
@@ -46,13 +48,13 @@ public class NotificationRepositoryTest extends BaseRepositoryTest {
     clear();
 
     // when
-    notificationRepository.saveAndFlush(expected);
+    repository.saveAndFlush(expected);
     printQueries();
     ensureQueryCount(1);
     clear();
 
     // then
-    Notification actual = notificationRepository.findById(expected.getId()).orElseThrow();
+    Notification actual = repository.findById(expected.getId()).orElseThrow();
     Assertions.assertThat(actual)
         .usingRecursiveComparison()
         .ignoringFields("user", "commentLike", "interest")
@@ -74,7 +76,7 @@ public class NotificationRepositoryTest extends BaseRepositoryTest {
         .build();
 
     // when & then
-    Assertions.assertThatThrownBy(() -> notificationRepository.saveAndFlush(expected))
+    Assertions.assertThatThrownBy(() -> repository.saveAndFlush(expected))
         .isInstanceOf(DataIntegrityViolationException.class)
         .rootCause()
         .message()
@@ -93,7 +95,7 @@ public class NotificationRepositoryTest extends BaseRepositoryTest {
         .build();
 
     // when & then
-    Assertions.assertThatThrownBy(() -> notificationRepository.saveAndFlush(expected))
+    Assertions.assertThatThrownBy(() -> repository.saveAndFlush(expected))
         .isInstanceOf(DataIntegrityViolationException.class)
         .rootCause()
         .message()
@@ -113,13 +115,13 @@ public class NotificationRepositoryTest extends BaseRepositoryTest {
     clear();
 
     // when
-    notificationRepository.saveAndFlush(expected);
+    repository.saveAndFlush(expected);
     printQueries();
     ensureQueryCount(1);
     clear();
 
     // then
-    Notification actual = notificationRepository.findById(expected.getId()).orElseThrow();
+    Notification actual = repository.findById(expected.getId()).orElseThrow();
     Assertions.assertThat(actual)
         .usingRecursiveComparison()
         .ignoringFields("user", "commentLike", "interest")
@@ -141,7 +143,7 @@ public class NotificationRepositoryTest extends BaseRepositoryTest {
         .build();
 
     // when & then
-    Assertions.assertThatThrownBy(() -> notificationRepository.saveAndFlush(expected))
+    Assertions.assertThatThrownBy(() -> repository.saveAndFlush(expected))
         .isInstanceOf(DataIntegrityViolationException.class)
         .rootCause()
         .message()
@@ -163,7 +165,7 @@ public class NotificationRepositoryTest extends BaseRepositoryTest {
     ReflectionTestUtils.setField(expected, "resourceType", ResourceType.INTEREST);
 
     // when & then
-    Assertions.assertThatThrownBy(() -> notificationRepository.saveAndFlush(expected))
+    Assertions.assertThatThrownBy(() -> repository.saveAndFlush(expected))
         .isInstanceOf(DataIntegrityViolationException.class)
         .rootCause()
         .message()
@@ -187,7 +189,7 @@ public class NotificationRepositoryTest extends BaseRepositoryTest {
 
     // when
     Pageable pageable = PageRequest.of(0, pageSize);
-    Slice<Notification> result = notificationRepository.findByCursor(null, null, user.getId(),
+    Slice<Notification> result = repository.findByCursor(null, null, user.getId(),
         pageable);
     List<Notification> actual = result.getContent();
     printQueries();
@@ -232,7 +234,7 @@ public class NotificationRepositoryTest extends BaseRepositoryTest {
 
     // when & then
     while (hasNext) {
-      Slice<Notification> result = notificationRepository.findByCursor(cursor, after, userA.getId(),
+      Slice<Notification> result = repository.findByCursor(cursor, after, userA.getId(),
           pageable);
       List<Notification> actual = result.getContent();
 
@@ -271,18 +273,47 @@ public class NotificationRepositoryTest extends BaseRepositoryTest {
     // when
     List<UUID> ids = getIds(expected);
     UUID userId = expected.get(0).getUser().getId();
-    int updatedSuccessCount = notificationRepository.bulkUpdateConfirmed(userId, updatedAt);
+    int updatedSuccessCount = repository.bulkUpdateConfirmed(userId, updatedAt);
     ensureQueryCount(1);
     printQueries();
 
     // then
     Assertions.assertThat(updatedSuccessCount).isEqualTo(num);
-    List<Notification> actual = notificationRepository.findAll();
+    List<Notification> actual = repository.findAll();
     Assertions.assertThat(actual)
         .usingRecursiveComparison()
         .ignoringFields("user", "interest")
         .ignoringCollectionOrder()
         .withEqualsForType(this::compareInstant, Instant.class)
         .isEqualTo(expected);
+  }
+
+  @Test
+  @DisplayName("""
+      조건에 맞는 데이터들 삭제 성공
+      확인한 날짜를 임의로 1~2주 전으로 저장한다
+      확인한 날짜가 1주일 지났으면 삭제 대상이다""")
+  void successToDelete() {
+    // given
+    int size = 100;
+    Instant now = Instant.now();
+    Instant threshold = now.minus(7, ChronoUnit.DAYS);
+    Instant twoWeekAgo = threshold.minus(7, ChronoUnit.DAYS);
+    Supplier<Instant> past = () -> Instancio.gen().temporal().instant().range(twoWeekAgo, now).get();
+    List<Notification> entities = testEntityManager.generateNotifications(size);
+    entities.forEach(n -> n.updateConfirmed(past.get()));
+    long expected = entities.stream().filter(n -> threshold.isAfter(n.getUpdatedAt())).count();
+    em.flush();
+    clear();
+
+    // when
+    long actual = repository.deleteOutdatedByChunk(threshold, size);
+    ensureQueryCount(1);
+    printQueries();
+
+    // then
+    Assertions.assertThat(actual).isEqualTo(expected);
+    List<Notification> results = repository.findAll();
+    Assertions.assertThat(results.size()).isEqualTo(size - expected);
   }
 }


### PR DESCRIPTION
## 📌 작업 내용
- 확인 완료된 알림 중 1주일 이상 지난 데이터를 주기적으로 삭제하는 기능을 추가했습니다.
- `NotificationRepository`에 `deleteChunkByUserId` 메서드를 추가하여 특정 임계값보다 오래된 확인 완료 알림을 일괄 삭제하도록 구현했습니다.
- `NotificationServer` 에서 이를 호출하는 `deleteByChunk` 를 추가했다.
- 해당 기능의 정확성을 보장하기 위해 `NotificationRepositoryTest`에 `successToDelete` 테스트 케이스를 작성했습니다.

## 🔧 변경 사항
- 

## 반영 브랜치
`feature/` -> `dev`

## 💬 기타 참고 사항
- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 확인된 알림을 지정한 시간 이전 기준으로 청크 단위로 일괄 삭제하는 기능 추가
  * 삭제 시 한 번에 처리하는 항목 수를 제한해 대량 삭제를 분할 실행 가능

* **테스트**
  * 청크 단위 일괄 삭제 동작을 검증하는 단위 테스트 추가 (삭제 건수 및 잔여 항목 검증)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->