### PR TITLE
[Feat] 관심사 구독 구현

### DIFF
--- a/src/main/java/com/springboot/monew/interest/controller/InterestController.java
+++ b/src/main/java/com/springboot/monew/interest/controller/InterestController.java
@@ -5,7 +5,9 @@ import com.springboot.monew.interest.dto.request.InterestRegisterRequest;
 import com.springboot.monew.interest.dto.request.InterestUpdateRequest;
 import com.springboot.monew.interest.dto.response.CursorPageResponseInterestDto;
 import com.springboot.monew.interest.dto.response.InterestDto;
+import com.springboot.monew.interest.dto.response.SubscriptionDto;
 import com.springboot.monew.interest.service.InterestService;
+import com.springboot.monew.interest.service.SubscriptionService;
 import jakarta.validation.Valid;
 import java.net.URI;
 import java.util.UUID;
@@ -27,6 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class InterestController implements InterestApiDocs {
 
   private final InterestService interestService;
+  private final SubscriptionService subscriptionService;
 
   @GetMapping
   public CursorPageResponseInterestDto list(@Valid InterestPageRequest request,
@@ -52,5 +55,12 @@ public class InterestController implements InterestApiDocs {
   public ResponseEntity<Void> delete(@PathVariable UUID interestId) {
     interestService.delete(interestId);
     return ResponseEntity.noContent().build();
+  }
+
+  @PostMapping("/{interestId}/subscriptions")
+  public ResponseEntity<SubscriptionDto> subscribe(@PathVariable UUID interestId,
+      @RequestHeader("Monew-Request-User-ID") UUID userId) {
+    SubscriptionDto subscriptionDto = subscriptionService.subscribe(interestId, userId);
+    return ResponseEntity.ok(subscriptionDto);
   }
 }

--- a/src/main/java/com/springboot/monew/interest/controller/InterestController.java
+++ b/src/main/java/com/springboot/monew/interest/controller/InterestController.java
@@ -31,8 +31,7 @@ public class InterestController implements InterestApiDocs {
   private final InterestService interestService;
 
   @GetMapping
-  public CursorPageResponseInterestDto list(
-      @Valid InterestPageRequest request,
+  public CursorPageResponseInterestDto list(@Valid InterestPageRequest request,
       @RequestHeader("Monew-Request-User-ID") UUID userId) {
     return interestService.list(request, userId);
   }

--- a/src/main/java/com/springboot/monew/interest/controller/InterestController.java
+++ b/src/main/java/com/springboot/monew/interest/controller/InterestController.java
@@ -10,7 +10,6 @@ import jakarta.validation.Valid;
 import java.net.URI;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,7 +21,6 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/interests")

--- a/src/main/java/com/springboot/monew/interest/entity/Interest.java
+++ b/src/main/java/com/springboot/monew/interest/entity/Interest.java
@@ -39,16 +39,4 @@ public class Interest extends BaseUpdatableEntity {
     this.name = name;
     this.subscriberCount = 0;
   }
-
-  // 구독자 수 증가
-  public void increaseSubscriberCount() {
-    this.subscriberCount++;
-  }
-
-  // 구독자 수 감소
-  public void decreaseSubscriberCount() {
-    if (this.subscriberCount > 0) {
-      this.subscriberCount--;
-    }
-  }
 }

--- a/src/main/java/com/springboot/monew/interest/exception/InterestErrorCode.java
+++ b/src/main/java/com/springboot/monew/interest/exception/InterestErrorCode.java
@@ -11,7 +11,8 @@ public enum InterestErrorCode implements ErrorCode {
 
   INTEREST_NAME_DUPLICATION(HttpStatus.CONFLICT, "IN01", "유사한 이름의 관심사가 이미 존재합니다."),
   DUPLICATE_KEYWORDS(HttpStatus.BAD_REQUEST, "IN02", "키워드는 중복될 수 없습니다."),
-  INTEREST_NOT_FOUND(HttpStatus.NOT_FOUND, "IN03", "관심사를 찾을 수 없습니다.");
+  INTEREST_NOT_FOUND(HttpStatus.NOT_FOUND, "IN03", "관심사를 찾을 수 없습니다."),
+  SUBSCRIPTION_ALREADY_EXISTS(HttpStatus.CONFLICT, "IN04", "이미 구독한 관심사입니다.");
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/src/main/java/com/springboot/monew/interest/mapper/SubscriptionDtoMapper.java
+++ b/src/main/java/com/springboot/monew/interest/mapper/SubscriptionDtoMapper.java
@@ -13,7 +13,8 @@ public interface SubscriptionDtoMapper {
   @Mapping(source = "subscription.interest.id", target = "interestId")
   @Mapping(source = "subscription.interest.name", target = "interestName")
   @Mapping(source = "interestKeywords", target = "interestKeywords")
-  @Mapping(source = "subscription.interest.subscriberCount", target = "interestSubscriberCount")
+  @Mapping(source = "interestSubscriberCount", target = "interestSubscriberCount")
   @Mapping(source = "subscription.createdAt", target = "createdAt")
-  SubscriptionDto toSubscriptionDto(Subscription subscription, List<String> interestKeywords);
+  SubscriptionDto toSubscriptionDto(Subscription subscription, List<String> interestKeywords,
+      long interestSubscriberCount);
 }

--- a/src/main/java/com/springboot/monew/interest/repository/InterestRepository.java
+++ b/src/main/java/com/springboot/monew/interest/repository/InterestRepository.java
@@ -5,7 +5,9 @@ import com.springboot.monew.interest.repository.qdsl.InterestQDSLRepository;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface InterestRepository extends JpaRepository<Interest, UUID>, InterestQDSLRepository {
 
@@ -13,4 +15,19 @@ public interface InterestRepository extends JpaRepository<Interest, UUID>, Inter
 
   @Query("SELECT i.name FROM Interest i")
   List<String> findAllNames();
+
+  @Modifying
+  @Query("""
+      UPDATE Interest i
+      SET i.subscriberCount = i.subscriberCount + 1
+      WHERE i.id = :interestId
+      """)
+  int incrementSubscriberCount(@Param("interestId") UUID interestId);
+
+  @Query("""
+      SELECT i.subscriberCount
+      FROM Interest i
+      WHERE i.id = :interestId
+      """)
+  Long findSubscriberCountById(@Param("interestId") UUID interestId);
 }

--- a/src/main/java/com/springboot/monew/interest/repository/SubscriptionRepository.java
+++ b/src/main/java/com/springboot/monew/interest/repository/SubscriptionRepository.java
@@ -20,4 +20,6 @@ public interface SubscriptionRepository extends JpaRepository<Subscription, UUID
 
   @Query("select s.user.id from Subscription s where s.interest.id = :interestId")
   List<UUID> findUserIdsByInterestId(UUID interestId);
+
+  boolean existsByUserIdAndInterestId(UUID userId, UUID interestId);
 }

--- a/src/main/java/com/springboot/monew/interest/service/InterestService.java
+++ b/src/main/java/com/springboot/monew/interest/service/InterestService.java
@@ -225,7 +225,7 @@ public class InterestService {
     try {
       return keywordRepository.saveAndFlush(new Keyword(keywordName));
     } catch (DataIntegrityViolationException e) {
-      log.debug("키워드 동시 생성 충돌 발생. 기존 키워드 재조회: {}", keywordName);
+      log.debug("키워드 동시 생성 충돌 발생 - 기존 키워드 재조회: {}", keywordName);
       return keywordRepository.findByName(keywordName)
           .orElseThrow(() -> e);
     }

--- a/src/main/java/com/springboot/monew/interest/service/SubscriptionService.java
+++ b/src/main/java/com/springboot/monew/interest/service/SubscriptionService.java
@@ -1,10 +1,89 @@
 package com.springboot.monew.interest.service;
 
+import com.springboot.monew.interest.dto.response.SubscriptionDto;
+import com.springboot.monew.interest.entity.Interest;
+import com.springboot.monew.interest.entity.InterestKeyword;
+import com.springboot.monew.interest.entity.Keyword;
+import com.springboot.monew.interest.entity.Subscription;
+import com.springboot.monew.interest.exception.InterestErrorCode;
+import com.springboot.monew.interest.exception.InterestException;
+import com.springboot.monew.interest.mapper.SubscriptionDtoMapper;
+import com.springboot.monew.interest.repository.InterestKeywordRepository;
+import com.springboot.monew.interest.repository.InterestRepository;
+import com.springboot.monew.interest.repository.SubscriptionRepository;
+import com.springboot.monew.users.entity.User;
+import com.springboot.monew.users.exception.UserErrorCode;
+import com.springboot.monew.users.exception.UserException;
+import com.springboot.monew.users.repository.UserRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class SubscriptionService {
 
+  private final SubscriptionRepository subscriptionRepository;
+  private final InterestRepository interestRepository;
+  private final InterestKeywordRepository interestKeywordRepository;
+  private final UserRepository userRepository;
+  private final SubscriptionDtoMapper subscriptionDtoMapper;
+
+  @Transactional
+  public SubscriptionDto subscribe(UUID interestId, UUID userId) {
+    // 요청 유저가 존재하는지 확인하고 삭제되지 않은 활성 사용자인지 검증
+    User user = validateActiveUser(userId);
+    // 존재하는 관심사인지 검증
+    Interest interest = interestRepository.findById(interestId).orElseThrow(
+        () -> new InterestException(InterestErrorCode.INTEREST_NOT_FOUND,
+            Map.of("interestId", interestId)));
+
+    // 이미 해당 관심사를 구독 중인지 확인
+    if (subscriptionRepository.existsByUserIdAndInterestId(userId, interestId)) {
+      throw new InterestException(InterestErrorCode.SUBSCRIPTION_ALREADY_EXISTS,
+          Map.of("interestId", interestId, "userId", userId));
+    }
+
+    // 구독 엔티티 저장
+    // 동시성 상황에서 중복 저장이 발생할 수 있으므로 saveAndFlush 내부에서 처리
+    Subscription subscription = saveSubscriptionSafely(user, interest, userId, interestId);
+    // 관심사의 구독자 수 1 증가
+    interest.increaseSubscriberCount();
+
+    // 해당 관심사에 연결된 키워드 목록 조회
+    List<String> keywords = interestKeywordRepository.findAllByInterestWithKeyword(interest)
+        .stream()
+        .map(InterestKeyword::getKeyword)
+        .map(Keyword::getName)
+        .toList();
+
+    return subscriptionDtoMapper.toSubscriptionDto(subscription, keywords);
+  }
+
+  private Subscription saveSubscriptionSafely(User user, Interest interest, UUID userId,
+      UUID interestId) {
+    try {
+      // 구독 엔티티 저장 후 즉시 flush
+      return subscriptionRepository.saveAndFlush(new Subscription(user, interest));
+    } catch (DataIntegrityViolationException e) {
+      throw new InterestException(InterestErrorCode.SUBSCRIPTION_ALREADY_EXISTS,
+          Map.of("interestId", interestId, "userId", userId));
+    }
+  }
+
+  private User validateActiveUser(UUID userId) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND,
+            Map.of("userId", userId)));
+
+    if (user.isDeleted()) {
+      throw new UserException(UserErrorCode.USER_NOT_FOUND, Map.of("userId", userId));
+    }
+
+    return user;
+  }
 }

--- a/src/main/java/com/springboot/monew/interest/service/SubscriptionService.java
+++ b/src/main/java/com/springboot/monew/interest/service/SubscriptionService.java
@@ -83,7 +83,16 @@ public class SubscriptionService {
             Map.of("interestId", interestId, "userId", userId));
       }
 
-      // 중복 구독이 아닌 경우 그대로 반환
+      // 존재하는 관심사인지 검증
+      if (!interestRepository.existsById(interestId)) {
+        throw new InterestException(InterestErrorCode.INTEREST_NOT_FOUND,
+            Map.of("interestId", interestId));
+      }
+
+      // 요청 유저가 존재하는지 확인하고 삭제되지 않은 활성 사용자인지 검증
+      validateActiveUser(userId);
+
+      // 그 외 오류는 그대로 반환
       throw e;
     }
   }

--- a/src/main/java/com/springboot/monew/interest/service/SubscriptionService.java
+++ b/src/main/java/com/springboot/monew/interest/service/SubscriptionService.java
@@ -76,9 +76,15 @@ public class SubscriptionService {
       // 구독 엔티티 저장 후 즉시 flush
       return subscriptionRepository.saveAndFlush(new Subscription(user, interest));
     } catch (DataIntegrityViolationException e) {
-      log.debug("관심사 구독 동시성 충돌 발생 - interestId: {}, userId: {}", interestId, userId);
-      throw new InterestException(InterestErrorCode.SUBSCRIPTION_ALREADY_EXISTS,
-          Map.of("interestId", interestId, "userId", userId));
+      log.debug("관심사 구독 실패 - interestId: {}, userId: {}", interestId, userId, e);
+      // 동시 요청 등으로 중복 구독이 발생한 경우 중복 구독 예외로 변환
+      if (subscriptionRepository.existsByUserIdAndInterestId(userId, interestId)) {
+        throw new InterestException(InterestErrorCode.SUBSCRIPTION_ALREADY_EXISTS,
+            Map.of("interestId", interestId, "userId", userId));
+      }
+
+      // 중복 구독이 아닌 경우 그대로 반환
+      throw e;
     }
   }
 

--- a/src/main/java/com/springboot/monew/interest/service/SubscriptionService.java
+++ b/src/main/java/com/springboot/monew/interest/service/SubscriptionService.java
@@ -53,8 +53,8 @@ public class SubscriptionService {
     // 구독 엔티티 저장
     // 동시성 상황에서 중복 저장이 발생할 수 있으므로 saveAndFlush 내부에서 처리
     Subscription subscription = saveSubscriptionSafely(user, interest, userId, interestId);
-    // 관심사의 구독자 수 1 증가
-    interest.increaseSubscriberCount();
+    // 관심사의 구독자 수를 DB에서 원자적으로 1 증가
+    incrementSubscriberCount(interestId);
 
     // 해당 관심사에 연결된 키워드 목록 조회
     List<String> keywords = interestKeywordRepository.findAllByInterestWithKeyword(interest)
@@ -63,8 +63,11 @@ public class SubscriptionService {
         .map(Keyword::getName)
         .toList();
 
+    // 증가가 반영된 최신 구독자 수 조회
+    long subscriberCount = getSubscriberCount(interestId);
+
     log.info("관심사 구독 완료 - interestId: {}, userId: {}", interestId, userId);
-    return subscriptionDtoMapper.toSubscriptionDto(subscription, keywords);
+    return subscriptionDtoMapper.toSubscriptionDto(subscription, keywords, subscriberCount);
   }
 
   private Subscription saveSubscriptionSafely(User user, Interest interest, UUID userId,
@@ -77,6 +80,31 @@ public class SubscriptionService {
       throw new InterestException(InterestErrorCode.SUBSCRIPTION_ALREADY_EXISTS,
           Map.of("interestId", interestId, "userId", userId));
     }
+  }
+
+  private void incrementSubscriberCount(UUID interestId) {
+    // 구독자 수를 DB update 쿼리로 증가시키고 영향 받은 행 수를 확인
+    int updatedRowCount = interestRepository.incrementSubscriberCount(interestId);
+
+    // 정확히 한 개의 관심사만 수정되어야 하므로, 수정된 행 수가 1이 아니면 예외 발생
+    if (updatedRowCount != 1) {
+      throw new InterestException(InterestErrorCode.INTEREST_NOT_FOUND,
+          Map.of("interestId", interestId));
+    }
+  }
+
+  private long getSubscriberCount(UUID interestId) {
+    // DB에 반영된 최신 구독자 수 조회
+    Long subscriberCount = interestRepository.findSubscriberCountById(interestId);
+
+    // 구독자 수가 null이라면(해당 관심사가 없다면) 예외 발생
+    if (subscriberCount == null) {
+      throw new InterestException(InterestErrorCode.INTEREST_NOT_FOUND,
+          Map.of("interestId", interestId));
+    }
+
+    // 조회된 최신 구독자 수 반환
+    return subscriberCount;
   }
 
   private User validateActiveUser(UUID userId) {

--- a/src/main/java/com/springboot/monew/interest/service/SubscriptionService.java
+++ b/src/main/java/com/springboot/monew/interest/service/SubscriptionService.java
@@ -19,10 +19,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class SubscriptionService {
@@ -61,6 +63,7 @@ public class SubscriptionService {
         .map(Keyword::getName)
         .toList();
 
+    log.info("관심사 구독 완료 - interestId: {}, userId: {}", interestId, userId);
     return subscriptionDtoMapper.toSubscriptionDto(subscription, keywords);
   }
 
@@ -70,6 +73,7 @@ public class SubscriptionService {
       // 구독 엔티티 저장 후 즉시 flush
       return subscriptionRepository.saveAndFlush(new Subscription(user, interest));
     } catch (DataIntegrityViolationException e) {
+      log.debug("관심사 구독 동시성 충돌 발생 - interestId: {}, userId: {}", interestId, userId);
       throw new InterestException(InterestErrorCode.SUBSCRIPTION_ALREADY_EXISTS,
           Map.of("interestId", interestId, "userId", userId));
     }

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -59,7 +59,7 @@ CREATE TABLE comments
     "user_id"    UUID                  NOT NULL,
     "article_id" UUID                  NOT NULL,
     "content"    VARCHAR(200)          NOT NULL,
-    "like_count" BIGINT DEFAULT 0     NOT NULL,
+    "like_count" BIGINT  DEFAULT 0     NOT NULL,
     "is_deleted" BOOLEAN DEFAULT false NOT NULL,
     "created_at" TIMESTAMPTZ           NOT NULL,
     "updated_at" TIMESTAMPTZ           NULL
@@ -68,10 +68,10 @@ CREATE TABLE comments
 CREATE TABLE interests
 (
     "id"               UUID PRIMARY KEY,
-    "name"             VARCHAR(50)       NOT NULL,
+    "name"             VARCHAR(50)      NOT NULL,
     "subscriber_count" BIGINT DEFAULT 0 NOT NULL,
-    "created_at"       TIMESTAMPTZ       NOT NULL,
-    "updated_at"       TIMESTAMPTZ       NULL
+    "created_at"       TIMESTAMPTZ      NOT NULL,
+    "updated_at"       TIMESTAMPTZ      NULL
 );
 
 CREATE TABLE keywords
@@ -103,7 +103,7 @@ CREATE TABLE news_articles
     "title"         VARCHAR(300) NOT NULL,
     "published_at"  TIMESTAMPTZ  NOT NULL,
     "summary"       TEXT         NOT NULL,
-    "view_count"    BIGINT      NOT NULL DEFAULT 0,
+    "view_count"    BIGINT       NOT NULL DEFAULT 0,
     "is_deleted"    BOOLEAN      NOT NULL
 );
 
@@ -197,9 +197,11 @@ ALTER TABLE notifications
     ADD CONSTRAINT "FK_NOTIFICATIONS_COMMENT_LIKES_ID" FOREIGN KEY ("comment_likes_id") REFERENCES "comment_likes" ("id") on delete cascade,
     ADD CONSTRAINT "CK_NOTIFICATION_POLYMORPHIC_MATCH"
         CHECK (
-            ("resource_type" = 'COMMENT' AND "comment_likes_id" IS NOT NULL AND "interest_id" IS NULL)
+            ("resource_type" = 'COMMENT' AND "comment_likes_id" IS NOT NULL AND
+             "interest_id" IS NULL)
                 OR
-            ("resource_type" = 'INTEREST' AND "interest_id" IS NOT NULL AND "comment_likes_id" IS NULL)
+            ("resource_type" = 'INTEREST' AND "interest_id" IS NOT NULL AND
+             "comment_likes_id" IS NULL)
             );
 
 -- =========================

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -9,7 +9,7 @@ spring:
     driver-class-name: org.h2.Driver
   jpa:
     hibernate:
-      ddl-auto: validate # subscriber_count 컬럼 타입이 안맞아 임시로 validate -> none으로 변경
+      ddl-auto: validate
     show-sql: false
     properties:
       hibernate:


### PR DESCRIPTION
## 📌 해당 이슈카드
Closes #138 #148 #171 

## 📌 작업 내용
- `schema.sql`, `application.yml` 포맷팅 적용 및 불필요 주석 제거
- 관심사 구독 컨트롤러 구현
- 관심사 구독 서비스 구현
- 관심사 구독 레포지토리 구현
- 관심사 구독자 수 증가 정합성 및 동시성 제어

## 🔧 변경 사항
- `schema.sql`, `application.yml` 포맷팅 적용 및 불필요 주석 제거
- `Interest` 엔티티에 있는 구독자 수 증감 메서드 제거

## 반영 브랜치
`feature/#138#148#171/Interest-Subscription` -> `dev`

## 💬 기타 참고 사항
- `Interest` 엔티티의 `subscriberCount` 필드는 관심사 조회 시 사용됩니다. 다만 구독자 수 증감 이후의 응답에는 엔티티가 가진 값을 직접 사용하지 않고, 관심사 테이블에서 최신 구독자 수를 다시 조회한 값을 사용하도록 구현했습니다.
- 엔티티의 `subscriberCount` 값과 `subscriptions` 테이블의 실제 구독 행 개수는 항상 같아야 하지만, 별도로 관리되는 값이기 때문에 정합성과 동시성 제어를 고려해야 했습니다. 이에 따라 구독자 수 증가는 엔티티 필드 값을 변경하는 방식이 아니라, 직접 UPDATE 쿼리로 증가시키는 방식으로 구현했습니다.
- 구독 취소도 동일한 방식으로 구현할 예정입니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 관심사 구독 API가 추가되어 사용자가 특정 관심사를 구독할 수 있습니다.
  * 구독 완료 시 구독 정보(구독 ID, 생성 시각, 관련 키워드)와 최신 구독자 수를 반환합니다.

* **버그 수정**
  * 이미 구독한 항목에 대해 409 충돌 응답과 명확한 오류 메시지를 제공합니다.
  * 구독 생성 시 동시성/중복 처리 개선으로 중복 등록 및 카운트 불일치 가능성을 줄였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->