### PR TITLE
[Feat] 사용자 활동 내역 MongoDB Document 모델 구현 및 로컬 실행 환경 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-batch'
-//    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
     implementation 'com.rometools:rome:2.1.0'
     implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'io.github.openfeign.querydsl:querydsl-jpa:7.1'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  mongodb:
+    image: mongo:latest
+    container_name: monew-mongo
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo-data:/data/db
+
+volumes:
+  mongo-data:

--- a/src/main/java/com/springboot/monew/users/document/UserActivityDocument.java
+++ b/src/main/java/com/springboot/monew/users/document/UserActivityDocument.java
@@ -1,0 +1,95 @@
+package com.springboot.monew.users.document;
+
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Document(collection = "user_activities")
+public class UserActivityDocument {
+  @Id
+  private UUID userId;
+
+  private String email;
+
+  private String nickname;
+
+  private Instant createdAt;
+
+  private List<SubscriptionItem> subscriptions = new ArrayList<>();
+
+  private List<CommentItem> comments = new ArrayList<>();
+
+  private List<CommentLikeItem> commentLikes = new ArrayList<>();
+
+  private List<ArticleViewItem> articleViews = new ArrayList<>();
+
+  public UserActivityDocument(UUID userId, String email, String nickname, Instant createdAt) {
+    this.userId = userId;
+    this.email = email;
+    this.nickname = nickname;
+    this.createdAt = createdAt;
+  }
+
+  public record SubscriptionItem(
+      UUID id,
+      UUID interestId,
+      String interestName,
+      List<String> interestKeywords,
+      Long interestSubscriberCount,
+      Instant createdAt
+  ) {
+  }
+
+  public record CommentItem(
+      UUID id,
+      UUID articleId,
+      String articleTitle,
+      UUID userId,
+      String userNickname,
+      String content,
+      Long likeCount,
+      Instant createdAt
+  ) {
+  }
+
+  public record CommentLikeItem(
+      UUID id,
+      Instant createdAt,
+      UUID commentId,
+      UUID articleId,
+      String articleTitle,
+      UUID commentUserId,
+      String commentUserNickname,
+      String commentContent,
+      Long commentLikeCount,
+      Instant commentCreatedAt
+  ) {
+  }
+
+  public record ArticleViewItem(
+      UUID id,
+      UUID viewedBy,
+      Instant createdAt,
+      UUID articleId,
+      String source,
+      String sourceUrl,
+      String articleTitle,
+      Instant articlePublishedDate,
+      String articleSummary,
+      Long articleCommentCount,
+      Long articleViewCount
+  ) {
+  }
+
+  }
+
+

--- a/src/main/java/com/springboot/monew/users/document/UserActivityDocument.java
+++ b/src/main/java/com/springboot/monew/users/document/UserActivityDocument.java
@@ -107,7 +107,6 @@ public class UserActivityDocument {
   ) {
 
   }
-
 }
 
 

--- a/src/main/java/com/springboot/monew/users/document/UserActivityDocument.java
+++ b/src/main/java/com/springboot/monew/users/document/UserActivityDocument.java
@@ -28,6 +28,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Document(collection = "user_activities")
 public class UserActivityDocument {
+
   @Id
   private UUID userId;
 
@@ -60,6 +61,7 @@ public class UserActivityDocument {
       Long interestSubscriberCount,
       Instant createdAt
   ) {
+
   }
 
   public record CommentItem(
@@ -72,6 +74,7 @@ public class UserActivityDocument {
       Long likeCount,
       Instant createdAt
   ) {
+
   }
 
   public record CommentLikeItem(
@@ -86,6 +89,7 @@ public class UserActivityDocument {
       Long commentLikeCount,
       Instant commentCreatedAt
   ) {
+
   }
 
   public record ArticleViewItem(
@@ -101,8 +105,9 @@ public class UserActivityDocument {
       Long articleCommentCount,
       Long articleViewCount
   ) {
-  }
 
   }
+
+}
 
 

--- a/src/main/java/com/springboot/monew/users/document/UserActivityDocument.java
+++ b/src/main/java/com/springboot/monew/users/document/UserActivityDocument.java
@@ -11,6 +11,19 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+/*
+  사용자 활동 내역 조회를 위한 MongoDB 저장 모델이다.
+
+  사용자별 활동 데이터를 한 문서에 모아 저장하여 활동 내역 조회 시 RDBMS의 여러 테이블을 조합하지 않고
+  MongoDB 문서 하나로 응답 DTO를 구성할 수 있도록 한다.
+
+  이 모델은 API 응답 DTO와 유사한 구조를 가지지만, 응답 DTO를 직접 저장 타입으로
+  사용하지 않고 Document 전용 Item record를 사용해 API 응답 모델과 MongoDB 저장 모델의 책임을 분리한다.
+
+  아래 Item record들은 UserActivityDocument 내부 리스트에 저장되는 한 건의 데이터이다.
+  API 응답 DTO와 필드 구조는 유사하지만 MongoDB 저장 전용 타입으로 사용한다.
+ */
+
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Document(collection = "user_activities")

--- a/src/main/java/com/springboot/monew/users/exception/UserErrorCode.java
+++ b/src/main/java/com/springboot/monew/users/exception/UserErrorCode.java
@@ -8,11 +8,11 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum UserErrorCode implements ErrorCode {
-  DUPLICATE_EMAIL(HttpStatus.CONFLICT, "DUPLICATE_EMAIL", "이미 사용 중인 이메일입니다."),
-  DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "DUPLICATE_NICKNAME", "이미 사용 중인 닉네임입니다."),
-  USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "사용자를 찾을 수 없습니다."),
-  INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "INVALID_CREDENTIALS", "이메일 또는 비밀번호가 올바르지 않습니다."),
-  USER_NOT_OWNED(HttpStatus.FORBIDDEN, "USER_NOT_OWNED", "본인의 사용자 정보만 수정할 수 있습니다.");
+  DUPLICATE_EMAIL(HttpStatus.CONFLICT, "UR01", "이미 사용 중인 이메일입니다."),
+  DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "UR02", "이미 사용 중인 닉네임입니다."),
+  USER_NOT_FOUND(HttpStatus.NOT_FOUND, "UR03", "사용자를 찾을 수 없습니다."),
+  INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "UR04", "이메일 또는 비밀번호가 올바르지 않습니다."),
+  USER_NOT_OWNED(HttpStatus.FORBIDDEN, "UR05", "본인의 사용자 정보만 수정할 수 있습니다.");
 
   private final HttpStatus httpStatus;
   private final String code;


### PR DESCRIPTION
## 📌 해당 이슈카드

Closes #98 #125 #126 #97 #121 #122

## 📌 작업 내용

- 사용자 활동 내역 조회를 위한 MongoDB Document 모델을 추가했습니다.
- 사용자 활동 문서 내부에 구독, 댓글, 좋아요 댓글, 기사 조회 저장용 Item 구조를 정의했습니다.
- 로컬 개발 환경에서 MongoDB를 Docker Compose로 실행할 수 있도록 설정을 추가했습니다.

## 🔧 변경 사항
- `UserActivityDocument` 추가
- MongoDB 저장용 내부 record 추가
  - `SubscriptionItem`
  - `CommentItem`
  - `CommentLikeItem`
  - `ArticleViewItem`
- `docker-compose.yml` 추가
  - `mongo` 이미지 기반 로컬 MongoDB 컨테이너 실행 설정
  - `27017` 포트 매핑
  - MongoDB 데이터 유지를 위한 volume 설정

## 반영 브랜치
`feature/#98/user-activity-document` -> `dev`

## 💬 기타 참고 사항
- 로컬 실행 시 MongoDB가 필요하므로 아래 명령어로 컨테이너를 실행해야 합니다.
```
  // MongoDB 이미지를 받고, 컨테이너를 만들고, 백그라운드로 실행
docker compose up -d mongodb

// MongoDB 컨테이너 중지
docker compose down
```
- 기본 MongoDB URI는 mongodb://localhost:27017/monew입니다.
- 실제 활동 내역 조회 API와 최근 10건 유지 갱신 로직은 후속 작업에서 구현 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 사용자 활동 추적 시스템 추가: 구독, 댓글, 댓글 좋아요, 기사 조회 기록을 사용자별로 저장.
  * 로컬 MongoDB 기반 개발 환경 추가: 컨테이너화된 DB 및 데이터 영속화 구성(docker-compose 및 볼륨).

* **개선**
  * 사용자 관련 에러 코드 형식 표준화: 기존 식별자에서 UR01~UR05로 변경.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->