### PR TITLE
[Feat] 관심사 구독 취소 구현

### DIFF
--- a/src/main/java/com/springboot/monew/interest/controller/InterestController.java
+++ b/src/main/java/com/springboot/monew/interest/controller/InterestController.java
@@ -68,6 +68,6 @@ public class InterestController implements InterestApiDocs {
   public ResponseEntity<Void> unsubscribe(@PathVariable UUID interestId,
       @RequestHeader("Monew-Request-User-ID") UUID userId) {
     subscriptionService.unsubscribe(interestId, userId);
-    return ResponseEntity.ok().build();
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/com/springboot/monew/interest/controller/InterestController.java
+++ b/src/main/java/com/springboot/monew/interest/controller/InterestController.java
@@ -63,4 +63,11 @@ public class InterestController implements InterestApiDocs {
     SubscriptionDto subscriptionDto = subscriptionService.subscribe(interestId, userId);
     return ResponseEntity.ok(subscriptionDto);
   }
+
+  @DeleteMapping("/{interestId}/subscriptions")
+  public ResponseEntity<Void> unsubscribe(@PathVariable UUID interestId,
+      @RequestHeader("Monew-Request-User-ID") UUID userId) {
+    subscriptionService.unsubscribe(interestId, userId);
+    return ResponseEntity.ok().build();
+  }
 }

--- a/src/main/java/com/springboot/monew/interest/exception/InterestErrorCode.java
+++ b/src/main/java/com/springboot/monew/interest/exception/InterestErrorCode.java
@@ -12,7 +12,8 @@ public enum InterestErrorCode implements ErrorCode {
   INTEREST_NAME_DUPLICATION(HttpStatus.CONFLICT, "IN01", "유사한 이름의 관심사가 이미 존재합니다."),
   DUPLICATE_KEYWORDS(HttpStatus.BAD_REQUEST, "IN02", "키워드는 중복될 수 없습니다."),
   INTEREST_NOT_FOUND(HttpStatus.NOT_FOUND, "IN03", "관심사를 찾을 수 없습니다."),
-  SUBSCRIPTION_ALREADY_EXISTS(HttpStatus.CONFLICT, "IN04", "이미 구독한 관심사입니다.");
+  SUBSCRIPTION_ALREADY_EXISTS(HttpStatus.CONFLICT, "IN04", "이미 구독한 관심사입니다."),
+  SUBSCRIPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "IN05", "구독 중인 관심사가 아닙니다.");
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/src/main/java/com/springboot/monew/interest/repository/InterestRepository.java
+++ b/src/main/java/com/springboot/monew/interest/repository/InterestRepository.java
@@ -24,6 +24,18 @@ public interface InterestRepository extends JpaRepository<Interest, UUID>, Inter
       """)
   int incrementSubscriberCount(@Param("interestId") UUID interestId);
 
+  @Modifying
+  @Query("""
+      UPDATE Interest i
+      SET i.subscriberCount =
+          CASE
+            WHEN i.subscriberCount > 0 THEN i.subscriberCount - 1
+            ELSE 0
+          END
+      WHERE i.id = :interestId
+      """)
+  int decrementSubscriberCount(@Param("interestId") UUID interestId);
+
   @Query("""
       SELECT i.subscriberCount
       FROM Interest i

--- a/src/main/java/com/springboot/monew/interest/repository/SubscriptionRepository.java
+++ b/src/main/java/com/springboot/monew/interest/repository/SubscriptionRepository.java
@@ -4,6 +4,7 @@ import com.springboot.monew.interest.entity.Subscription;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -13,7 +14,7 @@ public interface SubscriptionRepository extends JpaRepository<Subscription, UUID
           SELECT s.interest.id
           FROM Subscription s
           WHERE s.user.id = :userId
-            AND s.interest.id IN :interestIds
+          AND s.interest.id IN :interestIds
       """)
   List<UUID> findInterestIdsByUserIdAndInterestIdIn(@Param("userId") UUID userId,
       @Param("interestIds") List<UUID> interestIds);
@@ -22,4 +23,14 @@ public interface SubscriptionRepository extends JpaRepository<Subscription, UUID
   List<UUID> findUserIdsByInterestId(UUID interestId);
 
   boolean existsByUserIdAndInterestId(UUID userId, UUID interestId);
+
+  @Modifying
+  @Query("""
+          DELETE
+          FROM Subscription s
+          WHERE s.user.id = :userId
+          AND s.interest.id = :interestId
+      """)
+  int deleteByUserIdAndInterestId(@Param("userId") UUID userId,
+      @Param("interestId") UUID interestId);
 }

--- a/src/main/java/com/springboot/monew/interest/service/SubscriptionService.java
+++ b/src/main/java/com/springboot/monew/interest/service/SubscriptionService.java
@@ -74,11 +74,6 @@ public class SubscriptionService {
   public void unsubscribe(UUID interestId, UUID userId) {
     // 요청 유저가 존재하는지 확인하고 삭제되지 않은 활성 사용자인지 검증
     validateActiveUser(userId);
-    // 존재하는 관심사인지 검증
-    if (!interestRepository.existsById(interestId)) {
-      throw new InterestException(InterestErrorCode.INTEREST_NOT_FOUND,
-          Map.of("interestId", interestId));
-    }
 
     // 해당 관심사를 실제로 구독 중인지 확인하고 구독 삭제
     deleteSubscription(interestId, userId);
@@ -121,6 +116,12 @@ public class SubscriptionService {
 
     // 정확히 한 개의 구독만 삭제되어야 하므로, 삭제된 행 수가 1이 아니면 예외 발생
     if (deletedRowCount != 1) {
+      // 관심사가 존재하지 않아서 발생한 예외인지 확인
+      if (!interestRepository.existsById(interestId)) {
+        throw new InterestException(InterestErrorCode.INTEREST_NOT_FOUND,
+            Map.of("interestId", interestId));
+      }
+
       throw new InterestException(InterestErrorCode.SUBSCRIPTION_NOT_FOUND,
           Map.of("interestId", interestId, "userId", userId));
     }

--- a/src/main/java/com/springboot/monew/interest/service/SubscriptionService.java
+++ b/src/main/java/com/springboot/monew/interest/service/SubscriptionService.java
@@ -70,6 +70,21 @@ public class SubscriptionService {
     return subscriptionDtoMapper.toSubscriptionDto(subscription, keywords, subscriberCount);
   }
 
+  @Transactional
+  public void unsubscribe(UUID interestId, UUID userId) {
+    // 요청 유저가 존재하는지 확인하고 삭제되지 않은 활성 사용자인지 검증
+    validateActiveUser(userId);
+    // 존재하는 관심사인지 검증
+    interestRepository.findById(interestId).orElseThrow(
+        () -> new InterestException(InterestErrorCode.INTEREST_NOT_FOUND,
+            Map.of("interestId", interestId)));
+
+    // 해당 관심사를 실제로 구독 중인지 확인하고 구독 삭제
+    deleteSubscription(interestId, userId);
+    // 관심사의 구독자 수를 DB에서 원자적으로 1 감소
+    decrementSubscriberCount(interestId);
+  }
+
   private Subscription saveSubscriptionSafely(User user, Interest interest, UUID userId,
       UUID interestId) {
     try {
@@ -97,9 +112,31 @@ public class SubscriptionService {
     }
   }
 
+  private void deleteSubscription(UUID interestId, UUID userId) {
+    // 구독 row를 삭제하고 실제 삭제된 행 수를 확인
+    int deletedRowCount = subscriptionRepository.deleteByUserIdAndInterestId(userId, interestId);
+
+    // 정확히 한 개의 구독만 삭제되어야 하므로, 삭제된 행 수가 1이 아니면 예외 발생
+    if (deletedRowCount != 1) {
+      throw new InterestException(InterestErrorCode.SUBSCRIPTION_NOT_FOUND,
+          Map.of("interestId", interestId, "userId", userId));
+    }
+  }
+
   private void incrementSubscriberCount(UUID interestId) {
     // 구독자 수를 DB update 쿼리로 증가시키고 영향 받은 행 수를 확인
     int updatedRowCount = interestRepository.incrementSubscriberCount(interestId);
+
+    // 정확히 한 개의 관심사만 수정되어야 하므로, 수정된 행 수가 1이 아니면 예외 발생
+    if (updatedRowCount != 1) {
+      throw new InterestException(InterestErrorCode.INTEREST_NOT_FOUND,
+          Map.of("interestId", interestId));
+    }
+  }
+
+  private void decrementSubscriberCount(UUID interestId) {
+    // subscriberCount를 DB update 쿼리로 감소시키고 영향받은 행 수를 확인
+    int updatedRowCount = interestRepository.decrementSubscriberCount(interestId);
 
     // 정확히 한 개의 관심사만 수정되어야 하므로, 수정된 행 수가 1이 아니면 예외 발생
     if (updatedRowCount != 1) {

--- a/src/main/java/com/springboot/monew/interest/service/SubscriptionService.java
+++ b/src/main/java/com/springboot/monew/interest/service/SubscriptionService.java
@@ -83,6 +83,8 @@ public class SubscriptionService {
     deleteSubscription(interestId, userId);
     // 관심사의 구독자 수를 DB에서 원자적으로 1 감소
     decrementSubscriberCount(interestId);
+
+    log.info("관심사 구독 취소 완료 - interestId: {}, userId: {}", interestId, userId);
   }
 
   private Subscription saveSubscriptionSafely(User user, Interest interest, UUID userId,

--- a/src/main/java/com/springboot/monew/interest/service/SubscriptionService.java
+++ b/src/main/java/com/springboot/monew/interest/service/SubscriptionService.java
@@ -116,12 +116,6 @@ public class SubscriptionService {
 
     // 정확히 한 개의 구독만 삭제되어야 하므로, 삭제된 행 수가 1이 아니면 예외 발생
     if (deletedRowCount != 1) {
-      // 관심사가 존재하지 않아서 발생한 예외인지 확인
-      if (!interestRepository.existsById(interestId)) {
-        throw new InterestException(InterestErrorCode.INTEREST_NOT_FOUND,
-            Map.of("interestId", interestId));
-      }
-
       throw new InterestException(InterestErrorCode.SUBSCRIPTION_NOT_FOUND,
           Map.of("interestId", interestId, "userId", userId));
     }

--- a/src/main/java/com/springboot/monew/interest/service/SubscriptionService.java
+++ b/src/main/java/com/springboot/monew/interest/service/SubscriptionService.java
@@ -75,9 +75,10 @@ public class SubscriptionService {
     // 요청 유저가 존재하는지 확인하고 삭제되지 않은 활성 사용자인지 검증
     validateActiveUser(userId);
     // 존재하는 관심사인지 검증
-    interestRepository.findById(interestId).orElseThrow(
-        () -> new InterestException(InterestErrorCode.INTEREST_NOT_FOUND,
-            Map.of("interestId", interestId)));
+    if (!interestRepository.existsById(interestId)) {
+      throw new InterestException(InterestErrorCode.INTEREST_NOT_FOUND,
+          Map.of("interestId", interestId));
+    }
 
     // 해당 관심사를 실제로 구독 중인지 확인하고 구독 삭제
     deleteSubscription(interestId, userId);


### PR DESCRIPTION
## 📌 해당 이슈카드
Closes #141 #142 #171 

## 📌 작업 내용
- 관심사 구독 취소 컨트롤러 구현
- 관심사 구독 취소 서비스 구현
- 관심사 구독 취소 레포지토리 구현
- 관심사 구독자 수 감소 정합성 및 동시성 제어

## 🔧 변경 사항


## 반영 브랜치
`feature/#141#142#171/Interest-Unsubscription` -> `dev`

## 💬 기타 참고 사항
- 구독 방식과 동일한 방식으로 구현하였습니다.
- api-docs 상 구독 취소 성공 시 상태 코드가 200으로 되어 있어서 처음엔 200을 반환하도록 구현했지만 프로토타입에선 상태 코드가 204인 점, 204 상태 코드가 더 적절한 점을 따져봤을 때, 프로토타입의 코드 상에는 `noContent().build()`로 구현되었지만 Swagger 코드에는 "200"으로 구현된 것으로 보여져서 구독 취소 성공 시 204 상태 코드를 반환하도록 수정했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 관심사 구독 취소 API가 추가되어 사용자가 구독을 직접 취소할 수 있습니다.
  * 구독 취소 시 관심사의 구독자 수가 안전하게 감소하도록 처리됩니다.

* **버그 수정**
  * 사용자가 구독하지 않은 관심사를 취소하려 할 때 404 응답으로 적절히 처리됩니다.

* **신뢰성**
  * 구독 취소 작업이 일관되게 처리되도록 원자적(트랜잭션)으로 수행됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->