### PR TITLE
[Feat]뉴스기사 논리/물리 삭제 기능 구현

### DIFF
--- a/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleController.java
+++ b/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleController.java
@@ -39,7 +39,7 @@ public class NewsArticleController {
 
   //뉴스기사 물리삭제
   @DeleteMapping("/{articleId}/hard")
-  public ResponseEntity<?> delete(@PathVariable("articleId") UUID articleId) {
+  public ResponseEntity<Void> hardDelete(@PathVariable("articleId") UUID articleId) {
 
     log.debug("뉴스기사 물리삭제 요청: articleId={}", articleId);
     newsArticleService.hardDelete(articleId);

--- a/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleController.java
+++ b/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/article")
+@RequestMapping("/api/articles")
 public class NewsArticleController {
 
   private final NewsArticleCollectService newsArticleCollectService;

--- a/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleController.java
+++ b/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleController.java
@@ -1,24 +1,51 @@
 package com.springboot.monew.newsarticles.controller;
 
-import com.springboot.monew.newsarticles.entity.NewsArticle;
 import com.springboot.monew.newsarticles.service.NewsArticleCollectService;
+import com.springboot.monew.newsarticles.service.NewsArticleService;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/article")
 public class NewsArticleController {
 
-    private final NewsArticleCollectService newsArticleCollectService;
+  private final NewsArticleCollectService newsArticleCollectService;
+  private final NewsArticleService newsArticleService;
 
-    @PostMapping
-    public ResponseEntity<String> collectNews() {
-        newsArticleCollectService.collectAll();
-        return ResponseEntity.ok("뉴스 수집 완료");
-    }
+  @PostMapping
+  public ResponseEntity<String> collectNews() {
+    newsArticleCollectService.collectAll();
+    return ResponseEntity.ok("뉴스 수집 완료");
+  }
+
+  //뉴스기사 논리삭제
+  @DeleteMapping("/articles/{articleId}")
+  public ResponseEntity<Void> softDelete(@PathVariable UUID articleId) {
+    log.debug("뉴스기사 논리삭제 요청: articleId={}", articleId);
+    newsArticleService.softDelete(articleId);
+
+    return ResponseEntity.noContent().build();
+  }
+
+  //뉴스기사 물리삭제
+  @DeleteMapping("/{articleId}/hard")
+  public ResponseEntity<?> delete(@PathVariable("articleId") UUID articleId) {
+
+    log.debug("뉴스기사 물리삭제 요청: articleId={}", articleId);
+    newsArticleService.hardDelete(articleId);
+
+    //삭제 성공시 204
+    return ResponseEntity.noContent().build();
+
+  }
 }

--- a/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleController.java
+++ b/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleController.java
@@ -29,7 +29,7 @@ public class NewsArticleController {
   }
 
   //뉴스기사 논리삭제
-  @DeleteMapping("/articles/{articleId}")
+  @DeleteMapping("/{articleId}")
   public ResponseEntity<Void> softDelete(@PathVariable UUID articleId) {
     log.debug("뉴스기사 논리삭제 요청: articleId={}", articleId);
     newsArticleService.softDelete(articleId);

--- a/src/main/java/com/springboot/monew/newsarticles/dto/NaverNewsItem.java
+++ b/src/main/java/com/springboot/monew/newsarticles/dto/NaverNewsItem.java
@@ -1,10 +1,11 @@
 package com.springboot.monew.newsarticles.dto;
 
 public record NaverNewsItem(
-        String title,
-        String originallink,
-        String link,
-        String description,
-        String pubDate
+    String title,
+    String originallink,
+    String link,
+    String description,
+    String pubDate
 ) {
+
 }

--- a/src/main/java/com/springboot/monew/newsarticles/dto/RssItem.java
+++ b/src/main/java/com/springboot/monew/newsarticles/dto/RssItem.java
@@ -3,8 +3,10 @@ package com.springboot.monew.newsarticles.dto;
 import java.time.Instant;
 
 public record RssItem(
-        String title,
-        String link,
-        String description,
-        Instant publishedAt
-) {}
+    String title,
+    String link,
+    String description,
+    Instant publishedAt
+) {
+
+}

--- a/src/main/java/com/springboot/monew/newsarticles/dto/response/CollectedArticle.java
+++ b/src/main/java/com/springboot/monew/newsarticles/dto/response/CollectedArticle.java
@@ -1,15 +1,15 @@
 package com.springboot.monew.newsarticles.dto.response;
 
 import com.springboot.monew.newsarticles.enums.ArticleSource;
-
 import java.time.Instant;
 
 // 네이버,RSS 응답을 통일해주는 DTO
 public record CollectedArticle(
-        ArticleSource source,
-        String originalLink,
-        String title,
-        Instant publishedAt,
-        String summary
+    ArticleSource source,
+    String originalLink,
+    String title,
+    Instant publishedAt,
+    String summary
 ) {
+
 }

--- a/src/main/java/com/springboot/monew/newsarticles/dto/response/NaverNewsResponse.java
+++ b/src/main/java/com/springboot/monew/newsarticles/dto/response/NaverNewsResponse.java
@@ -2,12 +2,12 @@ package com.springboot.monew.newsarticles.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.springboot.monew.newsarticles.dto.NaverNewsItem;
-
 import java.util.List;
 
 //Naver API로 수집한 뉴스기사 data ResponseDto
 public record NaverNewsResponse(
-        @JsonProperty("items")
-        List<NaverNewsItem> articles
+    @JsonProperty("items")
+    List<NaverNewsItem> articles
 ) {
+
 }

--- a/src/main/java/com/springboot/monew/newsarticles/entity/ArticleInterest.java
+++ b/src/main/java/com/springboot/monew/newsarticles/entity/ArticleInterest.java
@@ -2,7 +2,13 @@ package com.springboot.monew.newsarticles.entity;
 
 import com.springboot.monew.common.entity.BaseEntity;
 import com.springboot.monew.interest.entity.Interest;
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -12,41 +18,39 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @Table(
-        name = "article_interests",
-        uniqueConstraints = {
-                @UniqueConstraint(
-                        name = "UK_ARTICLE_INTERESTS_ARTICLE_INTEREST",
-                        columnNames = {"news_article_id", "interest_id"}
-                )
-        }
-)
-public class  ArticleInterest extends BaseEntity {
-
-    // 관심사 N : 뉴스기사 1
-    // 지연로딩: 지금 당장 필요 없으니까 나중에 진짜 쓸때 가져옴.
-    // optional = false : 필수관계(NOT NULL)
-    @ManyToOne(fetch = FetchType.LAZY,  optional = false)   //뉴스기사 1 관심사 N
-    @JoinColumn(
-            name = "news_article_id",
-            nullable = false,
-            foreignKey = @ForeignKey(name = "FK_ARTICLE_INTERESTS_NEWS_ARTICLE")
-    )
-    private NewsArticle newsArticle;
-
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(
-            name = "interest_id",
-            nullable = false,
-            foreignKey = @ForeignKey(name = "FK_ARTICLE_INTERESTS_INTEREST")
-    )
-    private Interest interest;
-
-    public ArticleInterest(NewsArticle newsArticles, Interest interest) {
-        this.newsArticle = newsArticles;
-        this.interest = interest;
+    name = "article_interests",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "UK_ARTICLE_INTERESTS_ARTICLE_INTEREST",
+            columnNames = {"news_article_id", "interest_id"}
+        )
     }
+)
+public class ArticleInterest extends BaseEntity {
 
+  // 관심사 N : 뉴스기사 1
+  // 지연로딩: 지금 당장 필요 없으니까 나중에 진짜 쓸때 가져옴.
+  // optional = false : 필수관계(NOT NULL)
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)   //뉴스기사 1 관심사 N
+  @JoinColumn(
+      name = "news_article_id",
+      nullable = false,
+      foreignKey = @ForeignKey(name = "FK_ARTICLE_INTERESTS_NEWS_ARTICLE")
+  )
+  private NewsArticle newsArticle;
 
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(
+      name = "interest_id",
+      nullable = false,
+      foreignKey = @ForeignKey(name = "FK_ARTICLE_INTERESTS_INTEREST")
+  )
+  private Interest interest;
+
+  public ArticleInterest(NewsArticle newsArticles, Interest interest) {
+    this.newsArticle = newsArticles;
+    this.interest = interest;
+  }
 
 
 }

--- a/src/main/java/com/springboot/monew/newsarticles/entity/ArticleView.java
+++ b/src/main/java/com/springboot/monew/newsarticles/entity/ArticleView.java
@@ -2,7 +2,13 @@ package com.springboot.monew.newsarticles.entity;
 
 import com.springboot.monew.common.entity.BaseEntity;
 import com.springboot.monew.users.entity.User;
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -11,36 +17,36 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @Table(
-        name = "article_views",
-        uniqueConstraints = {
-                @UniqueConstraint(
-                        name = "UK_ARTICLE_VIEWS_ARTICLE_USER",
-                        columnNames = {"news_article_id", "user_id"}
-                )
-        }
+    name = "article_views",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "UK_ARTICLE_VIEWS_ARTICLE_USER",
+            columnNames = {"news_article_id", "user_id"}
+        )
+    }
 )
 public class ArticleView extends BaseEntity {
 
-    // 사용자 N : 뉴스기사 1
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(
-            name = "news_article_id",
-            nullable = false,
-            foreignKey = @ForeignKey(name = "FK_ARTICLE_VIEWS_NEWS_ARTICLE")
-    )
-    private NewsArticle newsArticle;
+  // 사용자 N : 뉴스기사 1
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(
+      name = "news_article_id",
+      nullable = false,
+      foreignKey = @ForeignKey(name = "FK_ARTICLE_VIEWS_NEWS_ARTICLE")
+  )
+  private NewsArticle newsArticle;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(
-            name = "user_id",
-            nullable = false,
-            foreignKey = @ForeignKey(name = "FK_ARTICLE_VIEWS_USER")
-    )
-    private User user;
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(
+      name = "user_id",
+      nullable = false,
+      foreignKey = @ForeignKey(name = "FK_ARTICLE_VIEWS_USER")
+  )
+  private User user;
 
-    public ArticleView(NewsArticle newsArticle, User user) {
-        this.newsArticle = newsArticle;
-        this.user = user;
-    }
+  public ArticleView(NewsArticle newsArticle, User user) {
+    this.newsArticle = newsArticle;
+    this.user = user;
+  }
 
 }

--- a/src/main/java/com/springboot/monew/newsarticles/entity/NewsArticle.java
+++ b/src/main/java/com/springboot/monew/newsarticles/entity/NewsArticle.java
@@ -2,56 +2,60 @@ package com.springboot.monew.newsarticles.entity;
 
 import com.springboot.monew.common.entity.BaseEntity;
 import com.springboot.monew.newsarticles.enums.ArticleSource;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.Instant;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.Instant;
-import java.util.UUID;
 
 @Entity
 @Getter
 @NoArgsConstructor //기본 생성자
 @Table(name = "news_articles",
-        uniqueConstraints = {
-                @UniqueConstraint(name = "UK_NEWS_ARTICLES_ORIGINAL_LINK", columnNames = "original_link")
-        }
+    uniqueConstraints = {
+        @UniqueConstraint(name = "UK_NEWS_ARTICLES_ORIGINAL_LINK", columnNames = "original_link")
+    }
 )
 public class NewsArticle extends BaseEntity {
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 20)
-    private ArticleSource source;
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 20)
+  private ArticleSource source;
 
-    @Column(name = "original_link", nullable = false, length = 500)
-    private String originalLink;
+  @Column(name = "original_link", nullable = false, length = 500)
+  private String originalLink;
 
-    @Column(nullable = false, length = 300)
-    private String title;
+  @Column(nullable = false, length = 300)
+  private String title;
 
-    @Column(name = "published_at", nullable = false)
-    private Instant publishedAt;
+  @Column(name = "published_at", nullable = false)
+  private Instant publishedAt;
 
-    @Column(columnDefinition = "TEXT")    //JPA가 테이블 생성할때 해당 컬럼을 DB의 TEXT 타입으로 지정하라.
-    private String summary;
+  @Column(columnDefinition = "TEXT")    //JPA가 테이블 생성할때 해당 컬럼을 DB의 TEXT 타입으로 지정하라.
+  private String summary;
 
-    @Column(name = "view_count", nullable = false)
-    private Long viewCount = 0L;
+  @Column(name = "view_count", nullable = false)
+  private Long viewCount = 0L;
 
-    @Column(name = "is_deleted", nullable = false)
-    private boolean isDeleted = false;
+  @Column(name = "is_deleted", nullable = false)
+  private boolean isDeleted = false;
 
-    @Builder
-    public NewsArticle(ArticleSource source, String originalLink, String title, Instant publishedAt, String summary) {
-        this.source = source;
-        this.originalLink = originalLink;
-        this.title = title;
-        this.publishedAt = publishedAt;
-        this.summary = summary;
-        this.viewCount = 0L;
-        this.isDeleted = false;
-    }
+  @Builder
+  public NewsArticle(ArticleSource source, String originalLink, String title, Instant publishedAt,
+      String summary) {
+    this.source = source;
+    this.originalLink = originalLink;
+    this.title = title;
+    this.publishedAt = publishedAt;
+    this.summary = summary;
+    this.viewCount = 0L;
+    this.isDeleted = false;
+  }
 
 //    // ===== 비즈니스 로직 =====
 //    public void increaseViewCount() {

--- a/src/main/java/com/springboot/monew/newsarticles/entity/NewsArticle.java
+++ b/src/main/java/com/springboot/monew/newsarticles/entity/NewsArticle.java
@@ -62,9 +62,9 @@ public class NewsArticle extends BaseEntity {
 //        this.viewCount++;
 //    }
 //
-//    public void delete() {
-//        this.isDeleted = true;
-//    }
+    public void delete() {
+        this.isDeleted = true;
+    }
 
 
 }

--- a/src/main/java/com/springboot/monew/newsarticles/enums/ArticleSource.java
+++ b/src/main/java/com/springboot/monew/newsarticles/enums/ArticleSource.java
@@ -2,8 +2,8 @@ package com.springboot.monew.newsarticles.enums;
 
 //네이버, 한국경제, 조선일보, 연합뉴스
 public enum ArticleSource {
-    NAVER,
-    HANKYUNG,
-    CHOSUN,
-    YONHAP
+  NAVER,
+  HANKYUNG,
+  CHOSUN,
+  YONHAP
 }

--- a/src/main/java/com/springboot/monew/newsarticles/exception/ArticleException.java
+++ b/src/main/java/com/springboot/monew/newsarticles/exception/ArticleException.java
@@ -2,11 +2,11 @@ package com.springboot.monew.newsarticles.exception;
 
 import com.springboot.monew.common.exception.ErrorCode;
 import com.springboot.monew.common.exception.MonewException;
-
 import java.util.Map;
 
 public class ArticleException extends MonewException {
-    public ArticleException(ErrorCode errorCode, Map<String, Object> details) {
-        super(errorCode, details);
-    }
+
+  public ArticleException(ErrorCode errorCode, Map<String, Object> details) {
+    super(errorCode, details);
+  }
 }

--- a/src/main/java/com/springboot/monew/newsarticles/exception/NewsArticleErrorCode.java
+++ b/src/main/java/com/springboot/monew/newsarticles/exception/NewsArticleErrorCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum NewsArticleErrorCode implements ErrorCode {
-  NEWS_ARTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "NA01", "뉴스기사를 찾을 수 없습니다.");
+  NEWS_ARTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "NA01", "뉴스기사를 찾을 수 없습니다."),
+  NEWS_ARTICLE_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "NA02", "이미 삭제된 뉴스기사입니다.");
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/src/main/java/com/springboot/monew/newsarticles/exception/NewsArticleErrorCode.java
+++ b/src/main/java/com/springboot/monew/newsarticles/exception/NewsArticleErrorCode.java
@@ -1,0 +1,21 @@
+package com.springboot.monew.newsarticles.exception;
+
+import com.springboot.monew.common.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum NewsArticleErrorCode implements ErrorCode {
+  NEWS_ARTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "NA01", "뉴스기사를 찾을 수 없습니다.");
+
+  private final HttpStatus httpStatus;
+  private final String code;
+  private final String message;
+
+  @Override
+  public String getCode() {
+    return code;
+  }
+}

--- a/src/main/java/com/springboot/monew/newsarticles/exception/NewsArticleErrorCode.java
+++ b/src/main/java/com/springboot/monew/newsarticles/exception/NewsArticleErrorCode.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum NewsArticleErrorCode implements ErrorCode {
-  NEWS_ARTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "NA01", "뉴스기사를 찾을 수 없습니다."),
+  NEWS_ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "NA01", "뉴스기사를 찾을 수 없습니다."),
   NEWS_ARTICLE_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "NA02", "이미 삭제된 뉴스기사입니다.");
 
   private final HttpStatus httpStatus;

--- a/src/main/java/com/springboot/monew/newsarticles/repository/NewsArticleRepository.java
+++ b/src/main/java/com/springboot/monew/newsarticles/repository/NewsArticleRepository.java
@@ -1,17 +1,18 @@
 package com.springboot.monew.newsarticles.repository;
 
-import com.springboot.monew.newsarticles.entity.ArticleInterest;
 import com.springboot.monew.newsarticles.entity.NewsArticle;
 import java.util.Collection;
 import java.util.List;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NewsArticleRepository extends JpaRepository<NewsArticle, UUID> {
 
-    //원본링크목록 조회
-    List<NewsArticle> findAllByOriginalLinkIn(Collection<String> originalLinks);
+  //원본링크목록 조회
+  List<NewsArticle> findAllByOriginalLinkIn(Collection<String> originalLinks);
+
+  //뉴스기사 존재 검증
+  Boolean existsByNewsArticleId(UUID articleId);
 
 
 }

--- a/src/main/java/com/springboot/monew/newsarticles/repository/NewsArticleRepository.java
+++ b/src/main/java/com/springboot/monew/newsarticles/repository/NewsArticleRepository.java
@@ -11,8 +11,5 @@ public interface NewsArticleRepository extends JpaRepository<NewsArticle, UUID> 
   //원본링크목록 조회
   List<NewsArticle> findAllByOriginalLinkIn(Collection<String> originalLinks);
 
-  //뉴스기사 존재 검증
-  Boolean existsByNewsArticleId(UUID articleId);
-
 
 }

--- a/src/main/java/com/springboot/monew/newsarticles/scheduler/NewsArticleScheduler.java
+++ b/src/main/java/com/springboot/monew/newsarticles/scheduler/NewsArticleScheduler.java
@@ -11,21 +11,21 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class NewsArticleScheduler {
 
-    private final NewsArticleCollectService newsArticleCollectService;
+  private final NewsArticleCollectService newsArticleCollectService;
 
-    //매 시간 0분 0초 newsArticleCollectService.collectAll()을 실행한다.
-    @Scheduled(cron = "0 0 * * * *")
-    public void collectArticlesEveryHour() {
+  //매 시간 0분 0초 newsArticleCollectService.collectAll()을 실행한다.
+  @Scheduled(cron = "0 0 * * * *")
+  public void collectArticlesEveryHour() {
 
-        log.info("뉴스 기사 수집 배치 시작");
+    log.info("뉴스 기사 수집 배치 시작");
 
-        try {
-            newsArticleCollectService.collectAll();
-        } catch (Exception e) {
-            log.error("뉴스 기사 수집 배치 실패", e);
-            //필요시 알림 발송 or 재시도 로직 추가
-        }
-
-        log.info("뉴스 기사 수집 배치 종료");
+    try {
+      newsArticleCollectService.collectAll();
+    } catch (Exception e) {
+      log.error("뉴스 기사 수집 배치 실패", e);
+      //필요시 알림 발송 or 재시도 로직 추가
     }
+
+    log.info("뉴스 기사 수집 배치 종료");
+  }
 }

--- a/src/main/java/com/springboot/monew/newsarticles/service/NaverNewsApiClient.java
+++ b/src/main/java/com/springboot/monew/newsarticles/service/NaverNewsApiClient.java
@@ -2,14 +2,12 @@ package com.springboot.monew.newsarticles.service;
 
 import com.springboot.monew.newsarticles.dto.NaverNewsItem;
 import com.springboot.monew.newsarticles.dto.response.NaverNewsResponse;
-import lombok.RequiredArgsConstructor;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.client.RestClientException;
-
-import java.util.List;
 
 @Slf4j
 @Service
@@ -30,7 +28,7 @@ public class NaverNewsApiClient {
   public NaverNewsApiClient(
       @Value("${naver.api.key}") String clientId,
       @Value("${naver.api.secret}") String clientSecret,
-      RestClient restClient){
+      RestClient restClient) {
     this.clientId = clientId;
     this.clientSecret = clientSecret;
     this.restClient = restClient;
@@ -59,8 +57,7 @@ public class NaverNewsApiClient {
 
       return response == null || response.articles() == null ? List.of() : response.articles();
 
-    }
-    catch (RestClientException ex){
+    } catch (RestClientException ex) {
       log.warn("Naver API 호출 실패. query={}", query, ex);
       return List.of();
     }

--- a/src/main/java/com/springboot/monew/newsarticles/service/NewsArticleCollectService.java
+++ b/src/main/java/com/springboot/monew/newsarticles/service/NewsArticleCollectService.java
@@ -1,13 +1,12 @@
 package com.springboot.monew.newsarticles.service;
 
 import com.springboot.monew.interest.dto.response.InterestKeywordInfo;
-import com.springboot.monew.interest.entity.Interest;
 import com.springboot.monew.interest.repository.InterestKeywordRepository;
-import com.springboot.monew.interest.repository.InterestRepository;
 import com.springboot.monew.newsarticles.dto.CollectedArticleWithInterest;
-import com.springboot.monew.newsarticles.service.collector.ArticleCollector;
 import com.springboot.monew.newsarticles.dto.response.CollectedArticle;
+import com.springboot.monew.newsarticles.service.collector.ArticleCollector;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -15,9 +14,6 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 //전체 수집 실행용 서비스
 //네이버 수집, 연합뉴스 수집, 한국경제 수집...을 한번에 실행
@@ -26,73 +22,73 @@ import java.util.List;
 @RequiredArgsConstructor
 public class NewsArticleCollectService {
 
-    //네이버수집기,연합뉴스수집기등이 List 형태로 들어간다.
-    private final List<ArticleCollector> collectors;
-    private final NewsArticleService newsArticleService;
-    private final InterestKeywordRepository interestKeywordRepository;
+  //네이버수집기,연합뉴스수집기등이 List 형태로 들어간다.
+  private final List<ArticleCollector> collectors;
+  private final NewsArticleService newsArticleService;
+  private final InterestKeywordRepository interestKeywordRepository;
 
-    //전체에서 수집
-    //단 하나의 외부 API만 느린 응답이 있어도 DB 트랜잭션이 길게 유지되어 DB연결을 불필요하게 점유한다.
-    //따라서 newsArticleService.saveAll안에서 트랜잭션 적용하는게 맞다.
-    //@Transactional
-    public void collectAll() {
+  //전체에서 수집
+  //단 하나의 외부 API만 느린 응답이 있어도 DB 트랜잭션이 길게 유지되어 DB연결을 불필요하게 점유한다.
+  //따라서 newsArticleService.saveAll안에서 트랜잭션 적용하는게 맞다.
+  //@Transactional
+  public void collectAll() {
 
-        //(관심사 id, 키워드) 리스트
-        List<InterestKeywordInfo> infos = interestKeywordRepository.findAllInterestKeywordInfos();
+    //(관심사 id, 키워드) 리스트
+    List<InterestKeywordInfo> infos = interestKeywordRepository.findAllInterestKeywordInfos();
 
-        //keyword -> interestIds
-        //{"키워드" -> [관심사 ID]}식으로 변경
-        // 하나의 키워드가 여러 관심사에 연결될 수도 있다.
-        // "ai" ->[기술, 스타트업, 투자] 이런식으로 ..
-        Map<String, Set<UUID>> keywordToInterestIds = infos.stream()
-            .collect(Collectors.groupingBy(
-                info -> info.keywordName().toLowerCase(),
-                Collectors.mapping(InterestKeywordInfo::interestId, Collectors.toSet())     //interestId 꺼낸다음에 Set으로 모아라.
-            ));
+    //keyword -> interestIds
+    //{"키워드" -> [관심사 ID]}식으로 변경
+    // 하나의 키워드가 여러 관심사에 연결될 수도 있다.
+    // "ai" ->[기술, 스타트업, 투자] 이런식으로 ..
+    Map<String, Set<UUID>> keywordToInterestIds = infos.stream()
+        .collect(Collectors.groupingBy(
+            info -> info.keywordName().toLowerCase(),
+            Collectors.mapping(InterestKeywordInfo::interestId,
+                Collectors.toSet())     //interestId 꺼낸다음에 Set으로 모아라.
+        ));
 
-        //키워드 리스트 추출
-        List<String> keywords = new ArrayList<>(keywordToInterestIds.keySet());
+    //키워드 리스트 추출
+    List<String> keywords = new ArrayList<>(keywordToInterestIds.keySet());
 
-        log.info("키워드 리스트={}", keywords);
+    log.info("키워드 리스트={}", keywords);
 
-        for (ArticleCollector collector : collectors) {
-            try {
-                List<CollectedArticle> collectedArticles = collector.collect(keywords);
+    for (ArticleCollector collector : collectors) {
+      try {
+        List<CollectedArticle> collectedArticles = collector.collect(keywords);
 
-                List<CollectedArticleWithInterest> matchedArticles = collectedArticles.stream()
-                    .map(article -> {
-                        Set<UUID> matchedInterestIds = findMatchedInterestIds(article,
-                            keywordToInterestIds);
+        List<CollectedArticleWithInterest> matchedArticles = collectedArticles.stream()
+            .map(article -> {
+              Set<UUID> matchedInterestIds = findMatchedInterestIds(article,
+                  keywordToInterestIds);
 
-                        return new CollectedArticleWithInterest(article, matchedInterestIds);
-                    })
-                    .filter(item -> !item.interestIds().isEmpty())
-                    .toList();
+              return new CollectedArticleWithInterest(article, matchedInterestIds);
+            })
+            .filter(item -> !item.interestIds().isEmpty())
+            .toList();
 
-                newsArticleService.saveAll(matchedArticles);
-            }
-            catch (Exception e) {
-                log.error("기사 수집 실패 source={}", collector.getSource(), e);
-            }
+        newsArticleService.saveAll(matchedArticles);
+      } catch (Exception e) {
+        log.error("기사 수집 실패 source={}", collector.getSource(), e);
+      }
 
-        }
     }
+  }
 
-    private Set<UUID> findMatchedInterestIds(
-        CollectedArticle article,
-        Map<String, Set<UUID>> keywordToInterestIds
-    ) {
-        //text = 제목 + 요약 소문자로 합친 문자열
-        String text = (article.title() + " " + article.summary()).toLowerCase();
+  private Set<UUID> findMatchedInterestIds(
+      CollectedArticle article,
+      Map<String, Set<UUID>> keywordToInterestIds
+  ) {
+    //text = 제목 + 요약 소문자로 합친 문자열
+    String text = (article.title() + " " + article.summary()).toLowerCase();
 
-        //"손흥민" -> [축구, 운동선수] 이런식으로 키워드 -> [관심사1, 관심사2 ..] 이런형태
-        //제목과 요약에 해당 키워드가 있으면 그 article은 관심사1, 관심사 2 ... 이런식으로 매칭이 된다.
-        // (기사1, [관심사1]), (기사2, [관심사1, 관심사2]) 이런식의 결과 return
-        return keywordToInterestIds.entrySet().stream()
-            .filter(entry -> text.contains(entry.getKey()))
-            .flatMap(entry -> entry.getValue().stream())
-            .collect(Collectors.toSet());
-    }
+    //"손흥민" -> [축구, 운동선수] 이런식으로 키워드 -> [관심사1, 관심사2 ..] 이런형태
+    //제목과 요약에 해당 키워드가 있으면 그 article은 관심사1, 관심사 2 ... 이런식으로 매칭이 된다.
+    // (기사1, [관심사1]), (기사2, [관심사1, 관심사2]) 이런식의 결과 return
+    return keywordToInterestIds.entrySet().stream()
+        .filter(entry -> text.contains(entry.getKey()))
+        .flatMap(entry -> entry.getValue().stream())
+        .collect(Collectors.toSet());
+  }
 }
 
 

--- a/src/main/java/com/springboot/monew/newsarticles/service/NewsArticleService.java
+++ b/src/main/java/com/springboot/monew/newsarticles/service/NewsArticleService.java
@@ -5,155 +5,179 @@ import com.springboot.monew.interest.repository.InterestRepository;
 import com.springboot.monew.newsarticles.dto.CollectedArticleWithInterest;
 import com.springboot.monew.newsarticles.entity.ArticleInterest;
 import com.springboot.monew.newsarticles.entity.NewsArticle;
+import com.springboot.monew.newsarticles.exception.ArticleException;
+import com.springboot.monew.newsarticles.exception.NewsArticleErrorCode;
 import com.springboot.monew.newsarticles.mapper.NewsArticleMapper;
 import com.springboot.monew.newsarticles.repository.ArticleInterestRepository;
 import com.springboot.monew.newsarticles.repository.NewsArticleRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class NewsArticleService {
 
-    private final NewsArticleRepository newsArticleRepository;
-    private final NewsArticleMapper newsArticleMapper;
-    private final InterestRepository interestRepository;
-    private final ArticleInterestRepository articleInterestRepository;
+  private final NewsArticleRepository newsArticleRepository;
+  private final NewsArticleMapper newsArticleMapper;
+  private final InterestRepository interestRepository;
+  private final ArticleInterestRepository articleInterestRepository;
 
-    @Transactional
-    public void saveAll(List<CollectedArticleWithInterest> articlesWithInterests) {
+  @Transactional
+  public void saveAll(List<CollectedArticleWithInterest> articlesWithInterests) {
 
-        if (articlesWithInterests == null || articlesWithInterests.isEmpty()) {
-            return;
-        }
+    if (articlesWithInterests == null || articlesWithInterests.isEmpty()) {
+      return;
+    }
 
-        // 1. originalLink가 유효한 데이터만 남기고,
-        // 같은 originalLink는 interestIds를 합쳐서 하나로 만든다.
-        List<CollectedArticleWithInterest> distinctItems = new ArrayList<>(
-            articlesWithInterests.stream()
-                .filter(item -> item.article() != null)
-                .filter(item -> item.article().originalLink() != null && !item.article().originalLink().isBlank())
-                .collect(Collectors.toMap(
-                    item -> item.article().originalLink(),
-                    item -> item,
-                    (existing, replacement) -> new CollectedArticleWithInterest(
-                        existing.article(),
-                        Stream.concat(
-                                existing.interestIds().stream(),
-                                replacement.interestIds().stream()
-                            )
-                            .collect(Collectors.toSet())
-                    )
-                ))
-                .values()
-        );
-
-        if (distinctItems.isEmpty()) {
-            return;
-        }
-
-        // 2. 요청에 들어온 originalLink 목록
-        Set<String> originalLinks = distinctItems.stream()
-            .map(item -> item.article().originalLink())
-            .collect(Collectors.toSet());
-
-        // 3. DB에 이미 존재하는 기사 조회
-        List<NewsArticle> existingArticles = newsArticleRepository.findAllByOriginalLinkIn(originalLinks);
-
-        Map<String, NewsArticle> existingArticleMap = existingArticles.stream()
+    // 1. originalLink가 유효한 데이터만 남기고,
+    // 같은 originalLink는 interestIds를 합쳐서 하나로 만든다.
+    List<CollectedArticleWithInterest> distinctItems = new ArrayList<>(
+        articlesWithInterests.stream()
+            .filter(item -> item.article() != null)
+            .filter(item -> item.article().originalLink() != null && !item.article().originalLink()
+                .isBlank())
             .collect(Collectors.toMap(
-                NewsArticle::getOriginalLink,
-                article -> article,
-                (left, right) -> left
-            ));
-
-        Set<String> existingLinks = existingArticleMap.keySet();
-
-        // 4. DB에 없는 신규 기사만 엔티티로 변환 후 저장
-        List<NewsArticle> newArticles = distinctItems.stream()
-            .filter(item -> !existingLinks.contains(item.article().originalLink()))
-            .map(item -> newsArticleMapper.toEntity(item.article()))
-            .toList();
-
-        List<NewsArticle> savedArticles = newArticles.isEmpty()
-            ? List.of()
-            : newsArticleRepository.saveAll(newArticles);
-
-        // 5. 기존 기사 + 신규 저장 기사 모두 합쳐서 originalLink -> NewsArticle 맵 생성
-        Map<String, NewsArticle> allArticleMap = Stream.concat(existingArticles.stream(), savedArticles.stream())
-            .collect(Collectors.toMap(
-                NewsArticle::getOriginalLink,
-                article -> article,
-                (left, right) -> left
-            ));
-
-        // 6. 이번 요청에서 사용될 모든 기사 엔티티 목록
-        List<NewsArticle> targetArticles = distinctItems.stream()
-            .map(item -> allArticleMap.get(item.article().originalLink()))
-            .filter(article -> article != null)
-            .toList();
-
-        if (targetArticles.isEmpty()) {
-            return;
-        }
-
-        // 7. 이미 존재하는 article_interest 연결 조회
-        List<ArticleInterest> existingArticleInterests =
-            articleInterestRepository.findAllByNewsArticleIn(targetArticles);
-
-        // (newsArticleId, interestId) 조합을 문자열 키로 만들어 중복 확인용 Set 생성
-        Set<String> existingRelationKeys = existingArticleInterests.stream()
-            .map(ai -> buildRelationKey(
-                ai.getNewsArticle().getId(),
-                ai.getInterest().getId()
+                item -> item.article().originalLink(),
+                item -> item,
+                (existing, replacement) -> new CollectedArticleWithInterest(
+                    existing.article(),
+                    Stream.concat(
+                            existing.interestIds().stream(),
+                            replacement.interestIds().stream()
+                        )
+                        .collect(Collectors.toSet())
+                )
             ))
-            .collect(Collectors.toSet());
+            .values()
+    );
 
-        // 8. 새로 저장할 article_interests 생성
-        List<ArticleInterest> newArticleInterests = distinctItems.stream()
-            .flatMap(item -> {
-                NewsArticle article = allArticleMap.get(item.article().originalLink());
+    if (distinctItems.isEmpty()) {
+      return;
+    }
 
-                if (article == null) {
-                    return Stream.empty();
+    // 2. 요청에 들어온 originalLink 목록
+    Set<String> originalLinks = distinctItems.stream()
+        .map(item -> item.article().originalLink())
+        .collect(Collectors.toSet());
+
+    // 3. DB에 이미 존재하는 기사 조회
+    List<NewsArticle> existingArticles = newsArticleRepository.findAllByOriginalLinkIn(
+        originalLinks);
+
+    Map<String, NewsArticle> existingArticleMap = existingArticles.stream()
+        .collect(Collectors.toMap(
+            NewsArticle::getOriginalLink,
+            article -> article,
+            (left, right) -> left
+        ));
+
+    Set<String> existingLinks = existingArticleMap.keySet();
+
+    // 4. DB에 없는 신규 기사만 엔티티로 변환 후 저장
+    List<NewsArticle> newArticles = distinctItems.stream()
+        .filter(item -> !existingLinks.contains(item.article().originalLink()))
+        .map(item -> newsArticleMapper.toEntity(item.article()))
+        .toList();
+
+    List<NewsArticle> savedArticles = newArticles.isEmpty()
+        ? List.of()
+        : newsArticleRepository.saveAll(newArticles);
+
+    // 5. 기존 기사 + 신규 저장 기사 모두 합쳐서 originalLink -> NewsArticle 맵 생성
+    Map<String, NewsArticle> allArticleMap = Stream.concat(existingArticles.stream(),
+            savedArticles.stream())
+        .collect(Collectors.toMap(
+            NewsArticle::getOriginalLink,
+            article -> article,
+            (left, right) -> left
+        ));
+
+    // 6. 이번 요청에서 사용될 모든 기사 엔티티 목록
+    List<NewsArticle> targetArticles = distinctItems.stream()
+        .map(item -> allArticleMap.get(item.article().originalLink()))
+        .filter(article -> article != null)
+        .toList();
+
+    if (targetArticles.isEmpty()) {
+      return;
+    }
+
+    // 7. 이미 존재하는 article_interest 연결 조회
+    List<ArticleInterest> existingArticleInterests =
+        articleInterestRepository.findAllByNewsArticleIn(targetArticles);
+
+    // (newsArticleId, interestId) 조합을 문자열 키로 만들어 중복 확인용 Set 생성
+    Set<String> existingRelationKeys = existingArticleInterests.stream()
+        .map(ai -> buildRelationKey(
+            ai.getNewsArticle().getId(),
+            ai.getInterest().getId()
+        ))
+        .collect(Collectors.toSet());
+
+    // 8. 새로 저장할 article_interests 생성
+    List<ArticleInterest> newArticleInterests = distinctItems.stream()
+        .flatMap(item -> {
+          NewsArticle article = allArticleMap.get(item.article().originalLink());
+
+          if (article == null) {
+            return Stream.empty();
+          }
+
+          return item.interestIds().stream()
+              .map(interestId -> {
+                String relationKey = buildRelationKey(article.getId(), interestId);
+
+                if (existingRelationKeys.contains(relationKey)) {
+                  return null;
                 }
 
-                return item.interestIds().stream()
-                    .map(interestId -> {
-                        String relationKey = buildRelationKey(article.getId(), interestId);
+                Interest interestRef = interestRepository.getReferenceById(interestId);
+                return new ArticleInterest(article, interestRef);
+              })
+              .filter(articleInterest -> articleInterest != null);
+        })
+        .toList();
 
-                        if (existingRelationKeys.contains(relationKey)) {
-                            return null;
-                        }
-
-                        Interest interestRef = interestRepository.getReferenceById(interestId);
-                        return new ArticleInterest(article, interestRef);
-                    })
-                    .filter(articleInterest -> articleInterest != null);
-            })
-            .toList();
-
-        if (!newArticleInterests.isEmpty()) {
-            articleInterestRepository.saveAll(newArticleInterests);
-        }
-
-        log.info("뉴스기사 저장 완료 - 신규 기사 수: {}, 신규 기사-관심사 연결 수: {}",
-            savedArticles.size(),
-            newArticleInterests.size());
+    if (!newArticleInterests.isEmpty()) {
+      articleInterestRepository.saveAll(newArticleInterests);
     }
 
-    private String buildRelationKey(Object articleId, Object interestId) {
-        return articleId + ":" + interestId;
+    log.info("뉴스기사 저장 완료 - 신규 기사 수: {}, 신규 기사-관심사 연결 수: {}",
+        savedArticles.size(),
+        newArticleInterests.size());
+  }
+
+  private String buildRelationKey(Object articleId, Object interestId) {
+    return articleId + ":" + interestId;
+  }
+
+  public void hardDelete(UUID articleId) {
+
+    //뉴스기사 존재검증
+    if (!newsArticleRepository.existsById(articleId)) {
+      throw new ArticleException(NewsArticleErrorCode.NEWS_ARTICE_NOT_FOUND,
+          Map.of("articleId", articleId));
     }
+    newsArticleRepository.deleteById(articleId);
+  }
+
+  public void sortDelete(UUID articleId) {
+
+    //뉴스기사 존재검증
+    if (!newsArticleRepository.existsById(articleId)) {
+      throw new ArticleException(NewsArticleErrorCode.NEWS_ARTICE_NOT_FOUND,
+          Map.of("articleId", articleId));
+    }
+    newsArticleRepository.deleteById(articleId);
+  }
 }

--- a/src/main/java/com/springboot/monew/newsarticles/service/NewsArticleService.java
+++ b/src/main/java/com/springboot/monew/newsarticles/service/NewsArticleService.java
@@ -185,6 +185,6 @@ public class NewsArticleService {
 
   private NewsArticle getNewsArticle(UUID articleId) {
     return newsArticleRepository.findById(articleId).orElseThrow(
-        () -> new ArticleException(NewsArticleErrorCode.NEWS_ARTICE_NOT_FOUND, Map.of("articleId", articleId)));
+        () -> new ArticleException(NewsArticleErrorCode.NEWS_ARTICLE_NOT_FOUND, Map.of("articleId", articleId)));
   }
 }

--- a/src/main/java/com/springboot/monew/newsarticles/service/NewsArticleService.java
+++ b/src/main/java/com/springboot/monew/newsarticles/service/NewsArticleService.java
@@ -161,23 +161,30 @@ public class NewsArticleService {
     return articleId + ":" + interestId;
   }
 
+  // 뉴스기사 물리 삭제
+  // 뉴스기사 관련된 모든 row 삭제 -> DB 제약조건에 따라 삭제
   public void hardDelete(UUID articleId) {
 
-    //뉴스기사 존재검증
-    if (!newsArticleRepository.existsById(articleId)) {
-      throw new ArticleException(NewsArticleErrorCode.NEWS_ARTICE_NOT_FOUND,
-          Map.of("articleId", articleId));
-    }
-    newsArticleRepository.deleteById(articleId);
+    NewsArticle newsArticle = getNewsArticle(articleId);
+    newsArticleRepository.delete(newsArticle);
+    log.info("뉴스기사 물리 삭제 완료 - articleId: {}", articleId);
   }
 
-  public void sortDelete(UUID articleId) {
+  // 뉴스기사 논리 삭제
+  public void softDelete(UUID articleId) {
 
-    //뉴스기사 존재검증
-    if (!newsArticleRepository.existsById(articleId)) {
-      throw new ArticleException(NewsArticleErrorCode.NEWS_ARTICE_NOT_FOUND,
-          Map.of("articleId", articleId));
+    NewsArticle newsArticle = getNewsArticle(articleId);
+
+    if (newsArticle.isDeleted()){
+      throw new ArticleException(NewsArticleErrorCode.NEWS_ARTICLE_ALREADY_DELETED, Map.of("articleId", articleId));
     }
-    newsArticleRepository.deleteById(articleId);
+    newsArticle.delete();
+    log.info("뉴스기사 논리 삭제 완료 - articleId: {}", articleId);
+
+  }
+
+  private NewsArticle getNewsArticle(UUID articleId) {
+    return newsArticleRepository.findById(articleId).orElseThrow(
+        () -> new ArticleException(NewsArticleErrorCode.NEWS_ARTICE_NOT_FOUND, Map.of("articleId", articleId)));
   }
 }

--- a/src/main/java/com/springboot/monew/newsarticles/service/NewsArticleService.java
+++ b/src/main/java/com/springboot/monew/newsarticles/service/NewsArticleService.java
@@ -163,6 +163,7 @@ public class NewsArticleService {
 
   // 뉴스기사 물리 삭제
   // 뉴스기사 관련된 모든 row 삭제 -> DB 제약조건에 따라 삭제
+  @Transactional
   public void hardDelete(UUID articleId) {
 
     NewsArticle newsArticle = getNewsArticle(articleId);
@@ -171,6 +172,7 @@ public class NewsArticleService {
   }
 
   // 뉴스기사 논리 삭제
+  @Transactional
   public void softDelete(UUID articleId) {
 
     NewsArticle newsArticle = getNewsArticle(articleId);

--- a/src/main/java/com/springboot/monew/newsarticles/service/RssClient.java
+++ b/src/main/java/com/springboot/monew/newsarticles/service/RssClient.java
@@ -1,62 +1,61 @@
 package com.springboot.monew.newsarticles.service;
 
 import com.springboot.monew.newsarticles.dto.RssItem;
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
-import org.springframework.stereotype.Component;
-
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.springframework.stereotype.Component;
 
 @Component
 public class RssClient {
 
-    public List<RssItem> read(String url) {
-        try {
-            // XML 전체를 Document 객체로 가져온다.
-            Document doc = Jsoup.connect(url).get();
+  public List<RssItem> read(String url) {
+    try {
+      // XML 전체를 Document 객체로 가져온다.
+      Document doc = Jsoup.connect(url).get();
 
-            List<RssItem> items = new ArrayList<>();
+      List<RssItem> items = new ArrayList<>();
 
-            //XML에서 item 태그를 하나씩 가져와서 for문 돌면서 title,link,description등으로 파싱.
-            for (Element item : doc.select("item")) {
+      //XML에서 item 태그를 하나씩 가져와서 for문 돌면서 title,link,description등으로 파싱.
+      for (Element item : doc.select("item")) {
 
-                String title = item.selectFirst("title").text();
-                String link = item.selectFirst("link").text();
+        String title = item.selectFirst("title").text();
+        String link = item.selectFirst("link").text();
 
-                //description이 없는 경우도 있어서 null 허용.
-                Element descriptionElement = item.selectFirst("description");
-                String description = descriptionElement != null ? descriptionElement.text() : "";
+        //description이 없는 경우도 있어서 null 허용.
+        Element descriptionElement = item.selectFirst("description");
+        String description = descriptionElement != null ? descriptionElement.text() : "";
 
-                String pubDate = item.selectFirst("pubDate").text();
+        String pubDate = item.selectFirst("pubDate").text();
 
-                //RssItem형으로 변환해서 반환
-                items.add(new RssItem(
-                        title,
-                        link,
-                        description,
-                        parseDate(pubDate)
-                ));
-            }
+        //RssItem형으로 변환해서 반환
+        items.add(new RssItem(
+            title,
+            link,
+            description,
+            parseDate(pubDate)
+        ));
+      }
 
-            return items;
+      return items;
 
-        } catch (Exception e) {
-            throw new RuntimeException("RSS 파싱 실패", e);
-        }
+    } catch (Exception e) {
+      throw new RuntimeException("RSS 파싱 실패", e);
     }
+  }
 
-    //Fri, 17 Apr 2026 11:12:07 +0900 이런 날짜를
-    //2026-04-17T10:30:00+09:00 이런형식으로 변환해준다.
-    private Instant parseDate(String pubDate) {
-        DateTimeFormatter formatter =
-                DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss Z", Locale.ENGLISH);
+  //Fri, 17 Apr 2026 11:12:07 +0900 이런 날짜를
+  //2026-04-17T10:30:00+09:00 이런형식으로 변환해준다.
+  private Instant parseDate(String pubDate) {
+    DateTimeFormatter formatter =
+        DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss Z", Locale.ENGLISH);
 
-        return ZonedDateTime.parse(pubDate, formatter).toInstant();
-    }
+    return ZonedDateTime.parse(pubDate, formatter).toInstant();
+  }
 }

--- a/src/main/java/com/springboot/monew/newsarticles/service/collector/ArticleCollector.java
+++ b/src/main/java/com/springboot/monew/newsarticles/service/collector/ArticleCollector.java
@@ -2,14 +2,14 @@ package com.springboot.monew.newsarticles.service.collector;
 
 import com.springboot.monew.newsarticles.dto.response.CollectedArticle;
 import com.springboot.monew.newsarticles.enums.ArticleSource;
-
 import java.util.List;
 
 //기사 수집 방법을 추상화
 public interface ArticleCollector {
-    //기사 출처
-    ArticleSource getSource();
 
-    //키워드 리스트를 넣고 기사 수집
-    List<CollectedArticle> collect(List<String> keywords);
+  //기사 출처
+  ArticleSource getSource();
+
+  //키워드 리스트를 넣고 기사 수집
+  List<CollectedArticle> collect(List<String> keywords);
 }

--- a/src/main/java/com/springboot/monew/newsarticles/service/collector/ChosunRssCollector.java
+++ b/src/main/java/com/springboot/monew/newsarticles/service/collector/ChosunRssCollector.java
@@ -3,11 +3,10 @@ package com.springboot.monew.newsarticles.service.collector;
 import com.springboot.monew.newsarticles.dto.response.CollectedArticle;
 import com.springboot.monew.newsarticles.enums.ArticleSource;
 import com.springboot.monew.newsarticles.service.RssClient;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 //조선일보 뉴스기사 수집기
 @Slf4j
@@ -15,31 +14,32 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ChosunRssCollector implements ArticleCollector {
 
-    private final RssClient rssClient;
+  private final RssClient rssClient;
 
-    @Override
-    public ArticleSource getSource() {
-        return ArticleSource.CHOSUN;
-    }
+  @Override
+  public ArticleSource getSource() {
+    return ArticleSource.CHOSUN;
+  }
 
-    //네이버 API처럼 키워드 검색은 아니다.
-    //일단 가져오고, NewsArticleCollectService에서 키워드 필터링한다.
-    @Override
-    public List<CollectedArticle> collect(List<String> keywords) {
-        List<CollectedArticle> result = rssClient.read("https://www.chosun.com/arc/outboundfeeds/rss/?outputType=xml")
-                .stream()
-                .filter(item -> item.link() != null && !item.link().isBlank())
-                .map(item -> new CollectedArticle(
-                        ArticleSource.CHOSUN,
-                        item.link(),
-                        item.title(),
-                        item.publishedAt(),
-                        item.description()
-                ))
-                .toList();
+  //네이버 API처럼 키워드 검색은 아니다.
+  //일단 가져오고, NewsArticleCollectService에서 키워드 필터링한다.
+  @Override
+  public List<CollectedArticle> collect(List<String> keywords) {
+    List<CollectedArticle> result = rssClient.read(
+            "https://www.chosun.com/arc/outboundfeeds/rss/?outputType=xml")
+        .stream()
+        .filter(item -> item.link() != null && !item.link().isBlank())
+        .map(item -> new CollectedArticle(
+            ArticleSource.CHOSUN,
+            item.link(),
+            item.title(),
+            item.publishedAt(),
+            item.description()
+        ))
+        .toList();
 
-        log.info("조선일보 수집 개수= {}", result.size());
+    log.info("조선일보 수집 개수= {}", result.size());
 
-        return result;
-    }
+    return result;
+  }
 }

--- a/src/main/java/com/springboot/monew/newsarticles/service/collector/HankyungRssCollector.java
+++ b/src/main/java/com/springboot/monew/newsarticles/service/collector/HankyungRssCollector.java
@@ -3,11 +3,10 @@ package com.springboot.monew.newsarticles.service.collector;
 import com.springboot.monew.newsarticles.dto.response.CollectedArticle;
 import com.springboot.monew.newsarticles.enums.ArticleSource;
 import com.springboot.monew.newsarticles.service.RssClient;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 //한국경제 뉴스기사 수집기
 @Slf4j
@@ -15,31 +14,31 @@ import java.util.List;
 @RequiredArgsConstructor
 public class HankyungRssCollector implements ArticleCollector {
 
-    private final RssClient rssClient;
+  private final RssClient rssClient;
 
-    @Override
-    public ArticleSource getSource() {
-        return ArticleSource.HANKYUNG;
-    }
+  @Override
+  public ArticleSource getSource() {
+    return ArticleSource.HANKYUNG;
+  }
 
-    //네이버 API처럼 키워드 검색은 아니다.
-    //일단 가져오고, NewsArticleCollectService에서 키워드 필터링한다.
-    @Override
-    public List<CollectedArticle> collect(List<String> keywords) {
-        List<CollectedArticle> result = rssClient.read("https://www.hankyung.com/feed/all-news")
-                .stream()
-                .filter(item -> item.link() != null && !item.link().isBlank())
-                .map(item -> new CollectedArticle(
-                        ArticleSource.HANKYUNG,
-                        item.link(),
-                        item.title(),
-                        item.publishedAt(),
-                        item.description()
-                ))
-                .toList();
+  //네이버 API처럼 키워드 검색은 아니다.
+  //일단 가져오고, NewsArticleCollectService에서 키워드 필터링한다.
+  @Override
+  public List<CollectedArticle> collect(List<String> keywords) {
+    List<CollectedArticle> result = rssClient.read("https://www.hankyung.com/feed/all-news")
+        .stream()
+        .filter(item -> item.link() != null && !item.link().isBlank())
+        .map(item -> new CollectedArticle(
+            ArticleSource.HANKYUNG,
+            item.link(),
+            item.title(),
+            item.publishedAt(),
+            item.description()
+        ))
+        .toList();
 
-        log.info("한국경제 수집 개수= {}", result.size());
+    log.info("한국경제 수집 개수= {}", result.size());
 
-        return result;
-    }
+    return result;
+  }
 }

--- a/src/main/java/com/springboot/monew/newsarticles/service/collector/NaverArticleCollector.java
+++ b/src/main/java/com/springboot/monew/newsarticles/service/collector/NaverArticleCollector.java
@@ -4,93 +4,92 @@ import com.springboot.monew.newsarticles.dto.NaverNewsItem;
 import com.springboot.monew.newsarticles.dto.response.CollectedArticle;
 import com.springboot.monew.newsarticles.enums.ArticleSource;
 import com.springboot.monew.newsarticles.service.NaverNewsApiClient;
-import java.time.format.DateTimeParseException;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Locale;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class NaverArticleCollector implements ArticleCollector {
 
-    private final NaverNewsApiClient naverNewsApiClient;
+  private final NaverNewsApiClient naverNewsApiClient;
 
-    @Override
-    public ArticleSource getSource() {
-        return ArticleSource.NAVER;
+  @Override
+  public ArticleSource getSource() {
+    return ArticleSource.NAVER;
+  }
+
+  @Override
+  public List<CollectedArticle> collect(List<String> keywords) {
+
+    log.info("네이버 뉴스 수집 시작 - keywords={}", keywords);
+
+    List<CollectedArticle> result = keywords.stream()
+        .flatMap(keyword -> naverNewsApiClient.searchNews(keyword).stream())
+        .map(this::toCollectedArticle)
+        .filter(article -> {
+          boolean valid = article.publishedAt() != null;
+          if (!valid) {
+            log.warn("publishedAt 없음으로 기사 제외 - originallink={}", article.originalLink());
+          }
+          return valid;
+        })
+        .distinct()
+        .toList();
+
+    log.info("네이버 뉴스 수집 종료 - 수집된 기사 수={}", result.size());
+
+    return result;
+  }
+
+  private CollectedArticle toCollectedArticle(NaverNewsItem item) {
+    Instant publishedAt = parsePublishedAt(item.pubDate());
+
+    if (publishedAt == null) {
+      log.warn(
+          "pubDate 파싱 실패 - originallink={}, pubDate={}",
+          item.originallink(),
+          item.pubDate()
+      );
     }
 
-    @Override
-    public List<CollectedArticle> collect(List<String> keywords) {
+    return new CollectedArticle(
+        ArticleSource.NAVER,
+        item.originallink(),
+        cleanHtml(item.title()),
+        publishedAt,
+        cleanHtml(item.description())
+    );
+  }
 
-        log.info("네이버 뉴스 수집 시작 - keywords={}", keywords);
+  private String cleanHtml(String text) {
+    if (text == null) {
+      return "";
+    }
+    return text.replaceAll("<.*?>", "").trim();
+  }
 
-        List<CollectedArticle> result = keywords.stream()
-            .flatMap(keyword -> naverNewsApiClient.searchNews(keyword).stream())
-            .map(this::toCollectedArticle)
-            .filter(article -> {
-                boolean valid = article.publishedAt() != null;
-                if (!valid) {
-                    log.warn("publishedAt 없음으로 기사 제외 - originallink={}", article.originalLink());
-                }
-                return valid;
-            })
-            .distinct()
-            .toList();
-
-        log.info("네이버 뉴스 수집 종료 - 수집된 기사 수={}", result.size());
-
-        return result;
+  private Instant parsePublishedAt(String pubDate) {
+    if (pubDate == null || pubDate.isBlank()) {
+      log.warn("pubDate 없음 - pubDate={}", pubDate);
+      return null;
     }
 
-    private CollectedArticle toCollectedArticle(NaverNewsItem item) {
-        Instant publishedAt = parsePublishedAt(item.pubDate());
+    DateTimeFormatter formatter =
+        DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss Z", Locale.ENGLISH);
 
-        if (publishedAt == null) {
-            log.warn(
-                "pubDate 파싱 실패 - originallink={}, pubDate={}",
-                item.originallink(),
-                item.pubDate()
-            );
-        }
-
-        return new CollectedArticle(
-            ArticleSource.NAVER,
-            item.originallink(),
-            cleanHtml(item.title()),
-            publishedAt,
-            cleanHtml(item.description())
-        );
+    try {
+      return ZonedDateTime.parse(pubDate, formatter).toInstant();
+    } catch (DateTimeParseException e) {
+      log.warn("pubDate 파싱 실패 - pubDate={}", pubDate, e);
+      return null;
     }
-
-    private String cleanHtml(String text) {
-        if (text == null) {
-            return "";
-        }
-        return text.replaceAll("<.*?>", "").trim();
-    }
-
-    private Instant parsePublishedAt(String pubDate) {
-        if (pubDate == null || pubDate.isBlank()) {
-            log.warn("pubDate 없음 - pubDate={}", pubDate);
-            return null;
-        }
-
-        DateTimeFormatter formatter =
-            DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss Z", Locale.ENGLISH);
-
-        try {
-            return ZonedDateTime.parse(pubDate, formatter).toInstant();
-        } catch (DateTimeParseException e) {
-            log.warn("pubDate 파싱 실패 - pubDate={}", pubDate, e);
-            return null;
-        }
-    }
+  }
 }

--- a/src/main/java/com/springboot/monew/newsarticles/service/collector/YonhapRssCollector.java
+++ b/src/main/java/com/springboot/monew/newsarticles/service/collector/YonhapRssCollector.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Service;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class YonhapRssCollector implements ArticleCollector{
+public class YonhapRssCollector implements ArticleCollector {
 
   private final RssClient rssClient;
 


### PR DESCRIPTION
Closes #19 #131 #133 #61 

## 📌 작업 내용
- [x] NewsArticleController 논리/물리 삭제 REST API 설계
- [x] NewsArticleErrorCode 추가
- [x] NewsArticleService 논리/물리 삭제 비즈니스 로직 구현

## 🔧 변경 사항
- 

## 반영 브랜치
`feature/#19/delete-newsarticle` -> `dev`

## 💬 기타 참고 사항
- 코드 포맷변경 때문에 실질적으로 수정하지 않은 파일까지 다 반영되었습니다.
- NewsArticleController
- NewsArticleErrorCode
- NewsArticleService
- 위 3개 파일의 논리/물리 삭제 기능 쪽만 체크해주시면 됩니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 뉴스 기사 소프트 삭제(일시 삭제) 및 하드 삭제(영구 삭제) API 추가
  * API 경로가 /api/article → /api/articles 로 변경

* **버그 수정 / 개선**
  * 삭제 처리 관련 오류 응답과 메시지 정비(존재하지 않는 기사, 이미 삭제된 기사에 대한 명확한 오류)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->