### PR TITLE
[Feat] 사용자 활동 내역 조회 API 기본 구조 및 테스트 구현

### DIFF
--- a/src/main/java/com/springboot/monew/users/controller/UserActivityController.java
+++ b/src/main/java/com/springboot/monew/users/controller/UserActivityController.java
@@ -1,0 +1,27 @@
+package com.springboot.monew.users.controller;
+
+import com.springboot.monew.users.dto.response.UserActivityDto;
+import com.springboot.monew.users.service.UserActivityService;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/user-activities")
+@RequiredArgsConstructor
+public class UserActivityController implements UserActivityDocs {
+
+  private final UserActivityService userActivityService;
+
+  @GetMapping("/{userId}")
+  public ResponseEntity<UserActivityDto> getUserActivity(
+      @PathVariable UUID userId
+  ) {
+    UserActivityDto userAct = userActivityService.findUserActivity(userId);
+    return ResponseEntity.ok(userAct);
+  }
+}

--- a/src/main/java/com/springboot/monew/users/controller/UserActivityDocs.java
+++ b/src/main/java/com/springboot/monew/users/controller/UserActivityDocs.java
@@ -1,0 +1,45 @@
+package com.springboot.monew.users.controller;
+
+import com.springboot.monew.common.exception.ErrorResponse;
+import com.springboot.monew.users.dto.response.UserActivityDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "사용자 활동 내역 관리", description = "사용자 활동 내역 관련 API")
+public interface UserActivityDocs {
+
+  @Operation(
+      summary = "사용자 활동 내역 관리",
+      description = "사용자 ID로 활동 내역을 조회합니다.",
+      operationId = "find"
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "사용자 활동 내역 조회 성공",
+          content = @Content(schema = @Schema(implementation = UserActivityDto.class))
+      ),
+      @ApiResponse(
+          responseCode = "404",
+          description = "사용자 정보 없음",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "500",
+          description = "서버 내부 오류",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      )
+  })
+  ResponseEntity<UserActivityDto> getUserActivity(
+      @Parameter(description = "사용자 ID")
+      @PathVariable UUID userId
+  );
+}

--- a/src/main/java/com/springboot/monew/users/controller/UserApiDocs.java
+++ b/src/main/java/com/springboot/monew/users/controller/UserApiDocs.java
@@ -1,10 +1,10 @@
 package com.springboot.monew.users.controller;
 
 import com.springboot.monew.common.exception.ErrorResponse;
-import com.springboot.monew.users.dto.response.UserDto;
 import com.springboot.monew.users.dto.request.UserLoginRequest;
 import com.springboot.monew.users.dto.request.UserRegisterRequest;
 import com.springboot.monew.users.dto.request.UserUpdateRequest;
+import com.springboot.monew.users.dto.response.UserDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -148,10 +148,6 @@ public interface UserApiDocs {
           description = "사용자 삭제 성공"
       ),
       @ApiResponse(
-          responseCode = "403",
-          description = "사용자 삭제 권한 없음"
-      ),
-      @ApiResponse(
           responseCode = "404",
           description = "사용자 정보 없음"
       ),
@@ -162,10 +158,7 @@ public interface UserApiDocs {
   })
   ResponseEntity<Void> delete(
       @Parameter(description = "사용자 ID")
-      @PathVariable UUID userId,
-
-      @Parameter(description = "요청자 ID")
-      @RequestHeader("Monew-Request-User-ID") UUID requestUserId
+      @PathVariable UUID userId
   );
 
   @Operation(
@@ -179,10 +172,6 @@ public interface UserApiDocs {
           description = "사용자 삭제 성공"
       ),
       @ApiResponse(
-          responseCode = "403",
-          description = "사용자 삭제 권한 없음"
-      ),
-      @ApiResponse(
           responseCode = "404",
           description = "사용자 정보 없음"
       ),
@@ -193,9 +182,6 @@ public interface UserApiDocs {
   })
   ResponseEntity<Void> hardDelete(
       @Parameter(description = "사용자 ID")
-      @PathVariable UUID userId,
-
-      @Parameter(description = "요청자 ID")
-      @RequestHeader("Monew-Request-User-ID") UUID requestUserId
+      @PathVariable UUID userId
   );
 }

--- a/src/main/java/com/springboot/monew/users/controller/UserController.java
+++ b/src/main/java/com/springboot/monew/users/controller/UserController.java
@@ -1,9 +1,9 @@
 package com.springboot.monew.users.controller;
 
-import com.springboot.monew.users.dto.response.UserDto;
 import com.springboot.monew.users.dto.request.UserLoginRequest;
 import com.springboot.monew.users.dto.request.UserRegisterRequest;
 import com.springboot.monew.users.dto.request.UserUpdateRequest;
+import com.springboot.monew.users.dto.response.UserDto;
 import com.springboot.monew.users.service.UserService;
 import jakarta.validation.Valid;
 import java.net.URI;
@@ -60,19 +60,17 @@ public class UserController implements UserApiDocs {
 
   @DeleteMapping("/{userId}")
   public ResponseEntity<Void> delete(
-      @PathVariable UUID userId,
-      @RequestHeader("Monew-Request-User-ID") UUID requestUserId
+      @PathVariable UUID userId
   ) {
-    userService.delete(userId, requestUserId);
+    userService.delete(userId);
     return ResponseEntity.noContent().build();
   }
 
   @DeleteMapping("/{userId}/hard")
   public ResponseEntity<Void> hardDelete(
-      @PathVariable UUID userId,
-      @RequestHeader("Monew-Request-User-ID") UUID requestUserId
+      @PathVariable UUID userId
   ) {
-    userService.hardDelete(userId, requestUserId);
+    userService.hardDelete(userId);
     return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/com/springboot/monew/users/document/UserActivityDocument.java
+++ b/src/main/java/com/springboot/monew/users/document/UserActivityDocument.java
@@ -30,7 +30,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 public class UserActivityDocument {
 
   @Id
-  private UUID userId;
+  private UUID id;
 
   private String email;
 
@@ -46,8 +46,8 @@ public class UserActivityDocument {
 
   private List<ArticleViewItem> articleViews = new ArrayList<>();
 
-  public UserActivityDocument(UUID userId, String email, String nickname, Instant createdAt) {
-    this.userId = userId;
+  public UserActivityDocument(UUID id, String email, String nickname, Instant createdAt) {
+    this.id = id;
     this.email = email;
     this.nickname = nickname;
     this.createdAt = createdAt;
@@ -58,7 +58,7 @@ public class UserActivityDocument {
       UUID interestId,
       String interestName,
       List<String> interestKeywords,
-      Long interestSubscriberCount,
+      long interestSubscriberCount,
       Instant createdAt
   ) {
 
@@ -71,7 +71,7 @@ public class UserActivityDocument {
       UUID userId,
       String userNickname,
       String content,
-      Long likeCount,
+      long likeCount,
       Instant createdAt
   ) {
 
@@ -86,7 +86,7 @@ public class UserActivityDocument {
       UUID commentUserId,
       String commentUserNickname,
       String commentContent,
-      Long commentLikeCount,
+      long commentLikeCount,
       Instant commentCreatedAt
   ) {
 
@@ -102,8 +102,8 @@ public class UserActivityDocument {
       String articleTitle,
       Instant articlePublishedDate,
       String articleSummary,
-      Long articleCommentCount,
-      Long articleViewCount
+      long articleCommentCount,
+      long articleViewCount
   ) {
 
   }

--- a/src/main/java/com/springboot/monew/users/dto/response/CommentActivityDto.java
+++ b/src/main/java/com/springboot/monew/users/dto/response/CommentActivityDto.java
@@ -24,7 +24,7 @@ public record CommentActivityDto(
     String content,
 
     @Schema(description = "좋아요 수")
-    Long likeCount,
+    long likeCount,
 
     @Schema(description = "작성된 날짜", format = "date-time")
     Instant createdAt

--- a/src/main/java/com/springboot/monew/users/dto/response/CommentLikeActivityDto.java
+++ b/src/main/java/com/springboot/monew/users/dto/response/CommentLikeActivityDto.java
@@ -30,7 +30,7 @@ public record CommentLikeActivityDto(
     String commentContent,
 
     @Schema(description = "좋아요 수")
-    Long commentLikeCount,
+    long commentLikeCount,
 
     @Schema(description = "작성된 날짜", format = "date-time")
     Instant commentCreatedAt

--- a/src/main/java/com/springboot/monew/users/dto/response/TemporaryArticleViewDto.java
+++ b/src/main/java/com/springboot/monew/users/dto/response/TemporaryArticleViewDto.java
@@ -13,8 +13,8 @@ public record TemporaryArticleViewDto(
     String articleTitle,
     Instant articlePublishedDate,
     String articleSummary,
-    Long articleCommentCount,
-    Long articleViewCount
+    long articleCommentCount,
+    long articleViewCount
 ) {
 
 }

--- a/src/main/java/com/springboot/monew/users/mapper/UserActivityMapper.java
+++ b/src/main/java/com/springboot/monew/users/mapper/UserActivityMapper.java
@@ -1,0 +1,35 @@
+package com.springboot.monew.users.mapper;
+
+import com.springboot.monew.interest.dto.response.SubscriptionDto;
+import com.springboot.monew.users.document.UserActivityDocument;
+import com.springboot.monew.users.document.UserActivityDocument.ArticleViewItem;
+import com.springboot.monew.users.document.UserActivityDocument.CommentItem;
+import com.springboot.monew.users.document.UserActivityDocument.CommentLikeItem;
+import com.springboot.monew.users.document.UserActivityDocument.SubscriptionItem;
+import com.springboot.monew.users.dto.response.CommentActivityDto;
+import com.springboot.monew.users.dto.response.CommentLikeActivityDto;
+import com.springboot.monew.users.dto.response.TemporaryArticleViewDto;
+import com.springboot.monew.users.dto.response.UserActivityDto;
+import com.springboot.monew.users.entity.User;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface UserActivityMapper {
+
+  @Mapping(target = "subscriptions", expression = "java(java.util.List.of())")
+  @Mapping(target = "comments", expression = "java(java.util.List.of())")
+  @Mapping(target = "commentLikes", expression = "java(java.util.List.of())")
+  @Mapping(target = "articleViews", expression = "java(java.util.List.of())")
+  UserActivityDto toEmptyDto(User user);
+
+  UserActivityDto toDto(UserActivityDocument document);
+
+  SubscriptionDto toDto(SubscriptionItem item);
+
+  CommentActivityDto toDto(CommentItem item);
+
+  CommentLikeActivityDto toDto(CommentLikeItem item);
+
+  TemporaryArticleViewDto toDto(ArticleViewItem item);
+}

--- a/src/main/java/com/springboot/monew/users/repository/UserActivityRepository.java
+++ b/src/main/java/com/springboot/monew/users/repository/UserActivityRepository.java
@@ -1,0 +1,9 @@
+package com.springboot.monew.users.repository;
+
+import com.springboot.monew.users.document.UserActivityDocument;
+import java.util.UUID;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface UserActivityRepository extends MongoRepository<UserActivityDocument, UUID> {
+
+}

--- a/src/main/java/com/springboot/monew/users/service/UserActivityService.java
+++ b/src/main/java/com/springboot/monew/users/service/UserActivityService.java
@@ -1,0 +1,46 @@
+package com.springboot.monew.users.service;
+
+import com.springboot.monew.users.dto.response.UserActivityDto;
+import com.springboot.monew.users.entity.User;
+import com.springboot.monew.users.exception.UserErrorCode;
+import com.springboot.monew.users.exception.UserException;
+import com.springboot.monew.users.mapper.UserActivityMapper;
+import com.springboot.monew.users.repository.UserActivityRepository;
+import com.springboot.monew.users.repository.UserRepository;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserActivityService {
+
+  private final UserRepository userRepository;
+  private final UserActivityRepository userActivityRepository;
+  private final UserActivityMapper userActivityMapper;
+
+  public UserActivityDto findUserActivity(UUID userId) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new UserException(
+            UserErrorCode.USER_NOT_FOUND,
+            Map.of("userId", userId)
+        ));
+
+    if (user.isDeleted()) {
+      throw new UserException(
+          UserErrorCode.USER_NOT_FOUND,
+          Map.of("userId", userId)
+      );
+    }
+
+    // MongoDB에 활동 내역 문서가 없으면 빈 배열이 들어간 응답 Dto를 반환하도록 설정
+    return userActivityRepository.findById(userId)
+        .map(userActivityMapper::toDto)
+        .orElseGet(() -> userActivityMapper.toEmptyDto(user));
+  }
+}

--- a/src/main/java/com/springboot/monew/users/service/UserService.java
+++ b/src/main/java/com/springboot/monew/users/service/UserService.java
@@ -114,9 +114,7 @@ public class UserService {
 
   // 논리 삭제
   @Transactional
-  public void delete(UUID userId, UUID requestUserId) {
-    validateOwner(userId, requestUserId);
-
+  public void delete(UUID userId) {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> {
           log.warn("사용자 탈퇴 실패: 사용자를 찾을 수 없음 - userId={}", userId);
@@ -140,9 +138,7 @@ public class UserService {
 
   // 수동 물리 삭제
   @Transactional
-  public void hardDelete(UUID userId, UUID requestUserId) {
-    validateOwner(userId, requestUserId);
-
+  public void hardDelete(UUID userId) {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> {
           log.warn("사용자 물리 삭제 실패: 사용자를 찾을 수 없음 - userId={}", userId);

--- a/src/test/java/com/springboot/monew/users/controller/UserActivityControllerTest.java
+++ b/src/test/java/com/springboot/monew/users/controller/UserActivityControllerTest.java
@@ -1,0 +1,91 @@
+package com.springboot.monew.users.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.springboot.monew.users.dto.response.UserActivityDto;
+import com.springboot.monew.users.exception.UserErrorCode;
+import com.springboot.monew.users.exception.UserException;
+import com.springboot.monew.users.service.UserActivityService;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = UserActivityController.class)
+public class UserActivityControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockitoBean
+  private UserActivityService userActivityService;
+
+  @Test
+  @DisplayName("사용자 활동 내역 조회 API는 200 OK와 활동 내역을 반환한다")
+  void getUserActivity_success() throws Exception {
+    // given
+    UUID userId = UUID.randomUUID();
+    Instant createdAt = Instant.parse("2026-04-18T00:00:00Z");
+
+    UserActivityDto expected = new UserActivityDto(
+        userId,
+        "test@example.com",
+        "monew123",
+        createdAt,
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of()
+    );
+
+    given(userActivityService.findUserActivity(userId)).willReturn(expected);
+
+    // when & then
+    mockMvc.perform(get("/api/user-activities/{userId}", userId))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(userId.toString()))
+        .andExpect(jsonPath("$.email").value(expected.email()))
+        .andExpect(jsonPath("$.nickname").value(expected.nickname()))
+        .andExpect(jsonPath("$.createdAt").value("2026-04-18T00:00:00Z"))
+        .andExpect(jsonPath("$.subscriptions").isArray())
+        .andExpect(jsonPath("$.comments").isArray())
+        .andExpect(jsonPath("$.commentLikes").isArray())
+        .andExpect(jsonPath("$.articleViews").isArray());
+
+    verify(userActivityService).findUserActivity(userId);
+  }
+
+  @Test
+  @DisplayName("사용자 활동 내역 조회 API는 사용자가 없으면 404 Not Found를 반환한다")
+  void getUserActivity_userNotFound() throws Exception {
+    // given
+    UUID userId = UUID.randomUUID();
+
+    given(userActivityService.findUserActivity(userId))
+        .willThrow(new UserException(
+        UserErrorCode.USER_NOT_FOUND,
+        Map.of("userId", userId)
+    ));
+
+    // when & then
+    mockMvc.perform(get("/api/user-activities/{userId}", userId))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.status").value(404))
+        .andExpect(jsonPath("$.code").value("UR03"))
+        .andExpect(jsonPath("$.exceptionType").value("UserException"))
+        .andExpect(jsonPath("$.details.userId").value(userId.toString()));
+
+    verify(userActivityService).findUserActivity(userId);
+  }
+
+}

--- a/src/test/java/com/springboot/monew/users/controller/UserControllerTest.java
+++ b/src/test/java/com/springboot/monew/users/controller/UserControllerTest.java
@@ -214,11 +214,10 @@ public class UserControllerTest {
     UUID userId = UUID.randomUUID();
 
     // when & then
-    mockMvc.perform(delete("/api/users/{userId}", userId)
-            .header("MoNew-Request-User-ID", userId))
+    mockMvc.perform(delete("/api/users/{userId}", userId))
         .andExpect(status().isNoContent());
 
-    verify(userService).delete(userId, userId);
+    verify(userService).delete(userId);
   }
 
   @Test
@@ -228,10 +227,9 @@ public class UserControllerTest {
     UUID userId = UUID.randomUUID();
 
     // when & then
-    mockMvc.perform(delete("/api/users/{userId}/hard", userId)
-            .header("MoNew-Request-User-ID", userId))
+    mockMvc.perform(delete("/api/users/{userId}/hard", userId))
         .andExpect(status().isNoContent());
 
-    verify(userService).hardDelete(userId, userId);
+    verify(userService).hardDelete(userId);
   }
 }

--- a/src/test/java/com/springboot/monew/users/service/UserActivityServiceTest.java
+++ b/src/test/java/com/springboot/monew/users/service/UserActivityServiceTest.java
@@ -1,0 +1,171 @@
+package com.springboot.monew.users.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.springboot.monew.users.document.UserActivityDocument;
+import com.springboot.monew.users.dto.response.UserActivityDto;
+import com.springboot.monew.users.entity.User;
+import com.springboot.monew.users.exception.UserErrorCode;
+import com.springboot.monew.users.exception.UserException;
+import com.springboot.monew.users.mapper.UserActivityMapper;
+import com.springboot.monew.users.repository.UserActivityRepository;
+import com.springboot.monew.users.repository.UserRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class UserActivityServiceTest {
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private UserActivityRepository userActivityRepository;
+
+  @Mock
+  private UserActivityMapper userActivityMapper;
+
+  @InjectMocks
+  private UserActivityService userActivityService;
+
+  @Test
+  @DisplayName("활동 내역 문서가 있으면 사용자 활동 내역을 조회한다")
+  void findUserActivity_success_withDocument() {
+    // given
+    UUID userId = UUID.randomUUID();
+    Instant createdAt = Instant.parse("2026-04-18T00:00:00Z");
+
+    User user = new User("test@example.com", "monew123", "password123");
+
+    UserActivityDocument document = new UserActivityDocument(
+        userId,
+        "test@example.com",
+        "monew123",
+        createdAt
+    );
+
+    UserActivityDto expected = new UserActivityDto(
+        userId,
+        "test@example.com",
+        "monew123",
+        createdAt,
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of()
+    );
+
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+    given(userActivityRepository.findById(userId)).willReturn(Optional.of(document));
+    given(userActivityMapper.toDto(document)).willReturn(expected);
+
+    // when
+    UserActivityDto result = userActivityService.findUserActivity(userId);
+
+    // then
+    assertThat(result).isEqualTo(expected);
+
+    verify(userRepository).findById(userId);
+    verify(userActivityRepository).findById(userId);
+    verify(userActivityMapper).toDto(document);
+    verify(userActivityMapper, never()).toEmptyDto(any());
+  }
+
+  @Test
+  @DisplayName("활동 내역 문서가 없으면 빈 활동 내역을 반환한다")
+  void findUserActivity_success_withEmptyDocument() {
+    // given
+    UUID userId = UUID.randomUUID();
+    Instant createdAt = Instant.parse("2026-04-18T00:00:00Z");
+
+    User user = new User("test@example.com", "monew123", "password123");
+
+    UserActivityDto expected = new UserActivityDto(
+        userId,
+        "test@example.com",
+        "monew123",
+        createdAt,
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of()
+    );
+
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+    given(userActivityRepository.findById(userId)).willReturn(Optional.empty());
+    given(userActivityMapper.toEmptyDto(user)).willReturn(expected);
+
+    // when
+    UserActivityDto result = userActivityService.findUserActivity(userId);
+
+    // then
+    assertThat(result).isEqualTo(expected);
+    assertThat(result.subscriptions()).isEmpty();
+    assertThat(result.comments()).isEmpty();
+    assertThat(result.commentLikes()).isEmpty();
+    assertThat(result.articleViews()).isEmpty();
+
+    verify(userRepository).findById(userId);
+    verify(userActivityRepository).findById(userId);
+    verify(userActivityMapper).toEmptyDto(user);
+    verify(userActivityMapper, never()).toDto(any(UserActivityDocument.class));
+  }
+
+  @Test
+  @DisplayName("사용자가 존재하지 않으면 USER_NOT_FOUND 예외가 발생한다")
+  void findUserActivity_userNotFound() {
+    // given
+    UUID userId = UUID.randomUUID();
+
+    given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> userActivityService.findUserActivity(userId))
+        .isInstanceOf(UserException.class)
+        .satisfies(throwable -> {
+          UserException exception = (UserException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("userId", userId));
+        });
+
+    verify(userRepository).findById(userId);
+    verify(userActivityRepository, never()).findById(any());
+  }
+
+  @Test
+  @DisplayName("논리 삭제된 사용자 조회 시 USER_NOT_FOUND 예외가 발생한다")
+  void findUserActivity_deletedUser() {
+    // given
+    UUID userId = UUID.randomUUID();
+
+    User deletedUser = new User("deleted@example.com", "monew123", "password123");
+    deletedUser.delete();
+
+    given(userRepository.findById(userId)).willReturn(Optional.of(deletedUser));
+
+    // when & then
+    assertThatThrownBy(() -> userActivityService.findUserActivity(userId))
+        .isInstanceOf(UserException.class)
+        .satisfies(throwable -> {
+          UserException exception = (UserException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("userId", userId));
+        });
+
+    verify(userRepository).findById(userId);
+    verify(userActivityRepository, never()).findById(any());
+  }
+}

--- a/src/test/java/com/springboot/monew/users/service/UserServiceTest.java
+++ b/src/test/java/com/springboot/monew/users/service/UserServiceTest.java
@@ -386,31 +386,11 @@ public class UserServiceTest {
     assertThat(user.isDeleted()).isFalse();
 
     // when
-    userService.delete(userId, userId);
+    userService.delete(userId);
 
     // then
     assertThat(user.isDeleted()).isTrue();
     verify(userRepository).findById(userId);
-  }
-
-  @Test
-  @DisplayName("요청 사용자와 삭제 대상 사용자가 다르면 USER_NOT_OWNED 예외가 발생한다")
-  void delete_userNotOwned() {
-    // given
-    UUID userId = UUID.randomUUID();
-    UUID requestUserId = UUID.randomUUID();
-
-    // when & then
-    assertThatThrownBy(() -> userService.delete(userId, requestUserId))
-        .isInstanceOf(UserException.class)
-        .satisfies(throwable -> {
-          UserException exception = (UserException) throwable;
-          assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_OWNED);
-          assertThat(exception.getDetails()).isEqualTo(
-              Map.of("userId", userId, "requestUserId", requestUserId));
-        });
-    verify(userRepository, never()).findById(any());
-    verify(userMapper, never()).toDto(any());
   }
 
   @Test
@@ -422,7 +402,7 @@ public class UserServiceTest {
     given(userRepository.findById(userId)).willReturn(Optional.empty());
 
     // when & then
-    assertThatThrownBy(() -> userService.delete(userId, userId))
+    assertThatThrownBy(() -> userService.delete(userId))
         .isInstanceOf(UserException.class)
         .satisfies(throwable -> {
           UserException exception = (UserException) throwable;
@@ -443,7 +423,7 @@ public class UserServiceTest {
     given(userRepository.findById(userId)).willReturn(Optional.of(deletedUser));
 
     // when & then
-    assertThatThrownBy(() -> userService.delete(userId, userId))
+    assertThatThrownBy(() -> userService.delete(userId))
         .isInstanceOf(UserException.class)
         .satisfies(throwable -> {
           UserException exception = (UserException) throwable;
@@ -464,31 +444,11 @@ public class UserServiceTest {
     given(userRepository.findById(userId)).willReturn(Optional.of(user));
 
     // when
-    userService.hardDelete(userId, userId);
+    userService.hardDelete(userId);
 
     // then
     verify(userRepository).findById(userId);
     verify(userRepository).delete(user);
-  }
-
-  @Test
-  @DisplayName("요청 사용자와 물리 삭제 대상 사용자가 다르면 USER_NOT_OWNED 예외가 발생한다")
-  void hardDelete_userNotOwned() {
-    // given
-    UUID userId = UUID.randomUUID();
-    UUID requestUserId = UUID.randomUUID();
-
-    // when & then
-    assertThatThrownBy(() -> userService.hardDelete(userId, requestUserId))
-        .isInstanceOf(UserException.class)
-        .satisfies(throwable -> {
-          UserException exception = (UserException) throwable;
-          assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_OWNED);
-          assertThat(exception.getDetails()).isEqualTo(
-              Map.of("userId", userId, "requestUserId", requestUserId));
-        });
-
-    verify(userRepository, never()).findById(any());
   }
 
   @Test
@@ -500,7 +460,7 @@ public class UserServiceTest {
     given(userRepository.findById(userId)).willReturn(Optional.empty());
 
     // when & then
-    assertThatThrownBy(() -> userService.hardDelete(userId, userId))
+    assertThatThrownBy(() -> userService.hardDelete(userId))
         .isInstanceOf(UserException.class)
         .satisfies(throwable -> {
           UserException exception = (UserException) throwable;


### PR DESCRIPTION
## 📌 해당 이슈카드

Closes #100 #90 #103 #104 #152 #153 #154

## 📌 작업 내용
- MongoDB 기반 사용자 활동 내역 조회 API 기본 구조를 구현했습니다.
- 사용자 ID로 RDB 사용자 존재 여부와 논리 삭제 여부를 검증하도록 구현했습니다.
- MongoDB에 사용자 활동 내역 문서가 있는 경우 해당 문서를 응답 DTO로 매핑하도록 구현했습니다.
- MongoDB에 사용자 활동 내역 문서가 없는 경우 사용자 정보와 빈 활동 목록을 담은 응답 DTO를 반환하도록 구현했습니다.
- 사용자 활동 내역 조회용 Repository, Service, Mapper, Controller, API 문서를 추가했습니다.
- 사용자 활동 내역 조회 Service 및 Controller 테스트를 추가했습니다.

## 🔧 변경 사항
- `UserActivityRepository` 추가
  - `MongoRepository<UserActivityDocument, UUID>` 기반 조회
  - 사용자 활동 문서 조회 시 기본 제공 `findById(UUID userId)` 사용

- `UserActivityMapper` 추가
  - `UserActivityDocument` -> `UserActivityDto` 매핑
  - `User` -> 빈 활동 목록을 포함한 `UserActivityDto` 매핑
  - 내부 Item record를 응답 DTO로 매핑

- `UserActivityService` 추가
  - MongoDB 활동 내역 문서 조회
  - 문서가 없을 경우 빈 활동 내역 응답 처리

- `UserActivityController` 추가

- `UserActivityDocs` 추가
  - 사용자 활동 내역 조회 API 문서화

- `UserActivityServiceTest` 추가

- `UserActivityControllerTest` 추가

## 반영 브랜치
`feature/#100/user-activity-api` -> `dev`

## 💬 기타 참고 사항
- 현재 작업은 사용자 활동 내역 조회 API의 기본 구조 구현 범위입니다.
- 실제 사용자 활동 발생 시 MongoDB 문서를 생성하거나 갱신하는 로직은 아직 포함되어 있지 않습니다.
- 최근 활동 목록 최대 10건 유지 로직은 후속 작업에서 구현 예정입니다.
- 후속 작업에서 `UserActivityUpdateService`를 구현하고, 구독/댓글/댓글 좋아요/기사 조회 서비스와 연동할 예정입니다.
- MongoDB 문서가 없는 경우 GET 요청에서 문서를 생성하지 않고 빈 활동 목록 응답만 반환합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자 활동 내역 조회 API 엔드포인트 추가

* **개선 사항**
  * 사용자 삭제 작업 간소화 (요청 헤더 제거)

* **문서화**
  * 사용자 활동 관리 API 문서 추가

* **테스트**
  * 사용자 활동 서비스 및 컨트롤러 테스트 커버리지 확대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->