### PR TITLE
[Feat] 관심사 목록 조회 구현 및 관심사 수정 개선, Actions workflow 네이버 API 키 추가

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      NAVER_API_KEY: ${{ secrets.NAVER_API_KEY }}
+      NAVER_API_SECRET: ${{ secrets.NAVER_API_SECRET }}
 
     steps:
       - uses: actions/checkout@v4

--- a/src/main/java/com/springboot/monew/interest/controller/InterestController.java
+++ b/src/main/java/com/springboot/monew/interest/controller/InterestController.java
@@ -1,7 +1,9 @@
 package com.springboot.monew.interest.controller;
 
+import com.springboot.monew.interest.dto.request.InterestPageRequest;
 import com.springboot.monew.interest.dto.request.InterestRegisterRequest;
 import com.springboot.monew.interest.dto.request.InterestUpdateRequest;
+import com.springboot.monew.interest.dto.response.CursorPageResponseInterestDto;
 import com.springboot.monew.interest.dto.response.InterestDto;
 import com.springboot.monew.interest.service.InterestService;
 import jakarta.validation.Valid;
@@ -11,10 +13,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -25,6 +29,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class InterestController implements InterestApiDocs {
 
   private final InterestService interestService;
+
+  @GetMapping
+  public CursorPageResponseInterestDto list(
+      @Valid InterestPageRequest request,
+      @RequestHeader("Monew-Request-User-ID") UUID userId) {
+    return interestService.list(request, userId);
+  }
 
   @PostMapping
   public ResponseEntity<InterestDto> create(@Valid @RequestBody InterestRegisterRequest request) {

--- a/src/main/java/com/springboot/monew/interest/dto/request/InterestPageRequest.java
+++ b/src/main/java/com/springboot/monew/interest/dto/request/InterestPageRequest.java
@@ -1,0 +1,20 @@
+package com.springboot.monew.interest.dto.request;
+
+import com.springboot.monew.interest.entity.InterestDirection;
+import com.springboot.monew.interest.entity.InterestOrderBy;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+
+// 관심사 목록 조회 요청 dto
+public record InterestPageRequest(
+    String keyword,
+    @NotNull InterestOrderBy orderBy,
+    @NotNull InterestDirection direction,
+    String cursor,
+    Instant after,
+    @NotNull @Min(1) @Max(100) Integer limit
+) {
+
+}

--- a/src/main/java/com/springboot/monew/interest/entity/InterestDirection.java
+++ b/src/main/java/com/springboot/monew/interest/entity/InterestDirection.java
@@ -1,0 +1,6 @@
+package com.springboot.monew.interest.entity;
+
+public enum InterestDirection {
+  ASC,
+  DESC
+}

--- a/src/main/java/com/springboot/monew/interest/entity/InterestOrderBy.java
+++ b/src/main/java/com/springboot/monew/interest/entity/InterestOrderBy.java
@@ -1,0 +1,18 @@
+package com.springboot.monew.interest.entity;
+
+public enum InterestOrderBy {
+  name {
+    @Override
+    public String getCursor(Interest interest) {
+      return interest.getName();
+    }
+  },
+  subscriberCount {
+    @Override
+    public String getCursor(Interest interest) {
+      return String.valueOf(interest.getSubscriberCount());
+    }
+  };
+
+  public abstract String getCursor(Interest interest);
+}

--- a/src/main/java/com/springboot/monew/interest/repository/InterestKeywordRepository.java
+++ b/src/main/java/com/springboot/monew/interest/repository/InterestKeywordRepository.java
@@ -4,10 +4,6 @@ import com.springboot.monew.interest.dto.response.InterestKeywordInfo;
 import com.springboot.monew.interest.entity.Interest;
 import com.springboot.monew.interest.entity.InterestKeyword;
 import java.util.List;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-
-import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -20,8 +16,20 @@ public interface InterestKeywordRepository extends JpaRepository<InterestKeyword
           FROM InterestKeyword ik
           JOIN FETCH ik.keyword
           WHERE ik.interest = :interest
+          ORDER BY ik.createdAt ASC
       """)
   List<InterestKeyword> findAllByInterestWithKeyword(@Param("interest") Interest interest);
+
+  @Query("""
+          SELECT ik
+          FROM InterestKeyword ik
+          JOIN FETCH ik.interest
+          JOIN FETCH ik.keyword
+          WHERE ik.interest.id IN :interestIds
+          ORDER BY ik.interest.id ASC, ik.createdAt ASC
+      """)
+  List<InterestKeyword> findAllByInterestIdInWithKeyword(
+      @Param("interestIds") List<UUID> interestIds);
 
   @Query("""
           SELECT DISTINCT ik.keyword.id
@@ -30,12 +38,11 @@ public interface InterestKeywordRepository extends JpaRepository<InterestKeyword
       """)
   List<UUID> findReferencedKeywordIds(@Param("keywordIds") List<UUID> keywordIds);
 
-    //관심사의 키워드 목록
-    @Query("""
-    select
-        ik.interest.id as interestId,
-        ik.keyword.name as keywordName
-    from InterestKeyword ik
-""")
-    List<InterestKeywordInfo> findAllInterestKeywordInfos();
+  @Query("""
+          SELECT
+              ik.interest.id AS interestId,
+              ik.keyword.name AS keywordName
+          FROM InterestKeyword ik
+      """)
+  List<InterestKeywordInfo> findAllInterestKeywordInfos();
 }

--- a/src/main/java/com/springboot/monew/interest/repository/SubscriptionRepository.java
+++ b/src/main/java/com/springboot/monew/interest/repository/SubscriptionRepository.java
@@ -1,9 +1,20 @@
 package com.springboot.monew.interest.repository;
 
 import com.springboot.monew.interest.entity.Subscription;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SubscriptionRepository extends JpaRepository<Subscription, UUID> {
 
+  @Query("""
+          SELECT s.interest.id
+          FROM Subscription s
+          WHERE s.user.id = :userId
+            AND s.interest.id IN :interestIds
+      """)
+  List<UUID> findInterestIdsByUserIdAndInterestIdIn(@Param("userId") UUID userId,
+      @Param("interestIds") List<UUID> interestIds);
 }

--- a/src/main/java/com/springboot/monew/interest/repository/qdsl/InterestQDSLRepository.java
+++ b/src/main/java/com/springboot/monew/interest/repository/qdsl/InterestQDSLRepository.java
@@ -1,10 +1,16 @@
 package com.springboot.monew.interest.repository.qdsl;
 
 import com.springboot.monew.interest.entity.Interest;
+import com.springboot.monew.interest.dto.request.InterestPageRequest;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface InterestQDSLRepository {
 
   Optional<Interest> findByIdWithArticleCount(UUID id);
+
+  List<Interest> findInterests(InterestPageRequest request);
+
+  long countInterests(String keyword);
 }

--- a/src/main/java/com/springboot/monew/interest/repository/qdsl/InterestQDSLRepositoryImpl.java
+++ b/src/main/java/com/springboot/monew/interest/repository/qdsl/InterestQDSLRepositoryImpl.java
@@ -1,10 +1,23 @@
 package com.springboot.monew.interest.repository.qdsl;
 
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.springboot.monew.interest.dto.request.InterestPageRequest;
 import com.springboot.monew.interest.entity.Interest;
+import com.springboot.monew.interest.entity.InterestDirection;
+import com.springboot.monew.interest.entity.InterestOrderBy;
 import com.springboot.monew.interest.entity.QInterest;
+import com.springboot.monew.interest.entity.QInterestKeyword;
+import com.springboot.monew.interest.entity.QKeyword;
 import com.springboot.monew.newsarticles.entity.QArticleInterest;
+import java.time.Instant;
+import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
@@ -14,8 +27,11 @@ import org.springframework.stereotype.Repository;
 @Repository
 @RequiredArgsConstructor
 public class InterestQDSLRepositoryImpl implements InterestQDSLRepository {
+
   private final JPAQueryFactory queryFactory;
   private final QInterest qInterest = QInterest.interest;
+  private final QInterestKeyword qInterestKeyword = QInterestKeyword.interestKeyword;
+  private final QKeyword qKeyword = QKeyword.keyword;
   private final QArticleInterest qArticleInterest = QArticleInterest.articleInterest;
 
   @Override
@@ -34,5 +50,176 @@ public class InterestQDSLRepositoryImpl implements InterestQDSLRepository {
     Long articleCount = Objects.requireNonNull(result.get(qArticleInterest.count()));
     interest.setArticleCount(articleCount);
     return Optional.of(interest);
+  }
+
+  @Override
+  public List<Interest> findInterests(InterestPageRequest request) {
+    // 동적 조건 조합을 위한 BooleanBuilder 생성
+    BooleanBuilder where = new BooleanBuilder();
+    // 검색 키워드 조건을 where 절에 추가
+    where.and(keywordContains(normalize(request.keyword())));
+    // 커서 페이지네이션 조건을 where 절에 추가
+    where.and(cursorCondition(request));
+
+    // 기본 검색 쿼리에 조건, 정렬, 조회 개수를 적용하여 결과를 조회
+    return interestSearchQuery()
+        .where(where)
+        .orderBy(orderSpecifiers(request.orderBy(), request.direction()))
+        .limit(request.limit() + 1)
+        .fetch();
+  }
+
+  @Override
+  public long countInterests(String keyword) {
+    // 관심사와 키워드를 조인하여 중복을 제거한 관심사 개수를 조회
+    Long count = queryFactory.select(qInterest.id.countDistinct())
+        .from(qInterest)
+        .leftJoin(qInterestKeyword).on(qInterestKeyword.interest.eq(qInterest))
+        .leftJoin(qInterestKeyword.keyword, qKeyword)
+        .where(keywordContains(normalize(keyword)))
+        .fetchOne();
+
+    return count == null ? 0L : count;
+  }
+
+  // 관심사 목록 검색에 공통으로 사용하는 기본 쿼리를 생성
+  private JPAQuery<Interest> interestSearchQuery() {
+    // 관심사와 키워드를 조인하고 중복 관심사를 제거하는 쿼리 생성
+    return queryFactory.selectDistinct(qInterest)
+        .from(qInterest)
+        .leftJoin(qInterestKeyword).on(qInterestKeyword.interest.eq(qInterest))
+        .leftJoin(qInterestKeyword.keyword, qKeyword);
+  }
+
+  // 관심사 이름이나 키워드 이름에 검색어가 포함되는 조건을 생성
+  private BooleanExpression keywordContains(String keyword) {
+    if (keyword == null) {
+      return null;
+    }
+
+    // 대소문자 구분 없이 구분하기 위해 검색어를 소문자로 변환
+    // 관심사 등록 시 대소문자를 구분해서 유사도 검사를 하는데 검색에선 대소문자 구분 없이 검색하는 이유
+    // -> 사용자는 관심사의 정책을 알 수 없고, 가능한 많은 후보를 노출해 사용자가 원하는 관심사를 직접 선택하도록
+    //    해야 한다. 즉, 검색은 검증이 아니라 탐색에 초점을 두기 때문에 등록과 다르게 대소문자를 구분하지 않는다.
+    String lowerKeyword = keyword.toLowerCase(Locale.ROOT);
+    // 관심사 이름 또는 키워드 이름에 검색어가 포함되는 조건을 반환
+    return qInterest.name.lower().contains(lowerKeyword)
+        .or(qKeyword.name.lower().contains(lowerKeyword));
+  }
+
+  // 요청된 정렬 기준과 커서 값에 맞는 페이지네이션 조건을 생성
+  private BooleanExpression cursorCondition(InterestPageRequest request) {
+    // 요청값에서 커서와 after 값을 추출
+    CursorValue cursorValue = CursorValue.from(request);
+    if (cursorValue.value() == null) {
+      return null;
+    }
+
+    // 이름 정렬이면 이름 기준 커서 조건을 생성
+    if (request.orderBy() == InterestOrderBy.name) {
+      return nameCursorCondition(cursorValue.value(), cursorValue.after(), request.direction());
+    }
+
+    // 구독자 수 커서를 long 값으로 변환
+    long subscriberCountCursor = parseSubscriberCountCursor(cursorValue.value());
+    // 구독자 수 기준 커서 조건을 생성
+    return subscriberCountCursorCondition(
+        subscriberCountCursor,
+        cursorValue.after(),
+        request.direction()
+    );
+  }
+
+  // 이름 정렬 시 현재 커서 이후 또는 이전 데이터를 조회하기 위한 조건을 생성
+  private BooleanExpression nameCursorCondition(String cursor, Instant after,
+      InterestDirection direction) {
+    // 정렬 방향에 따라 이름의 대소 비교 조건을 생성
+    BooleanExpression primaryCondition = direction == InterestDirection.ASC
+        ? qInterest.name.gt(cursor)
+        : qInterest.name.lt(cursor);
+
+    // after 값이 없으면 이름 비교 조건만 반환
+    if (after == null) {
+      return primaryCondition;
+    }
+
+    // 이름이 같은 경우 생성 시각으로 순서를 이어가기 위한 조건을 생성
+    BooleanExpression sameNameCondition = direction == InterestDirection.ASC
+        ? qInterest.createdAt.gt(after)
+        : qInterest.createdAt.lt(after);
+
+    // 이름 비교 조건과 동일 이름일 때의 생성 시각 조건을 합쳐 반환
+    return primaryCondition.or(qInterest.name.eq(cursor).and(sameNameCondition));
+  }
+
+  // 구독자 수 정렬 시 현재 커서 이후 또는 이전 데이터를 조회하기 위한 조건을 생성
+  private BooleanExpression subscriberCountCursorCondition(long cursor, Instant after,
+      InterestDirection direction) {
+    // 정렬 방향에 따라 구독자 수의 대소 비교 조건을 생성
+    BooleanExpression primaryCondition = direction == InterestDirection.ASC
+        ? qInterest.subscriberCount.gt(cursor)
+        : qInterest.subscriberCount.lt(cursor);
+
+    // after 값이 없으면 구독자 수 비교 조건만 반환
+    if (after == null) {
+      return primaryCondition;
+    }
+
+    // 구독자 수가 같은 경우 생성 시각으로 순서를 이어가기 위한 조건을 생성
+    BooleanExpression sameCountCondition = direction == InterestDirection.ASC
+        ? qInterest.createdAt.gt(after)
+        : qInterest.createdAt.lt(after);
+
+    // 구독자 수 비교 조건과 동일 구독자 수일 때의 생성 시각 조건을 합쳐 반환
+    return primaryCondition.or(qInterest.subscriberCount.eq(cursor).and(sameCountCondition));
+  }
+
+  // 요청된 정렬 기준과 방향에 맞는 정렬 조건 배열을 생성
+  private OrderSpecifier<?>[] orderSpecifiers(InterestOrderBy orderBy,
+      InterestDirection direction) {
+    // 정렬 방향을 Order 타입으로 변환
+    Order order = direction == InterestDirection.ASC ? Order.ASC : Order.DESC;
+
+    // 요청된 정렬 기준에 따라 정렬 조건 생성
+    OrderSpecifier<?> primaryOrder = orderBy == InterestOrderBy.name
+        ? new OrderSpecifier<>(order, qInterest.name)
+        : new OrderSpecifier<>(order, qInterest.subscriberCount);
+
+    // createdAt을 보조 정렬 기준으로 추가
+    return new OrderSpecifier<?>[]{
+        primaryOrder,
+        new OrderSpecifier<>(order, qInterest.createdAt)
+    };
+  }
+
+  private long parseSubscriberCountCursor(String cursor) {
+    try {
+      return Long.parseLong(cursor);
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException("Invalid subscriberCount cursor: " + cursor, e);
+    }
+  }
+
+  private String normalize(String value) {
+    if (value == null || value.isBlank()) {
+      return null;
+    }
+    return value.trim();
+  }
+
+  // 요청에서 추출한 커서 값과 after 값을 함께 보관하는 레코드
+  private record CursorValue(String value, Instant after) {
+
+    // 요청 객체에서 커서 값과 after 값을 꺼내 CursorValue로 변환
+    private static CursorValue from(InterestPageRequest request) {
+      return new CursorValue(normalize(request.cursor()), request.after());
+    }
+
+    private static String normalize(String value) {
+      if (value == null || value.isBlank()) {
+        return null;
+      }
+      return value.trim();
+    }
   }
 }

--- a/src/main/java/com/springboot/monew/interest/service/InterestService.java
+++ b/src/main/java/com/springboot/monew/interest/service/InterestService.java
@@ -14,6 +14,7 @@ import com.springboot.monew.interest.repository.InterestRepository;
 import com.springboot.monew.interest.repository.KeywordRepository;
 import com.springboot.monew.interest.util.StringSimilarityUtil;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -77,24 +78,46 @@ public class InterestService {
     validateDuplicateKeywords(keywordNames);
 
     // 해당 관심사의 연결 목록 조회
-    List<InterestKeyword> existingInterestKeywords = interestKeywordRepository.findAllByInterestWithKeyword(
-        interest);
-    // 해당 관심사의 기존 키워드 목록 추출
-    List<Keyword> oldKeywords = existingInterestKeywords.stream()
+    List<InterestKeyword> existingInterestKeywords =
+        interestKeywordRepository.findAllByInterestWithKeyword(interest);
+
+    // 연결 내용을 키워드 이름 기준으로 빠르게 조회하기 위해 (키워드 이름, 관심사-키워드 연결 엔티티)) 형태로 맵 생성
+    Map<String, InterestKeyword> existingInterestKeywordMap = new LinkedHashMap<>();
+    for (InterestKeyword interestKeyword : existingInterestKeywords) {
+      existingInterestKeywordMap.put(interestKeyword.getKeyword().getName(), interestKeyword);
+    }
+
+    // 요청 키워드 목록을 Set으로 생성
+    Set<String> requestedKeywordNames = new HashSet<>(keywordNames);
+
+    // 요청 목록에 없는 키워드만 선별하여 삭제 대상으로 생성
+    List<InterestKeyword> interestKeywordsToDelete = existingInterestKeywords.stream()
+        .filter(interestKeyword -> !requestedKeywordNames.contains(
+            interestKeyword.getKeyword().getName()))
+        .toList();
+
+    // 삭제 대상에 포함된 키워드 중 고아 객체 수집
+    List<Keyword> orphanCandidateKeywords = interestKeywordsToDelete.stream()
         .map(InterestKeyword::getKeyword)
         .toList();
 
-    // 조회한 관심사-키워드 연결 삭제
-    interestKeywordRepository.deleteAll(existingInterestKeywords);
+    // 삭제 대상이 있으면 삭제
+    if (!interestKeywordsToDelete.isEmpty()) {
+      interestKeywordRepository.deleteAll(interestKeywordsToDelete);
+    }
 
-    // 요청 받은 키워드 목록 순회
+    // 요청 목록을 순회하며 기존 연결이 없는 새로운 키워드만 새롭게 생성
     for (String keywordName : keywordNames) {
+      if (existingInterestKeywordMap.containsKey(keywordName)) {
+        continue;
+      }
+
       Keyword keyword = getOrCreateKeyword(keywordName);
       interestKeywordRepository.save(new InterestKeyword(interest, keyword));
     }
 
-    // 이전 키워드 목록을 순회하며 더 이상 연결된 관심사가 없다면 삭제
-    deleteOrphanKeywords(oldKeywords);
+    // 더 이상 연결된 관심사가 없는 키워드는 삭제
+    deleteOrphanKeywords(orphanCandidateKeywords);
 
     log.info("관심사 수정 완료 - interestId: {}, keywordNames: {}", interest.getId(), keywordNames);
     return interestDtoMapper.toInterestDto(interest, keywordNames, false);

--- a/src/main/java/com/springboot/monew/interest/service/InterestService.java
+++ b/src/main/java/com/springboot/monew/interest/service/InterestService.java
@@ -51,8 +51,8 @@ public class InterestService {
 
   @Transactional(readOnly = true)
   public CursorPageResponseInterestDto list(InterestPageRequest request, UUID userId) {
-    // 요청 유저가 존재하는 유저인지 검증
-    getActiveUser(userId);
+    // 요청 유저가 존재하는지 확인하고 삭제되지 않은 활성 사용자인지 검증
+    validateActiveUser(userId);
 
     // 요청 조건에 맞는 관심사 목록을 limit+1 개수만큼 조회
     List<Interest> interests = new ArrayList<>(interestRepository.findInterests(request));
@@ -320,7 +320,7 @@ public class InterestService {
     return request.orderBy().getCursor(interest);
   }
 
-  private void getActiveUser(UUID userId) {
+  private void validateActiveUser(UUID userId) {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND,
             Map.of("userId", userId)));

--- a/src/main/java/com/springboot/monew/interest/service/InterestService.java
+++ b/src/main/java/com/springboot/monew/interest/service/InterestService.java
@@ -1,7 +1,9 @@
 package com.springboot.monew.interest.service;
 
+import com.springboot.monew.interest.dto.request.InterestPageRequest;
 import com.springboot.monew.interest.dto.request.InterestRegisterRequest;
 import com.springboot.monew.interest.dto.request.InterestUpdateRequest;
+import com.springboot.monew.interest.dto.response.CursorPageResponseInterestDto;
 import com.springboot.monew.interest.dto.response.InterestDto;
 import com.springboot.monew.interest.entity.Interest;
 import com.springboot.monew.interest.entity.InterestKeyword;
@@ -12,7 +14,14 @@ import com.springboot.monew.interest.mapper.InterestDtoMapper;
 import com.springboot.monew.interest.repository.InterestKeywordRepository;
 import com.springboot.monew.interest.repository.InterestRepository;
 import com.springboot.monew.interest.repository.KeywordRepository;
+import com.springboot.monew.interest.repository.SubscriptionRepository;
 import com.springboot.monew.interest.util.StringSimilarityUtil;
+import com.springboot.monew.users.entity.User;
+import com.springboot.monew.users.exception.UserErrorCode;
+import com.springboot.monew.users.exception.UserException;
+import com.springboot.monew.users.repository.UserRepository;
+import java.time.Instant;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -36,7 +45,63 @@ public class InterestService {
   private final InterestRepository interestRepository;
   private final KeywordRepository keywordRepository;
   private final InterestKeywordRepository interestKeywordRepository;
+  private final SubscriptionRepository subscriptionRepository;
+  private final UserRepository userRepository;
   private final InterestDtoMapper interestDtoMapper;
+
+  @Transactional(readOnly = true)
+  public CursorPageResponseInterestDto list(InterestPageRequest request, UUID userId) {
+    // 요청 유저가 존재하는 유저인지 검증
+    getActiveUser(userId);
+
+    // 요청 조건에 맞는 관심사 목록을 limit+1 개수만큼 조회
+    List<Interest> interests = new ArrayList<>(interestRepository.findInterests(request));
+    // 조회된 개수가 요청 limit을 초과하면 다음 페이지가 존재한다고 판단
+    boolean hasNext = interests.size() > request.limit();
+
+    // 다음 페이지가 존재하는 경우 반환 데이터는 limit 개수만큼 잘라내기
+    if (hasNext) {
+      interests = new ArrayList<>(interests.subList(0, request.limit()));
+    }
+
+    // 조회된 관심사 목록에서 각 관심사의 ID 목록을 추출
+    List<UUID> interestIds = interests.stream()
+        .map(Interest::getId)
+        .toList();
+
+    // 관심사 ID 목록을 기준으로 각 관심사에 연결된 키워드 목록을 조회하여 매핑
+    Map<UUID, List<String>> keywordsByInterestId = getKeywordsByInterestId(interestIds);
+    // 현재 유저가 구독 중인 관심사 ID 목록을 조회
+    Set<UUID> subscribedInterestIds = getSubscribedInterestIds(userId, interestIds);
+
+    // 관심사 엔티티를 dto로 변환하면서 키워드 목록과 구독 여부를 주입
+    List<InterestDto> content = interests.stream()
+        .map(interest -> interestDtoMapper.toInterestDto(
+            interest,
+            keywordsByInterestId.getOrDefault(interest.getId(), List.of()),
+            subscribedInterestIds.contains(interest.getId())))
+        .toList();
+
+    // 마지막 관심사를 기준으로 다음 커서를 생성하기 위해 마지막 요소 추출
+    Interest lastInterest = interests.isEmpty() ? null : interests.get(interests.size() - 1);
+    // 다음 페이지가 존재하면 마지막 관심사를 기준으로 다음 커서를 생성하고 아니면 null로 설정
+    String nextCursor =
+        hasNext && lastInterest != null ? getNextCursor(request, lastInterest) : null;
+    // 다음 페이지가 존재하면 마지막 관심사의 생성 시간을 after 값으로 설정하고 아니면 null로 설정
+    Instant nextAfter = hasNext && lastInterest != null ? lastInterest.getCreatedAt() : null;
+    // 전체 관심사 개수를 조회하여 페이지네이션 메타데이터로 사용
+    long totalElements = interestRepository.countInterests(request.keyword());
+
+    // 조회 결과와 커서 정보, 전체 개수 등을 포함한 커서 기반 관심사 페이지 응답 dto 생성 및 반환
+    return new CursorPageResponseInterestDto(
+        content,
+        nextCursor,
+        nextAfter,
+        content.size(),
+        totalElements,
+        hasNext
+    );
+  }
 
   @Transactional
   public InterestDto create(InterestRegisterRequest request) {
@@ -212,4 +277,54 @@ public class InterestService {
     keywordRepository.deleteOrphanKeywordsByIds(keywordIds);
   }
 
+  private Map<UUID, List<String>> getKeywordsByInterestId(List<UUID> interestIds) {
+    if (interestIds.isEmpty()) {
+      return Map.of();
+    }
+
+    // 각 관심사 ID를 키로 가지는 결과 맵 초기화
+    Map<UUID, List<String>> keywordsByInterestId = new LinkedHashMap<>();
+    for (UUID interestId : interestIds) {
+      keywordsByInterestId.put(interestId, new ArrayList<>());
+    }
+
+    // 관심사 ID 목록에 해당하는 관심사-키워드 연결 목록을 조회
+    List<InterestKeyword> interestKeywords =
+        interestKeywordRepository.findAllByInterestIdInWithKeyword(interestIds);
+    for (InterestKeyword interestKeyword : interestKeywords) {
+      // 관심사 ID를 기준으로 해당 키워드 이름을 결과 맵에 추가
+      UUID interestId = interestKeyword.getInterest().getId();
+      keywordsByInterestId
+          .computeIfAbsent(interestId, id -> new ArrayList<>())
+          .add(interestKeyword.getKeyword().getName());
+    }
+
+    // 관심사별 키워드 이름 목록이 매핑된 결과를 반환
+    return keywordsByInterestId;
+  }
+
+  private Set<UUID> getSubscribedInterestIds(UUID userId, List<UUID> interestIds) {
+    if (interestIds.isEmpty()) {
+      return Set.of();
+    }
+
+    // 유저가 구독한 관심사 ID 목록을 조회하여 Set으로 변환해 반환
+    return new HashSet<>(
+        subscriptionRepository.findInterestIdsByUserIdAndInterestIdIn(userId, interestIds));
+  }
+
+  private String getNextCursor(InterestPageRequest request, Interest interest) {
+    // 요청한 정렬 기준에 맞는 커서 값을 관심사 엔티티에서 추출하여 반환
+    return request.orderBy().getCursor(interest);
+  }
+
+  private void getActiveUser(UUID userId) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND,
+            Map.of("userId", userId)));
+
+    if (user.isDeleted()) {
+      throw new UserException(UserErrorCode.USER_NOT_FOUND, Map.of("userId", userId));
+    }
+  }
 }

--- a/src/main/java/com/springboot/monew/interest/service/InterestService.java
+++ b/src/main/java/com/springboot/monew/interest/service/InterestService.java
@@ -92,6 +92,8 @@ public class InterestService {
     // 전체 관심사 개수를 조회하여 페이지네이션 메타데이터로 사용
     long totalElements = interestRepository.countInterests(request.keyword());
 
+    log.info("관심사 목록 조회 완료 - userId: {}, content.size: {}, hasNext: {}, totalElements: {}",
+        userId, content.size(), hasNext, totalElements);
     // 조회 결과와 커서 정보, 전체 개수 등을 포함한 커서 기반 관심사 페이지 응답 dto 생성 및 반환
     return new CursorPageResponseInterestDto(
         content,

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -69,7 +69,7 @@ CREATE TABLE interests
 (
     "id"               UUID PRIMARY KEY,
     "name"             VARCHAR(50)       NOT NULL,
-    "subscriber_count" INTEGER DEFAULT 0 NOT NULL,
+    "subscriber_count" BIGINT DEFAULT 0 NOT NULL,
     "created_at"       TIMESTAMPTZ       NOT NULL,
     "updated_at"       TIMESTAMPTZ       NULL
 );

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -69,7 +69,7 @@ CREATE TABLE interests
 (
     id               UUID PRIMARY KEY,
     name             VARCHAR(50)              NOT NULL,
-    subscriber_count INTEGER DEFAULT 0        NOT NULL,
+    subscriber_count BIGINT DEFAULT 0        NOT NULL,
     created_at       TIMESTAMP WITH TIME ZONE NOT NULL,
     updated_at       TIMESTAMP WITH TIME ZONE NULL
 );


### PR DESCRIPTION
## 📌 해당 이슈카드
Closes #101 #132 #134 #135 

## 📌 작업 내용
- 관심사 목록 조회 요청 dto와 관련 enum 생성
- 관심사 목록 조회 컨트롤러 구현
- 관심사 목록 조회 서비스 구현
- 관심사 목록 조회 레포지토리 구현
- 관심사 수정 서비스 개선
- DB의 구독자 수 데이터 타입 변경

## 🔧 변경 사항
- 관심사 수정 시 관심사의 키워드를 전체 삭제 후 재생성하는 방식에서 변경분만 반영하는 방식으로 변경
- DB의 구독자 수 데이터 타입을 INTEGER에서 BIGINT로 변경

## 반영 브랜치
`feature/#132#134#135/Interest-pagination` -> `dev`

## 💬 기타 참고 사항
- 현재 구독 관련 구현이 되어 있지 않아서 유저가 구독한 관심사에 대한 확인은 제대로 이뤄지지 못했습니다.
- 목록 조회 작동 여부를 위해 로컬 DB에서 관심사 60개, 키워드 138개, 관심사-키워드 연결 240개 정도의 더미 데이터를 생성하였고, 정상적으로 작동하는 것과 올바르게 정렬되는 것을 확인하였습니다. 
- 동일한 이름 혹은 구독자 수와 동일한 생성 시각인 관심사가 있다면 관심사 구분이 안되어서 id를 추가하려 했으나 프로토타입에선 id를 사용하지 않는 것으로 보여서 일단 넣지 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 관심사 목록 조회 API 추가: 커서 기반 페이지네이션, 키워드 필터, 이름/구독자수 정렬, 요청자별 구독 상태 포함, 최대 100개 지원
  * 페이지네이션 요청 DTO 및 정렬/방향 열거형 추가
  * 컨트롤러 엔드포인트 및 관련 조회·집계 API 추가

* **버그 수정**
  * 키워드 연결 동기화 개선: 기존 연결만 삭제하고 중복 재추가 방지

* **저장소**
  * 조회·집계/정렬 쿼리 및 페치 동작 개선, 사용자별 구독 조회 추가

* **데이터베이스**
  * interests.subscriber_count 타입 변경: INTEGER → BIGINT

* **기타**
  * 테스트 워크플로우 환경변수 추가 (시크릿 연동)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->