### PR TITLE
[Feat] 뉴스기사 조회이력 생성 기능 구현

### DIFF
--- a/src/main/java/com/springboot/monew/comment/repository/CommentRepository.java
+++ b/src/main/java/com/springboot/monew/comment/repository/CommentRepository.java
@@ -64,4 +64,7 @@ public interface CommentRepository extends JpaRepository<Comment, UUID> {
       @Param("cursor") String cursor,
       @Param("after") Instant after,
       @Param("limit") int limit);
+
+  //is_deleted가 false인 댓글 수 조회
+  long countByArticleIdAndIsDeletedFalse(UUID articleId);
 }

--- a/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleController.java
+++ b/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleController.java
@@ -38,7 +38,8 @@ public class NewsArticleController {
 
     NewsArticleViewDto newsArticleViewDto = newsArticleService.createView(articleId, userId);
 
-    return ResponseEntity.created(URI.create("/api/articles/" + articleId)).body(newsArticleViewDto);
+    //헤더: 생성된 리소스의 URL
+    return ResponseEntity.created(URI.create("/api/articles/" + articleId + "/article-views/" + newsArticleViewDto.id())).body(newsArticleViewDto);
 
   }
 

--- a/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleController.java
+++ b/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleController.java
@@ -37,7 +37,7 @@ public class NewsArticleController {
                                                        @RequestHeader("Monew-Request-User-ID") UUID userId) {
     log.debug("뉴스기사 뷰 등록 요청: articleId={} userId={}", articleId, userId);
 
-    NewsArticleViewDto newsArticleViewDto = newsArticleService.createView();
+    NewsArticleViewDto newsArticleViewDto = newsArticleService.createView(articleId, userId);
     return ResponseEntity.created(URI.create("/api/articles/" + articleId)).body(newsArticleViewDto);
 
   }

--- a/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleController.java
+++ b/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleController.java
@@ -35,9 +35,9 @@ public class NewsArticleController {
   @PostMapping("/{articleId}/article-views")
   public ResponseEntity<NewsArticleViewDto> createView(@PathVariable("articleId") UUID articleId,
                                                        @RequestHeader("Monew-Request-User-ID") UUID userId) {
-    log.debug("뉴스기사 뷰 등록 요청: articleId={} userId={}", articleId, userId);
 
     NewsArticleViewDto newsArticleViewDto = newsArticleService.createView(articleId, userId);
+
     return ResponseEntity.created(URI.create("/api/articles/" + articleId)).body(newsArticleViewDto);
 
   }
@@ -45,7 +45,7 @@ public class NewsArticleController {
   //뉴스기사 논리삭제
   @DeleteMapping("/{articleId}")
   public ResponseEntity<Void> softDelete(@PathVariable UUID articleId) {
-    log.debug("뉴스기사 논리삭제 요청: articleId={}", articleId);
+
     newsArticleService.softDelete(articleId);
 
     return ResponseEntity.noContent().build();
@@ -55,7 +55,6 @@ public class NewsArticleController {
   @DeleteMapping("/{articleId}/hard")
   public ResponseEntity<Void> hardDelete(@PathVariable("articleId") UUID articleId) {
 
-    log.debug("뉴스기사 물리삭제 요청: articleId={}", articleId);
     newsArticleService.hardDelete(articleId);
 
     //삭제 성공시 204

--- a/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleController.java
+++ b/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleController.java
@@ -1,7 +1,9 @@
 package com.springboot.monew.newsarticles.controller;
 
+import com.springboot.monew.newsarticles.dto.response.NewsArticleViewDto;
 import com.springboot.monew.newsarticles.service.NewsArticleCollectService;
 import com.springboot.monew.newsarticles.service.NewsArticleService;
+import java.net.URI;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -10,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -26,6 +29,17 @@ public class NewsArticleController {
   public ResponseEntity<String> collectNews() {
     newsArticleCollectService.collectAll();
     return ResponseEntity.ok("뉴스 수집 완료");
+  }
+
+  //기사 뷰 등록
+  @PostMapping("/{articleId}/article-views")
+  public ResponseEntity<NewsArticleViewDto> createView(@PathVariable("articleId") UUID articleId,
+                                                       @RequestHeader("Monew-Request-User-ID") UUID userId) {
+    log.debug("뉴스기사 뷰 등록 요청: articleId={} userId={}", articleId, userId);
+
+    NewsArticleViewDto newsArticleViewDto = newsArticleService.createView();
+    return ResponseEntity.created(URI.create("/api/articles/" + articleId)).body(newsArticleViewDto);
+
   }
 
   //뉴스기사 논리삭제

--- a/src/main/java/com/springboot/monew/newsarticles/dto/response/NewsArticleViewDto.java
+++ b/src/main/java/com/springboot/monew/newsarticles/dto/response/NewsArticleViewDto.java
@@ -1,0 +1,20 @@
+package com.springboot.monew.newsarticles.dto.response;
+
+import com.springboot.monew.newsarticles.enums.ArticleSource;
+import java.time.Instant;
+import java.util.UUID;
+
+public record NewsArticleViewDto (
+    UUID id,
+    UUID viewedBy,
+    Instant createdAt,
+    UUID articleId,
+    ArticleSource source,
+    String sourceUrl,
+    String articleTitle,
+    Instant articlePublishedDate,
+    String articleSummary,
+    Long articleCommentCount,
+    Long articleViewCount
+
+) {}

--- a/src/main/java/com/springboot/monew/newsarticles/entity/NewsArticle.java
+++ b/src/main/java/com/springboot/monew/newsarticles/entity/NewsArticle.java
@@ -57,11 +57,11 @@ public class NewsArticle extends BaseEntity {
     this.isDeleted = false;
   }
 
-//    // ===== 비즈니스 로직 =====
-//    public void increaseViewCount() {
-//        this.viewCount++;
-//    }
-//
+    // ===== 비즈니스 로직 =====
+    public void increaseViewCount() {
+        this.viewCount++;
+    }
+
     public void delete() {
         this.isDeleted = true;
     }

--- a/src/main/java/com/springboot/monew/newsarticles/entity/NewsArticle.java
+++ b/src/main/java/com/springboot/monew/newsarticles/entity/NewsArticle.java
@@ -57,10 +57,10 @@ public class NewsArticle extends BaseEntity {
     this.isDeleted = false;
   }
 
-    // ===== 비즈니스 로직 =====
-    public void increaseViewCount() {
-        this.viewCount++;
-    }
+//    // ===== 비즈니스 로직 =====
+//    public void increaseViewCount() {
+//        this.viewCount++;
+//    }
 
     public void delete() {
         this.isDeleted = true;

--- a/src/main/java/com/springboot/monew/newsarticles/exception/NewsArticleErrorCode.java
+++ b/src/main/java/com/springboot/monew/newsarticles/exception/NewsArticleErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum NewsArticleErrorCode implements ErrorCode {
   NEWS_ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "NA01", "뉴스기사를 찾을 수 없습니다."),
-  NEWS_ARTICLE_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "NA02", "이미 삭제된 뉴스기사입니다.");
+  NEWS_ARTICLE_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "NA02", "이미 삭제된 뉴스기사입니다."),
+  NEWS_ARTICLE_ALREADY_VIEWED(HttpStatus.BAD_REQUEST, "NA03", "이미 조회된 뉴스기사입니다.");
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/src/main/java/com/springboot/monew/newsarticles/mapper/NewsArticleViewMapper.java
+++ b/src/main/java/com/springboot/monew/newsarticles/mapper/NewsArticleViewMapper.java
@@ -1,0 +1,22 @@
+package com.springboot.monew.newsarticles.mapper;
+
+import com.springboot.monew.newsarticles.dto.response.NewsArticleViewDto;
+import com.springboot.monew.newsarticles.entity.ArticleView;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface NewsArticleViewMapper {
+
+  @Mapping(target = "viewedBy", source = "articleView.user.id")
+  @Mapping(target = "articleId", source = "articleView.newsArticle.id")
+  @Mapping(target = "source", source = "articleView.newsArticle.source")
+  @Mapping(target = "sourceUrl", source = "articleView.newsArticle.originalLink")
+  @Mapping(target = "articleTitle", source = "articleView.newsArticle.title")
+  @Mapping(target = "articlePublishedDate", source = "articleView.newsArticle.publishedAt")
+  @Mapping(target = "articleSummary", source = "articleView.newsArticle.summary")
+  @Mapping(target = "articleCommentCount", source = "commentCount")
+  @Mapping(target = "articleViewCount", source = "articleView.newsArticle.viewCount")
+  NewsArticleViewDto toDto(ArticleView articleView, Long commentCount);
+
+}

--- a/src/main/java/com/springboot/monew/newsarticles/repository/ArticleViewRepository.java
+++ b/src/main/java/com/springboot/monew/newsarticles/repository/ArticleViewRepository.java
@@ -1,0 +1,12 @@
+package com.springboot.monew.newsarticles.repository;
+
+import com.springboot.monew.newsarticles.entity.ArticleView;
+import com.springboot.monew.newsarticles.entity.NewsArticle;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArticleViewRepository extends JpaRepository<ArticleView, UUID> {
+
+  Boolean existsByNewsArticleIdAndUserId(UUID articleId, UUID userId);
+
+}

--- a/src/main/java/com/springboot/monew/newsarticles/repository/NewsArticleRepository.java
+++ b/src/main/java/com/springboot/monew/newsarticles/repository/NewsArticleRepository.java
@@ -5,11 +5,19 @@ import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface NewsArticleRepository extends JpaRepository<NewsArticle, UUID> {
 
   //원본링크목록 조회
   List<NewsArticle> findAllByOriginalLinkIn(Collection<String> originalLinks);
+
+  //뉴스기사 조회수 증가
+  @Modifying
+  @Query("UPDATE NewsArticle n SET n.viewCount = n.viewCount + 1 WHERE n.id = :articleId")
+  void incrementViewCount(@Param("articleId") UUID articleId);
 
 
 }

--- a/src/main/java/com/springboot/monew/newsarticles/service/NewsArticleService.java
+++ b/src/main/java/com/springboot/monew/newsarticles/service/NewsArticleService.java
@@ -180,8 +180,13 @@ public class NewsArticleService {
   @Transactional
   public NewsArticleViewDto createView(UUID articleId, UUID userId){
 
-    //기사 존재 확인
+    //뉴스기사 존재 확인
     NewsArticle newsArticle = getNewsArticle(articleId);
+
+    //논리 삭제된 뉴스기사의 경우 예외처리
+    if(newsArticle.isDeleted()){
+      throw new ArticleException(NewsArticleErrorCode.NEWS_ARTICLE_ALREADY_DELETED, Map.of("articleId", articleId));
+    }
 
     //사용자 존재 확인
     User user = userRepository.findById(userId).orElseThrow(

--- a/src/main/java/com/springboot/monew/newsarticles/service/NewsArticleService.java
+++ b/src/main/java/com/springboot/monew/newsarticles/service/NewsArticleService.java
@@ -218,8 +218,8 @@ public class NewsArticleService {
 
     //기사 조회수 증가
     // ToDo: 조회수 증가 로직의 동시성 문제를 DB 레벨에서 처리
-    // ToDo: DB 레벨 원자적 증가/낙관적 락/ 비관적 락 고려
-    newsArticle.increaseViewCount();
+    // ToDo: DB 레벨 원자적 증가/낙관적 락/ 비관적 락 고려 -> DB레벨 원자적 증가 선택
+    newsArticleRepository.incrementViewCount(articleId);
 
     return newsArticleViewMapper.toDto(savedArticleView, commentCount);
 

--- a/src/main/java/com/springboot/monew/newsarticles/service/NewsArticleService.java
+++ b/src/main/java/com/springboot/monew/newsarticles/service/NewsArticleService.java
@@ -192,7 +192,8 @@ public class NewsArticleService {
     User user = userRepository.findById(userId).orElseThrow(
         () -> new UserException(UserErrorCode.USER_NOT_FOUND, Map.of("userId", userId)));
 
-    //이미 본 기사인지 확인
+    // 이미 본 기사인지 확인
+    //
     if (articleViewRepository.existsByNewsArticleIdAndUserId(articleId, userId)) {
       throw new ArticleException(NewsArticleErrorCode.NEWS_ARTICLE_ALREADY_VIEWED,  Map.of("articleId", articleId, "userId", userId));
     }
@@ -205,6 +206,8 @@ public class NewsArticleService {
     Long commentCount = commentRepository.countByArticleIdAndIsDeletedFalse(articleId);
 
     //기사 조회수 증가
+    // ToDo: 조회수 증가 로직의 동시성 문제를 DB 레벨에서 처리
+    // ToDo: DB 레벨 원자적 증가/낙관적 락/ 비관적 락 고려
     newsArticle.increaseViewCount();
 
     return newsArticleViewMapper.toDto(savedArticleView, commentCount);

--- a/src/main/java/com/springboot/monew/newsarticles/service/NewsArticleService.java
+++ b/src/main/java/com/springboot/monew/newsarticles/service/NewsArticleService.java
@@ -1,15 +1,24 @@
 package com.springboot.monew.newsarticles.service;
 
+import com.springboot.monew.comment.repository.CommentRepository;
 import com.springboot.monew.interest.entity.Interest;
 import com.springboot.monew.interest.repository.InterestRepository;
 import com.springboot.monew.newsarticles.dto.CollectedArticleWithInterest;
+import com.springboot.monew.newsarticles.dto.response.NewsArticleViewDto;
 import com.springboot.monew.newsarticles.entity.ArticleInterest;
+import com.springboot.monew.newsarticles.entity.ArticleView;
 import com.springboot.monew.newsarticles.entity.NewsArticle;
 import com.springboot.monew.newsarticles.exception.ArticleException;
 import com.springboot.monew.newsarticles.exception.NewsArticleErrorCode;
 import com.springboot.monew.newsarticles.mapper.NewsArticleMapper;
+import com.springboot.monew.newsarticles.mapper.NewsArticleViewMapper;
 import com.springboot.monew.newsarticles.repository.ArticleInterestRepository;
+import com.springboot.monew.newsarticles.repository.ArticleViewRepository;
 import com.springboot.monew.newsarticles.repository.NewsArticleRepository;
+import com.springboot.monew.users.entity.User;
+import com.springboot.monew.users.exception.UserErrorCode;
+import com.springboot.monew.users.exception.UserException;
+import com.springboot.monew.users.repository.UserRepository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -28,9 +37,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class NewsArticleService {
 
   private final NewsArticleRepository newsArticleRepository;
-  private final NewsArticleMapper newsArticleMapper;
+  private final ArticleViewRepository articleViewRepository;
   private final InterestRepository interestRepository;
   private final ArticleInterestRepository articleInterestRepository;
+  private final UserRepository userRepository;
+
+  private final NewsArticleMapper newsArticleMapper;
+  private final NewsArticleViewMapper newsArticleViewMapper;
+  private final CommentRepository commentRepository;
 
   @Transactional
   public void saveAll(List<CollectedArticleWithInterest> articlesWithInterests) {
@@ -159,6 +173,37 @@ public class NewsArticleService {
 
   private String buildRelationKey(Object articleId, Object interestId) {
     return articleId + ":" + interestId;
+  }
+
+  //뉴스기사 뷰(조회 이력) 등록
+  //뉴스기사 클릭시, 조회이력 1건 생성 + 기사 조회수 1 증가
+  @Transactional
+  public NewsArticleViewDto createView(UUID articleId, UUID userId){
+
+    //기사 존재 확인
+    NewsArticle newsArticle = getNewsArticle(articleId);
+
+    //사용자 존재 확인
+    User user = userRepository.findById(userId).orElseThrow(
+        () -> new UserException(UserErrorCode.USER_NOT_FOUND, Map.of("userId", userId)));
+
+    //이미 본 기사인지 확인
+    if (articleViewRepository.existsByNewsArticleIdAndUserId(articleId, userId)) {
+      throw new ArticleException(NewsArticleErrorCode.NEWS_ARTICLE_ALREADY_VIEWED,  Map.of("articleId", articleId, "userId", userId));
+    }
+
+    //처음 보는 기사면 조회이력 생성
+    ArticleView articleView = new ArticleView(newsArticle, user);
+    ArticleView savedArticleView = articleViewRepository.save(articleView);
+
+    //뉴스기사 댓글수
+    Long commentCount = commentRepository.countByArticleIdAndIsDeletedFalse(articleId);
+
+    //기사 조회수 증가
+    newsArticle.increaseViewCount();
+
+    return newsArticleViewMapper.toDto(savedArticleView, commentCount);
+
   }
 
   // 뉴스기사 물리 삭제

--- a/src/main/java/com/springboot/monew/newsarticles/service/NewsArticleService.java
+++ b/src/main/java/com/springboot/monew/newsarticles/service/NewsArticleService.java
@@ -197,14 +197,21 @@ public class NewsArticleService {
         () -> new UserException(UserErrorCode.USER_NOT_FOUND, Map.of("userId", userId)));
 
     // 이미 본 기사인지 확인
-    //
+    // ToDo: 동시에 existsByNewsArticleIdAndUserId false받고, save하면 어떻게 되나? -> DB 유니크 제약 위반 발생
     if (articleViewRepository.existsByNewsArticleIdAndUserId(articleId, userId)) {
-      throw new ArticleException(NewsArticleErrorCode.NEWS_ARTICLE_ALREADY_VIEWED,  Map.of("articleId", articleId, "userId", userId));
+      throw new ArticleException(NewsArticleErrorCode.NEWS_ARTICLE_ALREADY_VIEWED, Map.of("articleId", articleId, "userId", userId));
     }
 
-    //처음 보는 기사면 조회이력 생성
-    ArticleView articleView = new ArticleView(newsArticle, user);
-    ArticleView savedArticleView = articleViewRepository.save(articleView);
+    ArticleView savedArticleView;
+
+    try{
+      //save() : 영속성 컨텍스트에만 저장, 실제 insert는 commit 시점.
+      //saveAndFlush() : 즉시 DB에 insert
+      //요청 A, 요청 B 동시에 요청이 들어왔다 -> A랑 B중 누구든지간에 saveAndFlush()를 먼저 하는 요청이 있을거라 DB 레벨에서 UNIQUE 조건에 의해 예외 발생될것이다.
+      savedArticleView = articleViewRepository.saveAndFlush(new ArticleView(newsArticle, user));
+    } catch (org.springframework.dao.DataIntegrityViolationException e) {
+      throw new ArticleException(NewsArticleErrorCode.NEWS_ARTICLE_ALREADY_VIEWED, Map.of("articleId", articleId, "userId", userId));
+    }
 
     //뉴스기사 댓글수
     Long commentCount = commentRepository.countByArticleIdAndIsDeletedFalse(articleId);


### PR DESCRIPTION
Closes #22, #229 , #230, #231

## 📌 작업 내용
- [x] 뉴스기사 조회이력 생성 REST API 설계
- [x] 뉴스기사 조회이력 생성 Service 단 구성
- [x] 뉴스기사 조회이력 생성 Repository 구성 - 조회이력 존재검증 메서드 구현
- [x] 특정 뉴스기사 댓글 수 조회 메서드 추가
- [x] ArticleViewMapper 구현

## 🔧 변경 사항
- 

## 반영 브랜치
`feature/#232/post-newsarticle-view` -> `dev`

## 💬 기타 참고 사항
- CommentRepository - countByArticleIdAndIsDeletedFalse()
- NewsArticleController - createView()
- NewsArticleService - createView()
- ArticleViewRepository
- ArticleViewMapper


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 뉴스 기사 조회 기록 생성 API 추가 — 사용자의 기사 조회를 서버에 기록하고 201 Created(위치 헤더 포함)를 반환합니다.
  * 조회 응답에 기사 메타와 통계(댓글수·조회수 등)를 포함하여 제공합니다.
* **개선**
  * 동일 사용자의 중복 조회 요청을 차단하여 중복 기록을 방지합니다.
  * 조회 시 기사 조회수가 올바르게 증가하도록 적용했습니다.
* **버그 수정**
  * 불필요한 디버그 로그를 제거했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->