### PR TITLE
[Test] CommentService, CommentLikeService 테스트

### DIFF
--- a/src/main/java/com/springboot/monew/comment/dto/CommentLikeDto.java
+++ b/src/main/java/com/springboot/monew/comment/dto/CommentLikeDto.java
@@ -15,5 +15,5 @@ public record CommentLikeDto(
     UUID commentUserId,
     String commentUserNickname,
     String commentContent,
-    Integer commentLikeCount,
+    Long commentLikeCount,
     Instant commentCreatedAt) {}

--- a/src/main/java/com/springboot/monew/interest/repository/qdsl/InterestQDSLRepositoryImpl.java
+++ b/src/main/java/com/springboot/monew/interest/repository/qdsl/InterestQDSLRepositoryImpl.java
@@ -38,7 +38,7 @@ public class InterestQDSLRepositoryImpl implements InterestQDSLRepository {
   public Optional<Interest> findByIdWithArticleCount(UUID id) {
     Tuple result = queryFactory.select(qInterest, qArticleInterest.count())
         .from(qInterest)
-        .leftJoin(qInterest, qArticleInterest.interest)
+        .leftJoin(qArticleInterest).on(qArticleInterest.interest.eq(qInterest))
         .where(qInterest.id.eq(id))
         .groupBy(qInterest)
         .fetchOne();

--- a/src/test/java/com/springboot/monew/comment/controller/CommentLikeControllerTest.java
+++ b/src/test/java/com/springboot/monew/comment/controller/CommentLikeControllerTest.java
@@ -53,7 +53,7 @@ class CommentLikeControllerTest {
         UUID.randomUUID(),
         "작성자닉네임",
         "댓글내용",
-        0,
+        0L,
         Instant.now()
     );
 

--- a/src/test/java/com/springboot/monew/comment/service/CommentLikeServiceTest.java
+++ b/src/test/java/com/springboot/monew/comment/service/CommentLikeServiceTest.java
@@ -1,0 +1,263 @@
+package com.springboot.monew.comment.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.instancio.Select.field;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.springboot.monew.comment.dto.CommentLikeDto;
+import com.springboot.monew.comment.entity.Comment;
+import com.springboot.monew.comment.entity.CommentLike;
+import com.springboot.monew.comment.exception.CommentErrorCode;
+import com.springboot.monew.comment.mapper.CommentLikeMapper;
+import com.springboot.monew.comment.repository.CommentLikeRepository;
+import com.springboot.monew.comment.repository.CommentRepository;
+import com.springboot.monew.common.exception.MonewException;
+import com.springboot.monew.notification.event.CommentLikeNotificationEvent;
+import com.springboot.monew.users.entity.User;
+import com.springboot.monew.users.exception.UserErrorCode;
+import com.springboot.monew.users.repository.UserRepository;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.instancio.Instancio;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+class CommentLikeServiceTest {
+
+  @Mock private CommentLikeRepository commentLikeRepository;
+  @Mock private CommentRepository commentRepository;
+  @Mock private CommentLikeMapper commentLikeMapper;
+  @Mock private UserRepository userRepository;
+  @Mock private ApplicationEventPublisher eventPublisher;
+
+  @InjectMocks
+  private CommentLikeService commentLikeService;
+
+  @Test
+  @DisplayName("좋아요 성공 테스트 케이스")
+  void like_성공() {
+    // given, instancio -> random 값으로 객체를 생성해주는 라이브러리 ?
+    Comment comment = Instancio.of(Comment.class).create();
+
+    Comment refreshed = Instancio.of(Comment.class)
+        .set(field(Comment.class, "likeCount"), comment.getLikeCount() + 1)
+        .create();
+
+    User user = Instancio.of(User.class)
+        .set(field(User.class, "deletedAt"), null)
+        .create();
+
+
+    CommentLikeDto expected = new CommentLikeDto(
+        UUID.randomUUID(),
+        user.getId(),
+        Instant.now(),
+        refreshed.getId(),
+        refreshed.getArticle().getId(),
+        refreshed.getUser().getId(),
+        refreshed.getUser().getNickname(),
+        refreshed.getContent(),
+        refreshed.getLikeCount(),
+        refreshed.getCreatedAt()
+    );
+
+    given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+    given(commentRepository.findByIdAndIsDeletedFalse(comment.getId()))
+        .willReturn(Optional.of(comment))
+            .willReturn(Optional.of(refreshed));
+    given(commentLikeRepository.existsByCommentIdAndUserId(comment.getId(), user.getId()))
+        .willReturn(false);
+    given(commentLikeMapper.toCommentLikeDto(any(CommentLike.class))).willReturn(expected);
+
+    // when
+    CommentLikeDto result = commentLikeService.like(comment.getId(), user.getId());
+
+    // then
+    assertThat(result).isEqualTo(expected);
+
+    verify(commentRepository, times(2)).findByIdAndIsDeletedFalse(comment.getId());
+    verify(commentLikeRepository).save(any(CommentLike.class));
+    verify(commentLikeMapper).toCommentLikeDto(any(CommentLike.class));
+    verify(eventPublisher).publishEvent(any(CommentLikeNotificationEvent.class));
+  }
+
+  @Test
+  @DisplayName("좋아요 실패 테스트 케이스 - SoftDelete 된 User")
+  void like_실패_UserNotFound() {
+    // given
+    // softDelete된 User 생성
+    User user = Instancio.of(User.class)
+        .set(field(User.class, "deletedAt"), Instant.now())
+        .create();
+    Comment comment = Instancio.of(Comment.class).create();
+
+    given(commentRepository.findByIdAndIsDeletedFalse(comment.getId())).willReturn(Optional.of(comment));
+    given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+    // when & then
+    assertThatThrownBy(() -> commentLikeService.like(comment.getId(), user.getId()))
+        .isInstanceOf(MonewException.class)
+        .satisfies(throwable -> {
+          MonewException exception = (MonewException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("userId", user.getId()));
+        });
+
+    verify(commentRepository, times(1)).findByIdAndIsDeletedFalse(comment.getId());
+    verify(userRepository, times(1)).findById(user.getId());
+    verify(commentLikeRepository, never()).save(any(CommentLike.class));
+    verify(eventPublisher, never()).publishEvent(any(CommentLikeNotificationEvent.class));
+    verify(commentLikeMapper, never()).toCommentLikeDto(any(CommentLike.class));
+  }
+
+  @Test
+  @DisplayName("좋아요 실패 테스트 케이스 - SoftDelete 된 Comment")
+  void like_실패_CommentNotFound() {
+    // given
+    Comment comment = Instancio.of(Comment.class)
+        .set(field(Comment.class, "isDeleted"), true)
+        .create();
+
+    given(commentRepository.findByIdAndIsDeletedFalse(comment.getId())).willReturn(Optional.empty());
+    // when & then
+    assertThatThrownBy(() -> commentLikeService.like(comment.getId(), UUID.randomUUID()))
+        .isInstanceOf(MonewException.class)
+        .satisfies(throwable -> {
+          MonewException exception = (MonewException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(CommentErrorCode.COMMENT_NOT_FOUND);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("commentId", comment.getId()));
+        });
+
+    verify(commentRepository, times(1)).findByIdAndIsDeletedFalse(comment.getId());
+    verify(userRepository, never()).findById(any());
+    verify(commentLikeRepository, never()).save(any(CommentLike.class));
+    verify(eventPublisher, never()).publishEvent(any(CommentLikeNotificationEvent.class));
+    verify(commentLikeMapper, never()).toCommentLikeDto(any(CommentLike.class));
+  }
+
+  @Test
+  @DisplayName("좋아요 취소 성공 테스트 케이스")
+  void unlike_성공() {
+    // given
+    Comment comment = Instancio.of(Comment.class)
+        .set(field(Comment.class, "likeCount"), 1)
+        .create();
+
+    User user = Instancio.of(User.class)
+        .set(field(User.class, "deletedAt"), null)
+        .create();
+
+    CommentLike commentLike = new CommentLike(comment, user);
+
+    given(commentRepository.findByIdAndIsDeletedFalse(comment.getId())).willReturn(Optional.of(comment));
+    given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+    given(commentLikeRepository.findCommentLikeByCommentAndUser(comment, user)).willReturn(Optional.of(commentLike));
+
+    // when
+    commentLikeService.unlike(comment.getId(), user.getId());
+
+    // then
+    verify(commentLikeRepository).delete(commentLike);
+    verify(commentRepository).decrementLikeCount(comment.getId());
+  }
+
+  @Test
+  @DisplayName("좋아요 취소 실패 테스트 - UserNotFound, softDelete된 경우")
+  void unlike_실패_UserNotFound() {
+    // given
+    Comment comment = Instancio.of(Comment.class).create();
+    User user = Instancio.of(User.class)
+        .set(field(User.class, "deletedAt"), Instant.now())
+        .create();
+
+    given(commentRepository.findByIdAndIsDeletedFalse(comment.getId())).willReturn(Optional.of(comment));
+    given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+
+    // when & then
+    assertThatThrownBy(() -> commentLikeService.unlike(comment.getId(), user.getId()))
+        .isInstanceOf(MonewException.class)
+        .satisfies(throwable -> {
+          MonewException exception = (MonewException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("userId", user.getId()));
+        });
+
+    verify(commentRepository, times(1)).findByIdAndIsDeletedFalse(comment.getId());
+    verify(userRepository, times(1)).findById(user.getId());
+    verify(commentLikeRepository, never()).delete(any(CommentLike.class));
+    verify(commentRepository, never()).decrementLikeCount(any(UUID.class));
+    verify(eventPublisher, never()).publishEvent(any(CommentLikeNotificationEvent.class));
+  }
+
+  @Test
+  @DisplayName("좋아요 취소 실패 테스트 - CommentNotFound")
+  void unlike_실패_CommentNotFound() {
+    // given
+    Comment comment = Instancio.of(Comment.class)
+        .set(field(Comment.class, "isDeleted"), true)
+        .create();
+    User user = Instancio.of(User.class).create();
+
+    given(commentRepository.findByIdAndIsDeletedFalse(comment.getId()))
+        .willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> commentLikeService.unlike(comment.getId(), user.getId()))
+        .isInstanceOf(MonewException.class)
+        .satisfies(throwable -> {
+          MonewException exception = (MonewException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(CommentErrorCode.COMMENT_NOT_FOUND);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("commentId", comment.getId()));
+        });
+
+    verify(commentRepository, times(1)).findByIdAndIsDeletedFalse(comment.getId());
+    verify(userRepository, never()).findById(any());
+    verify(commentLikeRepository, never()).delete(any(CommentLike.class));
+    verify(commentRepository, never()).decrementLikeCount(any(UUID.class));
+    verify(eventPublisher, never()).publishEvent(any(CommentLikeNotificationEvent.class));
+  }
+
+  @Test
+  @DisplayName("좋아요 취소 실패 테스트 - CommentLikeNotFound")
+  void unlike_실패_CommentLikeNotFound() {
+    // given
+    Comment comment = Instancio.of(Comment.class).create();
+    User user = Instancio.of(User.class)
+            .set(field(User.class, "deletedAt"), null)
+                .create();
+
+    given(commentRepository.findByIdAndIsDeletedFalse(comment.getId()))
+        .willReturn(Optional.of(comment));
+    given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+    given(commentLikeRepository.findCommentLikeByCommentAndUser(comment, user)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> commentLikeService.unlike(comment.getId(), user.getId()))
+        .isInstanceOf(MonewException.class)
+        .satisfies(throwable -> {
+          MonewException exception = (MonewException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(CommentErrorCode.COMMENT_LIKE_NOT_FOUND);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("commentId", comment.getId()));
+        });
+
+    verify(commentRepository, times(1)).findByIdAndIsDeletedFalse(comment.getId());
+    verify(userRepository, times(1)).findById(user.getId());
+    verify(commentLikeRepository, times(1)).findCommentLikeByCommentAndUser(comment, user);
+    verify(commentLikeRepository, never()).delete(any(CommentLike.class));
+    verify(commentRepository, never()).decrementLikeCount(any(UUID.class));
+    verify(eventPublisher, never()).publishEvent(any(CommentLikeNotificationEvent.class));
+  }
+}

--- a/src/test/java/com/springboot/monew/comment/service/CommentLikeServiceTest.java
+++ b/src/test/java/com/springboot/monew/comment/service/CommentLikeServiceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.verify;
 
 import com.springboot.monew.comment.dto.CommentLikeDto;
 import com.springboot.monew.comment.entity.Comment;
+import com.springboot.monew.common.entity.BaseEntity;
 import com.springboot.monew.comment.entity.CommentLike;
 import com.springboot.monew.comment.exception.CommentErrorCode;
 import com.springboot.monew.comment.mapper.CommentLikeMapper;
@@ -54,6 +55,11 @@ class CommentLikeServiceTest {
     Comment comment = Instancio.of(Comment.class).create();
 
     Comment refreshed = Instancio.of(Comment.class)
+        .set(field(BaseEntity.class, "id"), comment.getId())
+        .set(field(BaseEntity.class, "createdAt"), comment.getCreatedAt())
+        .set(field(Comment.class, "article"), comment.getArticle())
+        .set(field(Comment.class, "user"), comment.getUser())
+        .set(field(Comment.class, "content"), comment.getContent())
         .set(field(Comment.class, "likeCount"), comment.getLikeCount() + 1)
         .create();
 
@@ -143,6 +149,38 @@ class CommentLikeServiceTest {
 
     verify(commentRepository, times(1)).findByIdAndIsDeletedFalse(comment.getId());
     verify(userRepository, never()).findById(any());
+    verify(commentLikeRepository, never()).save(any(CommentLike.class));
+    verify(eventPublisher, never()).publishEvent(any(CommentLikeNotificationEvent.class));
+    verify(commentLikeMapper, never()).toCommentLikeDto(any(CommentLike.class));
+  }
+
+  @Test
+  @DisplayName("좋아요 실패 테스트 케이스 - 중복 좋아요")
+  void like_실패_CommentLikeAlreadyExists() {
+    // given
+    Comment comment = Instancio.of(Comment.class)
+          .create();
+    User user = Instancio.of(User.class)
+        .set(field(User.class, "deletedAt"), null)
+        .create();
+
+    given(commentRepository.findByIdAndIsDeletedFalse(comment.getId())).willReturn(Optional.of(comment));
+    given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+    // 중복 좋아요
+    given(commentLikeRepository.existsByCommentIdAndUserId(comment.getId(), user.getId())).willReturn(true);
+
+    // when & then
+    assertThatThrownBy(() -> commentLikeService.like(comment.getId(), user.getId()))
+        .isInstanceOf(MonewException.class)
+        .satisfies(throwable -> {
+          MonewException exception = (MonewException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(CommentErrorCode.COMMENT_LIKE_ALREADY_EXISTS);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("commentId", comment.getId(), "userId", user.getId()));
+        });
+
+    verify(commentRepository, times(1)).findByIdAndIsDeletedFalse(comment.getId());
+    verify(userRepository, times(1)).findById(user.getId());
+    verify(commentLikeRepository, times(1)).existsByCommentIdAndUserId(comment.getId(), user.getId());
     verify(commentLikeRepository, never()).save(any(CommentLike.class));
     verify(eventPublisher, never()).publishEvent(any(CommentLikeNotificationEvent.class));
     verify(commentLikeMapper, never()).toCommentLikeDto(any(CommentLike.class));

--- a/src/test/java/com/springboot/monew/comment/service/CommentLikeServiceTest.java
+++ b/src/test/java/com/springboot/monew/comment/service/CommentLikeServiceTest.java
@@ -50,7 +50,7 @@ class CommentLikeServiceTest {
 
   @Test
   @DisplayName("좋아요 성공 테스트 케이스")
-  void like_성공() {
+  void like_ReturnsCommentLikeDto_WhenValidRequest() {
     // given, instancio -> random 값으로 객체를 생성해주는 라이브러리 ?
     Comment comment = Instancio.of(Comment.class).create();
 
@@ -103,7 +103,7 @@ class CommentLikeServiceTest {
 
   @Test
   @DisplayName("좋아요 실패 테스트 케이스 - SoftDelete 된 User")
-  void like_실패_UserNotFound() {
+  void like_ThrowsException_WhenUserNotFound() {
     // given
     // softDelete된 User 생성
     User user = Instancio.of(User.class)
@@ -131,7 +131,7 @@ class CommentLikeServiceTest {
 
   @Test
   @DisplayName("좋아요 실패 테스트 케이스 - SoftDelete 된 Comment")
-  void like_실패_CommentNotFound() {
+  void like_ThrowsException_WhenCommentNotFound() {
     // given
     Comment comment = Instancio.of(Comment.class)
         .set(field(Comment.class, "isDeleted"), true)
@@ -156,7 +156,7 @@ class CommentLikeServiceTest {
 
   @Test
   @DisplayName("좋아요 실패 테스트 케이스 - 중복 좋아요")
-  void like_실패_CommentLikeAlreadyExists() {
+  void like_ThrowsException_WhenLikeAlreadyExists() {
     // given
     Comment comment = Instancio.of(Comment.class)
           .create();
@@ -188,7 +188,7 @@ class CommentLikeServiceTest {
 
   @Test
   @DisplayName("좋아요 취소 성공 테스트 케이스")
-  void unlike_성공() {
+  void unlike_DeletesLikeAndDecrementsCount_WhenValidRequest() {
     // given
     Comment comment = Instancio.of(Comment.class)
         .set(field(Comment.class, "likeCount"), 1)
@@ -214,7 +214,7 @@ class CommentLikeServiceTest {
 
   @Test
   @DisplayName("좋아요 취소 실패 테스트 - UserNotFound, softDelete된 경우")
-  void unlike_실패_UserNotFound() {
+  void unlike_ThrowsException_WhenUserNotFound() {
     // given
     Comment comment = Instancio.of(Comment.class).create();
     User user = Instancio.of(User.class)
@@ -242,7 +242,7 @@ class CommentLikeServiceTest {
 
   @Test
   @DisplayName("좋아요 취소 실패 테스트 - CommentNotFound")
-  void unlike_실패_CommentNotFound() {
+  void unlike_ThrowsException_WhenCommentNotFound() {
     // given
     Comment comment = Instancio.of(Comment.class)
         .set(field(Comment.class, "isDeleted"), true)
@@ -270,7 +270,7 @@ class CommentLikeServiceTest {
 
   @Test
   @DisplayName("좋아요 취소 실패 테스트 - CommentLikeNotFound")
-  void unlike_실패_CommentLikeNotFound() {
+  void unlike_ThrowsException_WhenLikeNotFound() {
     // given
     Comment comment = Instancio.of(Comment.class).create();
     User user = Instancio.of(User.class)

--- a/src/test/java/com/springboot/monew/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/springboot/monew/comment/service/CommentServiceTest.java
@@ -60,11 +60,20 @@ class CommentServiceTest {
 
   @Test
   @DisplayName("댓글 등록에 성공한다")
-  void create_성공() {
+  void create_성공() throws NoSuchFieldException, IllegalAccessException{
     // given
+    UUID userId = UUID.randomUUID();
+    UUID articleId = UUID.randomUUID();
+
     User user = new User("email", "nickname", "password");
     NewsArticle article = new NewsArticle(
         ArticleSource.NAVER, "https://test.com", "제목", Instant.now(), "요약");
+
+    // id 필드 리플렉션 -> id가 DB insert 되어야 생성되서 리플렉션 사용했습니다.
+    Field idField = BaseEntity.class.getDeclaredField("id");
+    idField.setAccessible(true);
+    idField.set(user, userId);
+    idField.set(article, articleId);
 
     CommentRegisterRequest request = new CommentRegisterRequest(
         article.getId(),
@@ -218,6 +227,7 @@ class CommentServiceTest {
 
     // when & then
     assertThatThrownBy(() -> commentService.update(commentId, userId, request))
+        .isInstanceOf(MonewException.class)
         .satisfies(throwable -> {
           MonewException exception = (MonewException) throwable;
           assertThat(exception.getErrorCode()).isEqualTo(CommentErrorCode.COMMENT_NOT_FOUND);
@@ -243,6 +253,7 @@ class CommentServiceTest {
 
     // when & then
     assertThatThrownBy(() -> commentService.update(commentId, userId, request))
+        .isInstanceOf(MonewException.class)
         .satisfies(throwable -> {
           MonewException exception = (MonewException) throwable;
           assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
@@ -280,6 +291,7 @@ class CommentServiceTest {
 
     // when
     assertThatThrownBy(() -> commentService.update(commentId, userId, request))
+        .isInstanceOf(MonewException.class)
         .satisfies(throwable -> {
           MonewException exception = (MonewException) throwable;
           assertThat(exception.getErrorCode()).isEqualTo(CommentErrorCode.COMMENT_NOT_OWNED_BY_USER);
@@ -321,6 +333,7 @@ class CommentServiceTest {
 
     // when & then
     assertThatThrownBy(() -> commentService.softDelete(commentId))
+        .isInstanceOf(MonewException.class)
         .satisfies(throwable -> {
           CommentException exception = (CommentException) throwable;
           assertThat(exception.getErrorCode()).isEqualTo(CommentErrorCode.COMMENT_NOT_FOUND);
@@ -343,6 +356,7 @@ class CommentServiceTest {
 
     // when
     assertThatThrownBy(() -> commentService.softDelete(commentId))
+        .isInstanceOf(MonewException.class)
         .satisfies(throwable -> {
           CommentException exception = (CommentException) throwable;
           assertThat(exception.getErrorCode()).isEqualTo(CommentErrorCode.COMMENT_ALREADY_DELETED);
@@ -379,6 +393,7 @@ class CommentServiceTest {
     given(commentRepository.findById(commentId)).willReturn(Optional.empty());
     // when
     assertThatThrownBy(() -> commentService.hardDelete(commentId))
+        .isInstanceOf(MonewException.class)
         .satisfies(throwable -> {
           CommentException exception = (CommentException) throwable;
           assertThat(exception.getErrorCode()).isEqualTo(CommentErrorCode.COMMENT_NOT_FOUND);
@@ -565,6 +580,7 @@ class CommentServiceTest {
 
     // when & then
     assertThatThrownBy(() -> commentService.list(request, userId))
+        .isInstanceOf(MonewException.class)
         .satisfies(throwable -> {
           MonewException exception = (MonewException) throwable;
           assertThat(exception.getErrorCode()).isEqualTo(NewsArticleErrorCode.NEWS_ARTICLE_NOT_FOUND);
@@ -591,6 +607,7 @@ class CommentServiceTest {
 
     // when & then
     assertThatThrownBy(() -> commentService.list(request, userId))
+        .isInstanceOf(MonewException.class)
         .satisfies(throwable -> {
           MonewException exception = (MonewException) throwable;
           assertThat(exception.getErrorCode()).isEqualTo(NewsArticleErrorCode.NEWS_ARTICLE_ALREADY_DELETED);
@@ -618,6 +635,7 @@ class CommentServiceTest {
 
     // when & then
     assertThatThrownBy(() -> commentService.list(request, userId))
+        .isInstanceOf(MonewException.class)
         .satisfies(throwable -> {
           MonewException exception = (MonewException) throwable;
           assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
@@ -647,6 +665,7 @@ class CommentServiceTest {
 
     // when & then
     assertThatThrownBy(() -> commentService.list(request, userId))
+        .isInstanceOf(MonewException.class)
         .satisfies(throwable -> {
           MonewException exception = (MonewException) throwable;
           assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);

--- a/src/test/java/com/springboot/monew/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/springboot/monew/comment/service/CommentServiceTest.java
@@ -60,7 +60,7 @@ class CommentServiceTest {
 
   @Test
   @DisplayName("댓글 등록에 성공한다")
-  void create_성공() throws NoSuchFieldException, IllegalAccessException{
+  void create_ReturnsCommentDto_WhenValidRequest() throws NoSuchFieldException, IllegalAccessException{
     // given
     UUID userId = UUID.randomUUID();
     UUID articleId = UUID.randomUUID();
@@ -112,7 +112,7 @@ class CommentServiceTest {
 
   @Test
   @DisplayName("Article이 존재하지 않는 경우는 ArticleNotFound를 반환한다")
-  void create_실패_ArticleNotFound() {
+  void create_ThrowsException_WhenArticleNotFound() {
     // given
     UUID articleId = UUID.randomUUID();
     CommentRegisterRequest request = new CommentRegisterRequest(articleId, UUID.randomUUID(), "테스트 댓글");
@@ -136,7 +136,7 @@ class CommentServiceTest {
 
   @Test
   @DisplayName("User가 존재하지 않는 경우는 UserNotFound를 반환한다")
-  void create_실패_UserNotFound() {
+  void create_ThrowsException_WhenUserNotFound() {
     // given
     UUID articleId = UUID.randomUUID();
     UUID userId = UUID.randomUUID();
@@ -163,7 +163,7 @@ class CommentServiceTest {
 
   @Test
   @DisplayName("댓글 수정에 성공한다.")
-  void update_성공() throws NoSuchFieldException, IllegalAccessException {
+  void update_ReturnsUpdatedCommentDto_WhenValidRequest() throws NoSuchFieldException, IllegalAccessException {
     // given
     NewsArticle article = mock(NewsArticle.class);
     User user = new User("email", "nickname", "password");
@@ -217,7 +217,7 @@ class CommentServiceTest {
 
   @Test
   @DisplayName("comment가 존재하지 않는 경우 댓글 수정에 실패한다.")
-  void update_실패_CommentNotFound() {
+  void update_ThrowsException_WhenCommentNotFound() {
     // given
     UUID commentId = UUID.randomUUID();
     UUID userId = UUID.randomUUID();
@@ -241,7 +241,7 @@ class CommentServiceTest {
 
   @Test
   @DisplayName("user가 존재하지 않는 경우 댓글 수정에 실패한다.")
-  void update_실패_UserNotFound() {
+  void update_ThrowsException_WhenUserNotFound() {
     // given
     UUID commentId = UUID.randomUUID();
     UUID userId = UUID.randomUUID();
@@ -267,7 +267,7 @@ class CommentServiceTest {
 
   @Test
   @DisplayName("본인 댓글이 아닌 경우 수정에 실패한다.")
-  void update_실패_CommentNotOwnedByUser() throws NoSuchFieldException, IllegalAccessException {
+  void update_ThrowsException_WhenNotOwnedByUser() throws NoSuchFieldException, IllegalAccessException {
     // given
     UUID commentId = UUID.randomUUID();
     UUID userId = UUID.randomUUID();
@@ -306,7 +306,7 @@ class CommentServiceTest {
 
   @Test
   @DisplayName("논리 삭제가 되었을 경우에는 댓글의 isDeleted 필드가 true가 되어야 한다")
-  void softDelete_성공() {
+  void softDelete_SetsIsDeletedTrue_WhenCommentExists() {
     // given
     UUID commentId = UUID.randomUUID();
     Comment comment = mock(Comment.class);
@@ -324,7 +324,7 @@ class CommentServiceTest {
 
   @Test
   @DisplayName("존재하지 않는 댓글은 논리 삭제에 실패한다.")
-  void softDelete_실패_COMMENT_NOT_FOUND() {
+  void softDelete_ThrowsException_WhenCommentNotFound() {
     // given
     UUID commentId = UUID.randomUUID();
     Comment comment = mock(Comment.class);
@@ -346,7 +346,7 @@ class CommentServiceTest {
 
   @Test
   @DisplayName("이미 논리 삭제된 댓글은 논리 삭제에 실패한다.")
-  void softDelete_실패_COMMENT_ALREADY_DELETED() {
+  void softDelete_ThrowsException_WhenAlreadyDeleted() {
     // given
     UUID commentId = UUID.randomUUID();
     Comment comment = mock(Comment.class);
@@ -369,7 +369,7 @@ class CommentServiceTest {
 
   @Test
   @DisplayName("댓글 물리 삭제에 성공한다.")
-  void hardDelete_성공() {
+  void hardDelete_DeletesComment_WhenCommentExists() {
     // given
     UUID commentId = UUID.randomUUID();
     Comment comment = mock(Comment.class);
@@ -385,7 +385,7 @@ class CommentServiceTest {
 
   @Test
   @DisplayName("존재하지 않는 댓글일 경우 댓글 물리 삭제에 실패한다.")
-  void hardDelete_실패_CommentNotFound() {
+  void hardDelete_ThrowsException_WhenCommentNotFound() {
     // given
     UUID commentId = UUID.randomUUID();
     Comment comment = mock(Comment.class);
@@ -405,7 +405,7 @@ class CommentServiceTest {
 
   @Test
   @DisplayName("댓글 목록 조회 성공 - hasNext = false")
-  void list_성공_hasNext_false() {
+  void list_ReturnsCursorPage_WhenHasNextFalse() {
     // given
     UUID articleId = UUID.randomUUID();
     UUID userId = UUID.randomUUID();
@@ -483,7 +483,7 @@ class CommentServiceTest {
 
   @Test
   @DisplayName("댓글 목록 조회 성공 - hasNext = true")
-  void list_성공_hasNext_true() {
+  void list_ReturnsCursorPageWithNextCursor_WhenHasNextTrue() {
     // given
     UUID articleId = UUID.randomUUID();
     UUID userId = UUID.randomUUID();
@@ -569,7 +569,7 @@ class CommentServiceTest {
 
   @Test
   @DisplayName("존재하지 않는 기사로 댓글 목록 조회 시 실패한다")
-  void list_실패_ArticleNotFound() {
+  void list_ThrowsException_WhenArticleNotFound() {
     // given
     UUID articleId = UUID.randomUUID();
     UUID userId = UUID.randomUUID();
@@ -594,7 +594,7 @@ class CommentServiceTest {
 
   @Test
   @DisplayName("논리 삭제된 기사로 댓글 목록 조회 시 실패한다")
-  void list_실패_ArticleAlreadyDeleted() {
+  void list_ThrowsException_WhenArticleAlreadyDeleted() {
     // given
     UUID articleId = UUID.randomUUID();
     UUID userId = UUID.randomUUID();
@@ -621,7 +621,7 @@ class CommentServiceTest {
 
   @Test
   @DisplayName("존재하지 않는 유저로 댓글 목록 조회 시 실패한다")
-  void list_실패_UserNotFound() {
+  void list_ThrowsException_WhenUserNotFound() {
     // given
     UUID articleId = UUID.randomUUID();
     UUID userId = UUID.randomUUID();
@@ -649,7 +649,7 @@ class CommentServiceTest {
 
   @Test
   @DisplayName("논리 삭제된 유저로 댓글 목록 조회 시 실패한다")
-  void list_실패_UserAlreadyDeleted() {
+  void list_ThrowsException_WhenUserAlreadyDeleted() {
     // given
     UUID articleId = UUID.randomUUID();
     UUID userId = UUID.randomUUID();

--- a/src/test/java/com/springboot/monew/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/springboot/monew/comment/service/CommentServiceTest.java
@@ -1,36 +1,660 @@
 package com.springboot.monew.comment.service;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.refEq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
+import com.springboot.monew.comment.dto.CommentDto;
+import com.springboot.monew.comment.dto.CommentPageRequest;
+import com.springboot.monew.comment.dto.CommentRegisterRequest;
+import com.springboot.monew.comment.dto.CommentUpdateRequest;
+import com.springboot.monew.comment.dto.CursorPageResponseCommentDto;
+import com.springboot.monew.comment.entity.Comment;
+import com.springboot.monew.comment.entity.CommentDirection;
+import com.springboot.monew.comment.entity.CommentOrderBy;
+import com.springboot.monew.comment.exception.CommentErrorCode;
+import com.springboot.monew.comment.exception.CommentException;
+import com.springboot.monew.comment.mapper.CommentMapper;
+import com.springboot.monew.comment.repository.CommentLikeRepository;
+import com.springboot.monew.comment.repository.CommentRepository;
+import com.springboot.monew.common.entity.BaseEntity;
+import com.springboot.monew.common.exception.MonewException;
+import com.springboot.monew.newsarticles.entity.NewsArticle;
+import com.springboot.monew.newsarticles.enums.ArticleSource;
+import com.springboot.monew.newsarticles.exception.NewsArticleErrorCode;
+import com.springboot.monew.newsarticles.repository.NewsArticleRepository;
+import com.springboot.monew.users.entity.User;
+import com.springboot.monew.users.exception.UserErrorCode;
+import com.springboot.monew.users.repository.UserRepository;
+import java.lang.reflect.Field;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 class CommentServiceTest {
 
+  @Mock CommentRepository commentRepository;
+  @Mock CommentLikeRepository commentLikeRepository;
+  @Mock NewsArticleRepository articleRepository;
+  @Mock UserRepository userRepository;
+  @Mock CommentMapper commentMapper;
+
+  @InjectMocks
+  private CommentService commentService;
+
   @Test
-  void create() {
+  @DisplayName("댓글 등록에 성공한다")
+  void create_성공() {
+    // given
+    User user = new User("email", "nickname", "password");
+    NewsArticle article = new NewsArticle(
+        ArticleSource.NAVER, "https://test.com", "제목", Instant.now(), "요약");
+
+    CommentRegisterRequest request = new CommentRegisterRequest(
+        article.getId(),
+        user.getId(),
+        "테스트 댓글입니다."
+    );
+    CommentDto expected = new CommentDto(
+        UUID.randomUUID(),
+        article.getId(),
+        user.getId(),
+        "nickname",
+        "테스트 댓글입니다.",
+        0L,
+        false,
+        Instant.now()
+    );
+
+    given(articleRepository.findById(article.getId())).willReturn(Optional.of(article));
+    given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+    given(commentMapper.toCommentDto(any(Comment.class), eq(false))).willReturn(expected);
+
+    // when
+    CommentDto result = commentService.create(request);
+
+    // then
+    assertThat(result).isEqualTo(expected);
+    assertThat(result.content()).isEqualTo(request.content());
+    assertThat(result.likeByMe()).isEqualTo(false);
+    assertThat(result.likeCount()).isEqualTo(0L);
+
+    verify(articleRepository).findById(article.getId());
+    verify(userRepository).findById(user.getId());
+    verify(commentMapper).toCommentDto(any(Comment.class), eq(false));
+
   }
 
   @Test
-  void update() {
+  @DisplayName("Article이 존재하지 않는 경우는 ArticleNotFound를 반환한다")
+  void create_실패_ArticleNotFound() {
+    // given
+    UUID articleId = UUID.randomUUID();
+    CommentRegisterRequest request = new CommentRegisterRequest(articleId, UUID.randomUUID(), "테스트 댓글");
+
+    given(articleRepository.findById(articleId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> commentService.create(request))
+        .isInstanceOf(MonewException.class)
+        .satisfies(throwable -> {
+          MonewException exception = (MonewException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(NewsArticleErrorCode.NEWS_ARTICLE_NOT_FOUND);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("articleId", articleId));
+        });
+
+    verify(articleRepository).findById(articleId);
+    verify(userRepository, never()).findById(any());
+    verify(commentMapper, never()).toCommentDto(any(), eq(false));
+    verify(commentRepository, never()).save(any());
   }
 
   @Test
-  void like() {
+  @DisplayName("User가 존재하지 않는 경우는 UserNotFound를 반환한다")
+  void create_실패_UserNotFound() {
+    // given
+    UUID articleId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+    NewsArticle article = mock(NewsArticle.class);
+    CommentRegisterRequest request = new CommentRegisterRequest(articleId, userId, "테스트 댓글");
+
+    given(articleRepository.findById(articleId)).willReturn(Optional.of(article));
+    given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> commentService.create(request))
+        .isInstanceOf(MonewException.class)
+        .satisfies(throwable -> {
+          MonewException exception = (MonewException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("userId", userId));
+        });
+
+    verify(articleRepository).findById(articleId);
+    verify(userRepository).findById(userId);
+    verify(commentMapper, never()).toCommentDto(any(), eq(false));
+    verify(commentRepository, never()).save(any());
   }
 
   @Test
-  void softDelete() {
+  @DisplayName("댓글 수정에 성공한다.")
+  void update_성공() throws NoSuchFieldException, IllegalAccessException {
+    // given
+    NewsArticle article = mock(NewsArticle.class);
+    User user = new User("email", "nickname", "password");
+
+    Comment comment = new Comment(user, article, "수정 전 댓글입니다.");
+
+    UUID commentId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+
+    // id 필드 리플렉션 -> id가 DB insert 되어야 생성되서 리플렉션 사용했습니다.
+    Field idField = BaseEntity.class.getDeclaredField("id");
+    idField.setAccessible(true);
+    idField.set(user, userId);
+    idField.set(comment, commentId);
+
+    CommentUpdateRequest request = new CommentUpdateRequest(
+        "수정 후 댓글입니다."
+    );
+
+    // 예상 기댓값
+    CommentDto expected = new CommentDto(
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        user.getId(),
+        "nickname",
+        "수정 후 댓글입니다.",
+        0L,
+        false,
+        Instant.now()
+    );
+
+
+    given(commentRepository.findByIdAndIsDeletedFalse(comment.getId())).willReturn(Optional.of(comment));
+    given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+    given(commentLikeRepository.existsByCommentIdAndUserId(comment.getId(), user.getId())).willReturn(false);
+    given(commentMapper.toCommentDto(any(Comment.class), eq(false))).willReturn(expected);
+
+    // when
+    CommentDto result = commentService.update(comment.getId(), user.getId(), request);
+
+    // then
+    assertThat(result).isEqualTo(expected);
+    assertThat(result.content()).isEqualTo(expected.content());
+    assertThat(result.likeByMe()).isEqualTo(expected.likeByMe());
+    assertThat(result.likeCount()).isEqualTo(expected.likeCount());
+
+    verify(commentRepository).findByIdAndIsDeletedFalse(comment.getId());
+    verify(userRepository).findById(user.getId());
+    verify(commentMapper).toCommentDto(any(Comment.class), eq(false));
   }
 
   @Test
-  void hardDelete() {
+  @DisplayName("comment가 존재하지 않는 경우 댓글 수정에 실패한다.")
+  void update_실패_CommentNotFound() {
+    // given
+    UUID commentId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+    CommentUpdateRequest request = new CommentUpdateRequest("수정할 댓글");
+
+    given(commentRepository.findByIdAndIsDeletedFalse(commentId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> commentService.update(commentId, userId, request))
+        .satisfies(throwable -> {
+          MonewException exception = (MonewException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(CommentErrorCode.COMMENT_NOT_FOUND);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("commentId", commentId));
+        });
+
+    verify(commentRepository).findByIdAndIsDeletedFalse(commentId);
+    verify(userRepository, never()).findById(any());
+    verify(commentMapper, never()).toCommentDto(any(), eq(false));
   }
 
   @Test
-  void unlike() {
+  @DisplayName("user가 존재하지 않는 경우 댓글 수정에 실패한다.")
+  void update_실패_UserNotFound() {
+    // given
+    UUID commentId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+    CommentUpdateRequest request = new CommentUpdateRequest("수정할 댓글");
+    Comment comment = mock(Comment.class);
+
+    given(commentRepository.findByIdAndIsDeletedFalse(commentId)).willReturn(Optional.of(comment));
+    given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> commentService.update(commentId, userId, request))
+        .satisfies(throwable -> {
+          MonewException exception = (MonewException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("userId", userId));
+        });
+
+    verify(commentRepository).findByIdAndIsDeletedFalse(commentId);
+    verify(userRepository).findById(userId);
+    verify(commentMapper, never()).toCommentDto(any(), eq(false));
   }
 
   @Test
-  void list() {
+  @DisplayName("본인 댓글이 아닌 경우 수정에 실패한다.")
+  void update_실패_CommentNotOwnedByUser() throws NoSuchFieldException, IllegalAccessException {
+    // given
+    UUID commentId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+    UUID wrongUserId = UUID.randomUUID();
+
+    NewsArticle article = mock(NewsArticle.class);
+    User user = new User("email", "nickname", "password");
+    Comment comment = new Comment(user, article, "댓글이다.");
+
+    CommentUpdateRequest request = new CommentUpdateRequest("수정했다.");
+
+    // 리플렉션 get으로 id에 접근해야 함.
+    Field idField = BaseEntity.class.getDeclaredField("id");
+    idField.setAccessible(true);
+    idField.set(user, wrongUserId);
+    idField.set(comment, commentId);
+
+
+    given(commentRepository.findByIdAndIsDeletedFalse(commentId)).willReturn(Optional.of(comment));
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+    // when
+    assertThatThrownBy(() -> commentService.update(commentId, userId, request))
+        .satisfies(throwable -> {
+          MonewException exception = (MonewException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(CommentErrorCode.COMMENT_NOT_OWNED_BY_USER);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("commentId", commentId));
+        });
+
+    // then
+    verify(commentRepository).findByIdAndIsDeletedFalse(commentId);
+    verify(userRepository).findById(userId);
+    verify(commentMapper, never()).toCommentDto(any(), eq(false));
+  }
+
+  @Test
+  @DisplayName("논리 삭제가 되었을 경우에는 댓글의 isDeleted 필드가 true가 되어야 한다")
+  void softDelete_성공() {
+    // given
+    UUID commentId = UUID.randomUUID();
+    Comment comment = mock(Comment.class);
+
+    given(commentRepository.findById(commentId)).willReturn(Optional.of(comment));
+    given(comment.isDeleted()).willReturn(false);
+
+    // when
+    commentService.softDelete(commentId);
+
+    // then
+    verify(commentRepository).findById(commentId);
+    verify(comment).delete();
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 댓글은 논리 삭제에 실패한다.")
+  void softDelete_실패_COMMENT_NOT_FOUND() {
+    // given
+    UUID commentId = UUID.randomUUID();
+    Comment comment = mock(Comment.class);
+
+    given(commentRepository.findById(commentId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> commentService.softDelete(commentId))
+        .satisfies(throwable -> {
+          CommentException exception = (CommentException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(CommentErrorCode.COMMENT_NOT_FOUND);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("commentId", commentId));
+        });
+
+    verify(commentRepository).findById(commentId);
+    verify(comment, never()).delete();
+  }
+
+  @Test
+  @DisplayName("이미 논리 삭제된 댓글은 논리 삭제에 실패한다.")
+  void softDelete_실패_COMMENT_ALREADY_DELETED() {
+    // given
+    UUID commentId = UUID.randomUUID();
+    Comment comment = mock(Comment.class);
+
+    given(commentRepository.findById(commentId)).willReturn(Optional.of(comment));
+    given(comment.isDeleted()).willReturn(true);
+
+    // when
+    assertThatThrownBy(() -> commentService.softDelete(commentId))
+        .satisfies(throwable -> {
+          CommentException exception = (CommentException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(CommentErrorCode.COMMENT_ALREADY_DELETED);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("commentId", commentId));
+        });
+
+    verify(commentRepository).findById(commentId);
+    verify(comment, never()).delete();
+  }
+
+  @Test
+  @DisplayName("댓글 물리 삭제에 성공한다.")
+  void hardDelete_성공() {
+    // given
+    UUID commentId = UUID.randomUUID();
+    Comment comment = mock(Comment.class);
+
+    given(commentRepository.findById(commentId)).willReturn(Optional.of(comment));
+    // when
+    commentService.hardDelete(commentId);
+
+    // then
+    verify(commentRepository).findById(commentId);
+    verify(commentRepository).delete(comment);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 댓글일 경우 댓글 물리 삭제에 실패한다.")
+  void hardDelete_실패_CommentNotFound() {
+    // given
+    UUID commentId = UUID.randomUUID();
+    Comment comment = mock(Comment.class);
+
+    given(commentRepository.findById(commentId)).willReturn(Optional.empty());
+    // when
+    assertThatThrownBy(() -> commentService.hardDelete(commentId))
+        .satisfies(throwable -> {
+          CommentException exception = (CommentException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(CommentErrorCode.COMMENT_NOT_FOUND);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("commentId", commentId));
+        });
+    verify(commentRepository).findById(commentId);
+    verify(commentRepository, never()).delete(comment);
+  }
+
+  @Test
+  @DisplayName("댓글 목록 조회 성공 - hasNext = false")
+  void list_성공_hasNext_false() {
+    // given
+    UUID articleId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+
+    // Article, User는 실제 동작이 필요 없고 isDeleted() 반환값만 제어하면 되므로 mock 사용
+    NewsArticle article = mock(NewsArticle.class);
+    User user = mock(User.class);
+
+    // 기사 존재하고 삭제되지 않은 상태
+    given(articleRepository.findById(articleId)).willReturn(Optional.of(article));
+    given(article.isDeleted()).willReturn(false);
+
+    // 유저 존재하고 삭제되지 않은 상태
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+    given(user.isDeleted()).willReturn(false);
+
+    UUID commentId1 = UUID.randomUUID();
+    UUID commentId2 = UUID.randomUUID();
+
+    // Comment도 getId() 제어가 필요하므로 mock 사용
+    // (getId()는 JPA persist 시점에 세팅되므로 new로 만들면 null)
+    Comment comment1 = mock(Comment.class);
+    Comment comment2 = mock(Comment.class);
+
+    given(comment1.getId()).willReturn(commentId1);
+    given(comment2.getId()).willReturn(commentId2);
+
+    // mapper가 반환할 실제 CommentDto 객체 (mock 사용 시 필드가 null이라 id 검증 불가)
+    CommentDto commentDto1 = new CommentDto(commentId1, articleId, userId, "nickname", "댓글1", 0L, true, Instant.now());
+    CommentDto commentDto2 = new CommentDto(commentId2, articleId, userId, "nickname", "댓글2", 0L, true, Instant.now());
+
+    CommentPageRequest request = new CommentPageRequest(
+        articleId,
+        CommentOrderBy.createdAt,
+        CommentDirection.DESC,
+        null,
+        null,
+        10
+    );
+
+    // 서비스 내부에서 limit + 1로 조회함 (다음 페이지 존재 여부 판단용)
+    // 반환된 댓글 수(2)가 limit(10)보다 작으므로 hasNext = false
+    given(commentRepository.findComments(
+        request.articleId(),
+        request.orderBy(),
+        request.direction(),
+        request.cursor(),
+        request.after(),
+        request.limit() + 1
+    )).willReturn(List.of(comment1, comment2));
+
+    // 두 댓글 모두 userId가 좋아요 누른 상태
+    given(commentLikeRepository.findCommentIdsByUserIdAndCommentIdIn(userId, List.of(commentId1, commentId2)))
+        .willReturn(List.of(commentId1, commentId2));
+
+    // 해당 기사의 삭제되지 않은 전체 댓글 수
+    given(commentRepository.countByArticleIdAndIsDeletedFalse(articleId)).willReturn(2L);
+
+    // comment1, comment2 모두 좋아요 누른 상태이므로 likeByMe = true
+    given(commentMapper.toCommentDto(comment1, true)).willReturn(commentDto1);
+    given(commentMapper.toCommentDto(comment2, true)).willReturn(commentDto2);
+
+    // when
+    CursorPageResponseCommentDto<CommentDto> result = commentService.list(request, userId);
+
+    // then
+    assertThat(result.hasNext()).isFalse();                                    // 2개 < limit(10)이므로 다음 페이지 없음
+    assertThat(result.content()).hasSize(2);                                   // 댓글 2개 반환
+    assertThat(result.content().get(0).id()).isEqualTo(commentId1);            // 첫 번째 댓글 id 확인
+    assertThat(result.content().get(1).id()).isEqualTo(commentId2);            // 두 번째 댓글 id 확인
+    assertThat(result.content().get(0).likeByMe()).isTrue();                   // 좋아요 누른 댓글은 likeByMe = true
+    assertThat(result.nextCursor()).isNull();
+    assertThat(result.nextAfter()).isNull();
+  }
+
+  @Test
+  @DisplayName("댓글 목록 조회 성공 - hasNext = true")
+  void list_성공_hasNext_true() {
+    // given
+    UUID articleId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+
+    // 페이지네이션 요청 Dto
+    CommentPageRequest request = new CommentPageRequest(
+        articleId,
+        CommentOrderBy.likeCount,
+        CommentDirection.DESC,
+        null,
+        null,
+        2
+    );
+
+    NewsArticle article = mock(NewsArticle.class);
+    User user = mock(User.class);
+
+    // 기사, 사용자 삭제되지 않은 상태
+    given(articleRepository.findById(articleId)).willReturn(Optional.of(article));
+    given(article.isDeleted()).willReturn(false);
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+    given(user.isDeleted()).willReturn(false);
+
+
+    // limit=2, 3개 반환(limit+1)
+    Comment comment1 = mock(Comment.class);
+    Comment comment2 = mock(Comment.class);
+    Comment comment3 = mock(Comment.class);
+
+    UUID commentId1 = UUID.randomUUID();
+    UUID commentId2 = UUID.randomUUID();
+    UUID commentId3 = UUID.randomUUID();
+
+    given(comment1.getId()).willReturn(commentId1);
+    given(comment2.getId()).willReturn(commentId2);
+    given(comment3.getId()).willReturn(commentId3);
+    given(comment1.getLikeCount()).willReturn(5L);
+
+    // nextAfter는 subList 후 마지막 댓글(comment1)의 createdAt
+    Instant comment1CreatedAt = Instant.now().minusSeconds(5);
+    given(comment1.getCreatedAt()).willReturn(comment1CreatedAt);
+
+    // mapper가 반환할 실제 CommentDto 객체 (mock 사용 시 필드가 null이라 id 검증 불가)
+    CommentDto commentDto1 = new CommentDto(commentId1, articleId, userId, "nickname", "댓글1", 5L, true, Instant.now());
+    CommentDto commentDto2 = new CommentDto(commentId2, articleId, userId, "nickname", "댓글2", 10L, false, Instant.now());
+
+
+    // 좋아요 순 페이지네이션 시 comment2, comment1 순서로
+    given(commentRepository.findComments(
+        request.articleId(),
+        request.orderBy(),
+        request.direction(),
+        request.cursor(),
+        request.after(),
+        request.limit() + 1))
+        .willReturn(List.of(comment2, comment1, comment3));
+
+    // comment1만 좋아요 누른 걸 가정
+    given(commentLikeRepository.findCommentIdsByUserIdAndCommentIdIn(userId, List.of(commentId2, commentId1, commentId3)))
+    .willReturn(List.of(commentId1));
+
+    // 댓글 전체 개수 3개
+    given(commentRepository.countByArticleIdAndIsDeletedFalse(articleId))
+        .willReturn(3L);
+
+    given(commentMapper.toCommentDto(comment1, true)).willReturn(commentDto1);
+    given(commentMapper.toCommentDto(comment2, false)).willReturn(commentDto2);
+
+    // when
+    CursorPageResponseCommentDto<CommentDto> result = commentService.list(request, userId);
+
+    // then
+    assertThat(result.content()).hasSize(2);
+    assertThat(result.content().get(0).id()).isEqualTo(commentId2);
+    assertThat(result.content().get(1).id()).isEqualTo(commentId1);
+    assertThat(result.content().get(0).likeByMe()).isFalse();
+    assertThat(result.content().get(1).likeByMe()).isTrue();
+    assertThat(result.hasNext()).isTrue();
+    assertThat(result.nextCursor()).isEqualTo("5");
+    assertThat(result.nextAfter()).isEqualTo(comment1CreatedAt);
+    assertThat(result.totalElements()).isEqualTo(3L);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 기사로 댓글 목록 조회 시 실패한다")
+  void list_실패_ArticleNotFound() {
+    // given
+    UUID articleId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+    CommentPageRequest request = new CommentPageRequest(
+        articleId, CommentOrderBy.createdAt, CommentDirection.DESC, null, null, 10);
+
+    given(articleRepository.findById(articleId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> commentService.list(request, userId))
+        .satisfies(throwable -> {
+          MonewException exception = (MonewException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(NewsArticleErrorCode.NEWS_ARTICLE_NOT_FOUND);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("articleId", articleId));
+        });
+
+    verify(articleRepository).findById(articleId);
+    verify(userRepository, never()).findById(any());
+    verify(commentRepository, never()).findComments(any(), any(), any(), any(), any(), anyInt());
+  }
+
+  @Test
+  @DisplayName("논리 삭제된 기사로 댓글 목록 조회 시 실패한다")
+  void list_실패_ArticleAlreadyDeleted() {
+    // given
+    UUID articleId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+    CommentPageRequest request = new CommentPageRequest(
+        articleId, CommentOrderBy.createdAt, CommentDirection.DESC, null, null, 10);
+
+    NewsArticle article = mock(NewsArticle.class);
+    given(articleRepository.findById(articleId)).willReturn(Optional.of(article));
+    given(article.isDeleted()).willReturn(true);
+
+    // when & then
+    assertThatThrownBy(() -> commentService.list(request, userId))
+        .satisfies(throwable -> {
+          MonewException exception = (MonewException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(NewsArticleErrorCode.NEWS_ARTICLE_ALREADY_DELETED);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("articleId", articleId));
+        });
+
+    verify(articleRepository).findById(articleId);
+    verify(userRepository, never()).findById(any());
+    verify(commentRepository, never()).findComments(any(), any(), any(), any(), any(), anyInt());
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 유저로 댓글 목록 조회 시 실패한다")
+  void list_실패_UserNotFound() {
+    // given
+    UUID articleId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+    CommentPageRequest request = new CommentPageRequest(
+        articleId, CommentOrderBy.createdAt, CommentDirection.DESC, null, null, 10);
+
+    NewsArticle article = mock(NewsArticle.class);
+    given(articleRepository.findById(articleId)).willReturn(Optional.of(article));
+    given(article.isDeleted()).willReturn(false);
+    given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> commentService.list(request, userId))
+        .satisfies(throwable -> {
+          MonewException exception = (MonewException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("userId", userId));
+        });
+
+    verify(articleRepository).findById(articleId);
+    verify(userRepository).findById(userId);
+    verify(commentRepository, never()).findComments(any(), any(), any(), any(), any(), anyInt());
+  }
+
+  @Test
+  @DisplayName("논리 삭제된 유저로 댓글 목록 조회 시 실패한다")
+  void list_실패_UserAlreadyDeleted() {
+    // given
+    UUID articleId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+    CommentPageRequest request = new CommentPageRequest(
+        articleId, CommentOrderBy.createdAt, CommentDirection.DESC, null, null, 10);
+
+    NewsArticle article = mock(NewsArticle.class);
+    User user = mock(User.class);
+    given(articleRepository.findById(articleId)).willReturn(Optional.of(article));
+    given(article.isDeleted()).willReturn(false);
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+    given(user.isDeleted()).willReturn(true);
+
+    // when & then
+    assertThatThrownBy(() -> commentService.list(request, userId))
+        .satisfies(throwable -> {
+          MonewException exception = (MonewException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("userId", userId));
+        });
+
+    verify(articleRepository).findById(articleId);
+    verify(userRepository).findById(userId);
+    verify(commentRepository, never()).findComments(any(), any(), any(), any(), any(), anyInt());
   }
 }


### PR DESCRIPTION
## 관련 이슈 번호
Closes #224 #244 

## 📌 작업 내용
  - `CommentService`, `CommentLikeService` 단위 테스트 작성
                                                                                                     
## 🔧 변경 사항
  - `CommentServiceTest` - create/update/softDelete/hardDelete/list 성공·실패 케이스 단위 테스트 추가
  - `CommentLikeServiceTest` - 좋아요/취소 성공·실패 케이스 단위 테스트 추가                         
  - `InterestQDSLRepositoryImpl` - `findByIdWithArticleCount` leftJoin 문법 오류 수정                
  - `CommentLikeDto` - `commentLikeCount` 타입 `Integer` → `Long` 변경                               
  - `CommentLikeControllerTest` - 타입 변경에 따른 테스트 코드 수정                                  
                                                                                                     
## 반영 브랜치                                                                                     
  `feature/#224/service-test` -> `dev`                                                            
                                                                                                     
## 💬 기타 참고 사항                                                                               
  - 서비스 테스트는 Mockito 기반 단위 테스트로 작성, Repository는 mock 처리
  - `@GeneratedValue`로 생성되는 id는 Instancio 또는 리플렉션으로 세팅
  - 테스트 메서드 명 통일은 리뷰 끝나신 뒤 한번에 할 예정입니다.
  - InterestQDSLRepositoryImpl은 단순 문법 오류 수정이니 리뷰 안하셔도 됩니다. 주현님 허락받고 수정해서 PR 올립니다 ^^

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 관심사별 기사 카운트 집계 정확도 개선

* **Chores**
  * 댓글 좋아요 카운트의 내부 수치 범위 확장으로 안정성·일관성 강화

* **Tests**
  * 댓글 좋아요 컨트롤러 및 서비스에 대한 단위 테스트 확대(좋아요/취소, 오류 케이스 검증 포함)
  * 댓글 서비스 전반에 대한 유닛 테스트 추가(생성/수정/삭제/목록·페이징·권한/예외 시나리오 검증)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->