### PR TITLE
[Feat]뉴스기사 목록조회,단건조회,출처조회 기능 구현

### DIFF
--- a/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleController.java
+++ b/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleController.java
@@ -47,7 +47,7 @@ public class NewsArticleController {
 
   //단건 조회
   @GetMapping("/{articleId}")
-  public ResponseEntity<NewsArticleDto> find(@RequestParam("articleId") UUID articleId,
+  public ResponseEntity<NewsArticleDto> find(@PathVariable("articleId") UUID articleId,
                                                  @RequestHeader("Monew-Request-User-ID") UUID userId){
 
     NewsArticleDto newsArticleDto = newsArticleService.findById(articleId, userId);

--- a/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleController.java
+++ b/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleController.java
@@ -2,9 +2,11 @@ package com.springboot.monew.newsarticles.controller;
 
 import com.springboot.monew.newsarticles.dto.response.NewsArticleDto;
 import com.springboot.monew.newsarticles.dto.response.NewsArticleViewDto;
+import com.springboot.monew.newsarticles.enums.ArticleSource;
 import com.springboot.monew.newsarticles.service.NewsArticleCollectService;
 import com.springboot.monew.newsarticles.service.NewsArticleService;
 import java.net.URI;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -53,6 +55,12 @@ public class NewsArticleController {
     NewsArticleDto newsArticleDto = newsArticleService.findById(articleId, userId);
     return ResponseEntity.ok(newsArticleDto);
 
+  }
+
+  //출처 목록 조회
+  @GetMapping("/sources")
+  public ResponseEntity<List<ArticleSource>> findSource(){
+    return ResponseEntity.ok(newsArticleService.findAllSources());
   }
 
   //뉴스기사 논리삭제

--- a/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleController.java
+++ b/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleController.java
@@ -1,10 +1,13 @@
 package com.springboot.monew.newsarticles.controller;
 
+import com.springboot.monew.newsarticles.dto.request.NewsArticlePageRequest;
+import com.springboot.monew.newsarticles.dto.response.CursorPageResponseNewsArticleDto;
 import com.springboot.monew.newsarticles.dto.response.NewsArticleDto;
 import com.springboot.monew.newsarticles.dto.response.NewsArticleViewDto;
 import com.springboot.monew.newsarticles.enums.ArticleSource;
 import com.springboot.monew.newsarticles.service.NewsArticleCollectService;
 import com.springboot.monew.newsarticles.service.NewsArticleService;
+import jakarta.validation.Valid;
 import java.net.URI;
 import java.util.List;
 import java.util.UUID;
@@ -47,7 +50,15 @@ public class NewsArticleController {
 
   }
 
-  //단건 조회
+  //뉴스기사 목록 조회
+  @GetMapping
+  public CursorPageResponseNewsArticleDto list(@Valid NewsArticlePageRequest request,
+      @RequestHeader("Monew-Request-User-ID") UUID userId){
+    return newsArticleService.list(request, userId);
+
+  }
+
+  //뉴스기사 단건 조회
   @GetMapping("/{articleId}")
   public ResponseEntity<NewsArticleDto> find(@PathVariable("articleId") UUID articleId,
                                                  @RequestHeader("Monew-Request-User-ID") UUID userId){

--- a/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleController.java
+++ b/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleController.java
@@ -1,5 +1,6 @@
 package com.springboot.monew.newsarticles.controller;
 
+import com.springboot.monew.newsarticles.dto.response.NewsArticleDto;
 import com.springboot.monew.newsarticles.dto.response.NewsArticleViewDto;
 import com.springboot.monew.newsarticles.service.NewsArticleCollectService;
 import com.springboot.monew.newsarticles.service.NewsArticleService;
@@ -9,10 +10,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -39,6 +42,16 @@ public class NewsArticleController {
 
     //헤더: 생성된 리소스의 URL
     return ResponseEntity.created(URI.create("/api/articles/" + articleId + "/article-views/" + newsArticleViewDto.id())).body(newsArticleViewDto);
+
+  }
+
+  //단건 조회
+  @GetMapping
+  public ResponseEntity<NewsArticleDto> find(@RequestParam("articleId") UUID articleId,
+                                                 @RequestHeader("Monew-Request-User-ID") UUID userId){
+
+    NewsArticleDto newsArticleDto = newsArticleService.findById(articleId, userId);
+    return ResponseEntity.ok(newsArticleDto);
 
   }
 

--- a/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleController.java
+++ b/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleController.java
@@ -46,7 +46,7 @@ public class NewsArticleController {
   }
 
   //단건 조회
-  @GetMapping
+  @GetMapping("/{articleId}")
   public ResponseEntity<NewsArticleDto> find(@RequestParam("articleId") UUID articleId,
                                                  @RequestHeader("Monew-Request-User-ID") UUID userId){
 

--- a/src/main/java/com/springboot/monew/newsarticles/dto/ParsedCursor.java
+++ b/src/main/java/com/springboot/monew/newsarticles/dto/ParsedCursor.java
@@ -1,0 +1,11 @@
+package com.springboot.monew.newsarticles.dto;
+
+import java.time.Instant;
+
+//QueryDSL에서 파싱용 cursor
+public record ParsedCursor(
+    String value,
+    Instant after
+) {
+
+}

--- a/src/main/java/com/springboot/monew/newsarticles/dto/request/NewsArticlePageRequest.java
+++ b/src/main/java/com/springboot/monew/newsarticles/dto/request/NewsArticlePageRequest.java
@@ -30,6 +30,8 @@ public record NewsArticlePageRequest(
     @NotNull NewsArticleDirection direction,
 
     //커서 기반 페이징
+    // after는 Swagger 스펙 상 별도 파라미터로 정의되어 있으나,
+    // 실제 페이지네이션 조회 시에는 cursor 파라미터 내부에 "cursor|after" 형태로 인코딩되어 전달됩니다.
     String cursor,
     String after,
 

--- a/src/main/java/com/springboot/monew/newsarticles/dto/request/NewsArticlePageRequest.java
+++ b/src/main/java/com/springboot/monew/newsarticles/dto/request/NewsArticlePageRequest.java
@@ -1,0 +1,41 @@
+package com.springboot.monew.newsarticles.dto.request;
+
+import com.springboot.monew.newsarticles.enums.ArticleSource;
+import com.springboot.monew.newsarticles.enums.NewsArticleDirection;
+import com.springboot.monew.newsarticles.enums.NewsArticleOrderBy;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+public record NewsArticlePageRequest(
+
+    //검색어(제목, 요약)
+    String keyword,
+
+    //관심사ID
+    UUID interestId,
+
+    //출처 필터
+    List<ArticleSource> sourceIn,
+
+    //날짜 범위
+    Instant publishDateFrom,
+    Instant publishDateTo,
+
+    //정렬
+    @NotNull NewsArticleOrderBy orderBy,
+    @NotNull NewsArticleDirection direction,
+
+    //커서 기반 페이징
+    String cursor,
+    String after,
+
+    //페이지 크기
+    @NotNull @Min(1) @Max(100) Integer limit
+
+) {
+
+}

--- a/src/main/java/com/springboot/monew/newsarticles/dto/response/CursorPageResponseNewsArticleDto.java
+++ b/src/main/java/com/springboot/monew/newsarticles/dto/response/CursorPageResponseNewsArticleDto.java
@@ -1,0 +1,18 @@
+package com.springboot.monew.newsarticles.dto.response;
+
+import com.springboot.monew.newsarticles.enums.NewsArticleDirection;
+import java.time.Instant;
+import java.util.List;
+
+// 커서 기반 뉴스기사 페이지 응답 DTO
+public record CursorPageResponseNewsArticleDto(
+    List<NewsArticleDto> content,
+    String nextCursor,
+    String nextAfter,
+    int size,
+    long totalElements,
+    boolean hasNext
+) {
+
+
+}

--- a/src/main/java/com/springboot/monew/newsarticles/dto/response/NewsArticleCursorRow.java
+++ b/src/main/java/com/springboot/monew/newsarticles/dto/response/NewsArticleCursorRow.java
@@ -1,0 +1,36 @@
+package com.springboot.monew.newsarticles.dto.response;
+
+import com.springboot.monew.newsarticles.enums.ArticleSource;
+import java.time.Instant;
+import java.util.UUID;
+
+//내부 조회용 DTO
+//NewsArticle을 return으로  쓰자니 CommentCount와 Interest가 없다.
+//NewsArticleDto를 return으로 쓰자니 createdAt이 없다.
+public record NewsArticleCursorRow(
+    UUID id,
+    ArticleSource source,
+    String sourceUrl,
+    String title,
+    Instant publishDate,
+    String summary,
+    Long commentCount,
+    Long viewCount,
+    Boolean viewedByMe,
+    Instant createdAt
+) {
+
+  public NewsArticleDto toDto() {
+    return new NewsArticleDto(
+        id,
+        source,
+        sourceUrl,
+        title,
+        publishDate,
+        summary,
+        commentCount,
+        viewCount,
+        viewedByMe
+    );
+  }
+}

--- a/src/main/java/com/springboot/monew/newsarticles/dto/response/NewsArticleDto.java
+++ b/src/main/java/com/springboot/monew/newsarticles/dto/response/NewsArticleDto.java
@@ -1,0 +1,18 @@
+package com.springboot.monew.newsarticles.dto.response;
+
+import com.springboot.monew.newsarticles.enums.ArticleSource;
+import java.time.Instant;
+import java.util.UUID;
+
+public record NewsArticleDto(
+    UUID id,
+    ArticleSource source,
+    String sorceUrl,
+    String title,
+    Instant publishDate,
+    String summary,
+    Long commentCount,
+    Long viewCount,
+    Boolean viewedByMe
+
+) {}

--- a/src/main/java/com/springboot/monew/newsarticles/dto/response/NewsArticleDto.java
+++ b/src/main/java/com/springboot/monew/newsarticles/dto/response/NewsArticleDto.java
@@ -7,7 +7,7 @@ import java.util.UUID;
 public record NewsArticleDto(
     UUID id,
     ArticleSource source,
-    String sorceUrl,
+    String sourceUrl,
     String title,
     Instant publishDate,
     String summary,

--- a/src/main/java/com/springboot/monew/newsarticles/enums/NewsArticleDirection.java
+++ b/src/main/java/com/springboot/monew/newsarticles/enums/NewsArticleDirection.java
@@ -1,0 +1,6 @@
+package com.springboot.monew.newsarticles.enums;
+
+public enum NewsArticleDirection {
+  ASC,
+  DESC
+}

--- a/src/main/java/com/springboot/monew/newsarticles/enums/NewsArticleOrderBy.java
+++ b/src/main/java/com/springboot/monew/newsarticles/enums/NewsArticleOrderBy.java
@@ -1,0 +1,10 @@
+package com.springboot.monew.newsarticles.enums;
+
+import com.springboot.monew.newsarticles.entity.NewsArticle;
+import java.time.Instant;
+
+public enum NewsArticleOrderBy {
+  publishDate,
+  commentCount,
+  viewCount
+}

--- a/src/main/java/com/springboot/monew/newsarticles/mapper/NewsArticleMapper.java
+++ b/src/main/java/com/springboot/monew/newsarticles/mapper/NewsArticleMapper.java
@@ -1,13 +1,20 @@
 package com.springboot.monew.newsarticles.mapper;
 
 import com.springboot.monew.newsarticles.dto.response.CollectedArticle;
+import com.springboot.monew.newsarticles.dto.response.NewsArticleDto;
 import com.springboot.monew.newsarticles.entity.NewsArticle;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface NewsArticleMapper {
 
   NewsArticle toEntity(CollectedArticle article);
+
+  @Mapping(target = "commentCount", source = "commentCount")
+  @Mapping(target = "viewedByMe", source = "viewedByMe")
+  @Mapping(target = "sourceUrl", source = "article.originalLink")
+  NewsArticleDto toDto(NewsArticle article, Long commentCount, Boolean viewedByMe);
 
 
 }

--- a/src/main/java/com/springboot/monew/newsarticles/repository/NewsArticleRepository.java
+++ b/src/main/java/com/springboot/monew/newsarticles/repository/NewsArticleRepository.java
@@ -1,6 +1,8 @@
 package com.springboot.monew.newsarticles.repository;
 
+import com.springboot.monew.newsarticles.dto.request.NewsArticlePageRequest;
 import com.springboot.monew.newsarticles.entity.NewsArticle;
+import com.springboot.monew.newsarticles.repository.qdsl.NewsArticleQDSLRepository;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
@@ -9,7 +11,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface NewsArticleRepository extends JpaRepository<NewsArticle, UUID> {
+public interface NewsArticleRepository extends JpaRepository<NewsArticle, UUID>, NewsArticleQDSLRepository {
 
   //원본링크목록 조회
   List<NewsArticle> findAllByOriginalLinkIn(Collection<String> originalLinks);

--- a/src/main/java/com/springboot/monew/newsarticles/repository/qdsl/NewsArticleQDSLRepository.java
+++ b/src/main/java/com/springboot/monew/newsarticles/repository/qdsl/NewsArticleQDSLRepository.java
@@ -1,0 +1,16 @@
+package com.springboot.monew.newsarticles.repository.qdsl;
+
+import com.springboot.monew.newsarticles.dto.request.NewsArticlePageRequest;
+import com.springboot.monew.newsarticles.dto.response.NewsArticleCursorRow;
+import com.springboot.monew.newsarticles.dto.response.NewsArticleDto;
+import java.util.List;
+import java.util.UUID;
+
+public interface NewsArticleQDSLRepository {
+
+  List<NewsArticleCursorRow> findNewsArticles(NewsArticlePageRequest request, UUID userId);
+
+  //전체 데이터 개수 조회
+  long countNewsArticles(NewsArticlePageRequest request);
+
+}

--- a/src/main/java/com/springboot/monew/newsarticles/repository/qdsl/NewsArticleQDSLRepositoryImpl.java
+++ b/src/main/java/com/springboot/monew/newsarticles/repository/qdsl/NewsArticleQDSLRepositoryImpl.java
@@ -231,7 +231,8 @@ public class NewsArticleQDSLRepositoryImpl implements NewsArticleQDSLRepository 
     ParsedCursor parsedCursor = parseCursor(request.cursor());
 
     //주커서
-    Instant cursorValue = Instant.parse(parsedCursor.value());
+    //cursor값을 Instant로 파싱하는 과정에서 깨질때 대비한 예외처리
+    Instant cursorValue = parseInstantCursor(parsedCursor.value(), "cursor.value");;
 
     //마지막 row의 publishedAt이 2026.04.24라면 2026.04.24 > publishedAt
     BooleanExpression primaryCondition = request.direction() == NewsArticleDirection.DESC
@@ -258,7 +259,7 @@ public class NewsArticleQDSLRepositoryImpl implements NewsArticleQDSLRepository 
   private BooleanExpression viewCountCursorCondition(NewsArticlePageRequest request) {
     ParsedCursor parsedCursor = parseCursor(request.cursor());
 
-    Long cursorValue = Long.parseLong(parsedCursor.value());
+    Long cursorValue = parseLongCursor(parsedCursor.value(), "cursor.value");
 
     BooleanExpression primaryCondition = request.direction() == NewsArticleDirection.DESC
         ? newsArticle.viewCount.lt(cursorValue)
@@ -285,7 +286,7 @@ public class NewsArticleQDSLRepositoryImpl implements NewsArticleQDSLRepository 
   ) {
     ParsedCursor parsedCursor = parseCursor(request.cursor());
 
-    Long cursorValue = Long.parseLong(parsedCursor.value());
+    Long cursorValue = parseLongCursor(parsedCursor.value(), "cursor.value");
 
     BooleanExpression primaryCondition = request.direction() == NewsArticleDirection.DESC
         ? commentCountExpr.lt(cursorValue)
@@ -335,10 +336,27 @@ public class NewsArticleQDSLRepositoryImpl implements NewsArticleQDSLRepository 
     String[] parts = cursor.split("\\|");
 
     String value = parts[0];
-    Instant after = parts.length > 1 ? Instant.parse(parts[1]) : null;
+    Instant after = parts.length > 1 ? parseInstantCursor(parts[1], "cursor.after") : null;
 
     return new ParsedCursor(value, after);
   }
 
+  //cursor값을 Instant로 파싱하는 과정에서 깨질때 대비한 예외처리
+  private Instant parseInstantCursor(String raw, String field){
+    try {
+      return Instant.parse(raw);
+    }catch (Exception e){
+      throw new IllegalArgumentException("잘못된 커서 형식입니다." + field);
+    }
+  }
+
+  //cursor값을 Long으로 파싱하는 과정에서 깨질때 대비한 예외처리
+  private Long parseLongCursor(String raw, String field) {
+    try {
+      return Long.parseLong(raw);
+    } catch (Exception e) {
+      throw new IllegalArgumentException("잘못된 커서 형식입니다: " + field);
+    }
+  }
 
 }

--- a/src/main/java/com/springboot/monew/newsarticles/repository/qdsl/NewsArticleQDSLRepositoryImpl.java
+++ b/src/main/java/com/springboot/monew/newsarticles/repository/qdsl/NewsArticleQDSLRepositoryImpl.java
@@ -1,0 +1,279 @@
+package com.springboot.monew.newsarticles.repository.qdsl;
+
+import static com.querydsl.core.types.Projections.constructor;
+import static com.springboot.monew.comment.entity.QComment.comment;
+import static com.springboot.monew.newsarticles.entity.QArticleInterest.articleInterest;
+import static com.springboot.monew.newsarticles.entity.QArticleView.articleView;
+import static com.springboot.monew.newsarticles.entity.QNewsArticle.newsArticle;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.springboot.monew.newsarticles.dto.request.NewsArticlePageRequest;
+import com.springboot.monew.newsarticles.dto.response.NewsArticleCursorRow;
+import com.springboot.monew.newsarticles.enums.NewsArticleDirection;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class NewsArticleQDSLRepositoryImpl implements NewsArticleQDSLRepository {
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public List<NewsArticleCursorRow> findNewsArticles(NewsArticlePageRequest request, UUID userId) {
+
+    // 동적 조건 조합을 위한 where 절
+    BooleanBuilder where = new BooleanBuilder();
+
+    // 삭제되지 않은 기사만 조회
+    where.and(newsArticle.isDeleted.isFalse());
+
+    // 검색 키워드 조건 (제목 또는 요약 부분일치)
+    where.and(keywordContains(normalize(request.keyword())));
+
+    // 관심사 필터
+    where.and(interestIdEq(request.interestId()));
+
+    // 출처 필터
+    where.and(sourceIn(request));
+
+    // 날짜 범위 필터
+    where.and(publishDateGoe(request.publishDateFrom()));
+    where.and(publishDateLoe(request.publishDateTo()));
+
+    // 댓글 수 집계 표현식
+    NumberExpression<Long> commentCountExpr = comment.id.countDistinct();
+
+    // 커서 조건 추가
+    BooleanExpression cursorCondition = buildCursorCondition(request, commentCountExpr);
+    if (cursorCondition != null) {
+      where.and(cursorCondition);
+    }
+
+    return queryFactory
+        .select(constructor(
+            NewsArticleCursorRow.class,
+            newsArticle.id,
+            newsArticle.source,
+            newsArticle.originalLink,   // sourceUrl
+            newsArticle.title,
+            newsArticle.publishedAt,    // publishDate
+            newsArticle.summary,
+            commentCountExpr,
+            newsArticle.viewCount,
+            articleView.id.isNotNull(), // viewedByMe
+            newsArticle.createdAt       // nextAfter 계산용 내부 필드
+        ))
+        .from(newsArticle)
+        // 관심사 필터용 조인
+        .leftJoin(articleInterest).on(articleInterest.newsArticle.eq(newsArticle))
+        // 댓글 수 집계용 조인
+        .leftJoin(comment).on(
+            comment.article.eq(newsArticle)
+                .and(comment.isDeleted.isFalse())
+        )
+        // 현재 유저가 조회했는지 확인용 조인
+        .leftJoin(articleView).on(
+            articleView.newsArticle.eq(newsArticle)
+                .and(articleView.user.id.eq(userId))
+        )
+        .where(where)
+        .groupBy(
+            newsArticle.id,
+            newsArticle.source,
+            newsArticle.originalLink,
+            newsArticle.title,
+            newsArticle.publishedAt,
+            newsArticle.summary,
+            newsArticle.viewCount,
+            articleView.id,
+            newsArticle.createdAt
+        )
+        .orderBy(getOrderSpecifiers(request, commentCountExpr).toArray(OrderSpecifier[]::new))
+        // 다음 페이지 존재 여부 확인 위해 limit + 1 조회
+        .limit(request.limit() + 1L)
+        .fetch();
+  }
+
+  @Override
+  public long countNewsArticles(NewsArticlePageRequest request) {
+
+    BooleanBuilder where = new BooleanBuilder();
+
+    // 삭제되지 않은 기사만 count
+    where.and(newsArticle.isDeleted.isFalse());
+
+    // 검색/필터 조건 동일 적용
+    where.and(keywordContains(normalize(request.keyword())));
+    where.and(interestIdEq(request.interestId()));
+    where.and(sourceIn(request));
+    where.and(publishDateGoe(request.publishDateFrom()));
+    where.and(publishDateLoe(request.publishDateTo()));
+
+    Long count = queryFactory
+        .select(newsArticle.id.countDistinct())
+        .from(newsArticle)
+        .leftJoin(articleInterest).on(articleInterest.newsArticle.eq(newsArticle))
+        .where(where)
+        .fetchOne();
+
+    return count == null ? 0L : count;
+  }
+
+  // 공백 제거 후 빈 값이면 null 반환
+  private String normalize(String value) {
+    if (value == null) {
+      return null;
+    }
+    String trimmed = value.trim();
+    return trimmed.isEmpty() ? null : trimmed;
+  }
+
+  // 제목 또는 요약에 검색어가 부분일치하는 조건
+  private BooleanExpression keywordContains(String keyword) {
+    if (keyword == null) {
+      return null;
+    }
+
+    return newsArticle.title.containsIgnoreCase(keyword)
+        .or(newsArticle.summary.containsIgnoreCase(keyword));
+  }
+
+  // 관심사 조건
+  private BooleanExpression interestIdEq(UUID interestId) {
+    if (interestId == null) {
+      return null;
+    }
+
+    return articleInterest.interest.id.eq(interestId);
+  }
+
+  // 출처 포함 조건
+  private BooleanExpression sourceIn(NewsArticlePageRequest request) {
+    if (request.sourceIn() == null || request.sourceIn().isEmpty()) {
+      return null;
+    }
+
+    return newsArticle.source.in(request.sourceIn());
+  }
+
+  // 날짜 시작 범위 조건
+  private BooleanExpression publishDateGoe(Instant publishDateFrom) {
+    if (publishDateFrom == null) {
+      return null;
+    }
+
+    return newsArticle.publishedAt.goe(publishDateFrom);
+  }
+
+  // 날짜 끝 범위 조건
+  private BooleanExpression publishDateLoe(Instant publishDateTo) {
+    if (publishDateTo == null) {
+      return null;
+    }
+
+    return newsArticle.publishedAt.loe(publishDateTo);
+  }
+
+  // 정렬 기준에 따른 커서 조건 생성
+  private BooleanExpression buildCursorCondition(
+      NewsArticlePageRequest request,
+      NumberExpression<Long> commentCountExpr
+  ) {
+    if (request.cursor() == null || request.after() == null) {
+      return null;
+    }
+
+    return switch (request.orderBy()) {
+      case publishDate -> publishDateCursorCondition(request);
+      case commentCount -> commentCountCursorCondition(request, commentCountExpr);
+      case viewCount -> viewCountCursorCondition(request);
+    };
+  }
+
+  // 날짜 정렬 기준 커서 조건
+  private BooleanExpression publishDateCursorCondition(NewsArticlePageRequest request) {
+    Instant cursorValue = Instant.parse(request.cursor());
+    Instant afterValue = Instant.parse(request.after());
+
+    if (request.direction() == NewsArticleDirection.DESC) {
+      return newsArticle.publishedAt.lt(cursorValue)
+          .or(newsArticle.publishedAt.eq(cursorValue)
+              .and(newsArticle.createdAt.lt(afterValue)));
+    }
+
+    return newsArticle.publishedAt.gt(cursorValue)
+        .or(newsArticle.publishedAt.eq(cursorValue)
+            .and(newsArticle.createdAt.gt(afterValue)));
+  }
+
+  // 조회수 정렬 기준 커서 조건
+  private BooleanExpression viewCountCursorCondition(NewsArticlePageRequest request) {
+    Long cursorValue = Long.parseLong(request.cursor());
+    Instant afterValue = Instant.parse(request.after());
+
+    if (request.direction() == NewsArticleDirection.DESC) {
+      return newsArticle.viewCount.lt(cursorValue)
+          .or(newsArticle.viewCount.eq(cursorValue)
+              .and(newsArticle.createdAt.lt(afterValue)));
+    }
+
+    return newsArticle.viewCount.gt(cursorValue)
+        .or(newsArticle.viewCount.eq(cursorValue)
+            .and(newsArticle.createdAt.gt(afterValue)));
+  }
+
+  // 댓글 수 정렬 기준 커서 조건
+  // 집계값(count)이므로 DB/JPA 조합에 따라 having으로 분리해야 할 수도 있음
+  private BooleanExpression commentCountCursorCondition(
+      NewsArticlePageRequest request,
+      NumberExpression<Long> commentCountExpr
+  ) {
+    Long cursorValue = Long.parseLong(request.cursor());
+    Instant afterValue = Instant.parse(request.after());
+
+    if (request.direction() == NewsArticleDirection.DESC) {
+      return commentCountExpr.lt(cursorValue)
+          .or(commentCountExpr.eq(cursorValue)
+              .and(newsArticle.createdAt.lt(afterValue)));
+    }
+
+    return commentCountExpr.gt(cursorValue)
+        .or(commentCountExpr.eq(cursorValue)
+            .and(newsArticle.createdAt.gt(afterValue)));
+  }
+
+  // 정렬 기준 + 보조 정렬(createdAt) 생성
+  private List<OrderSpecifier<?>> getOrderSpecifiers(
+      NewsArticlePageRequest request,
+      NumberExpression<Long> commentCountExpr
+  ) {
+    List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
+    Order direction = request.direction() == NewsArticleDirection.ASC ? Order.ASC : Order.DESC;
+
+    switch (request.orderBy()) {
+      case publishDate ->
+          orderSpecifiers.add(new OrderSpecifier<>(direction, newsArticle.publishedAt));
+      case commentCount ->
+          orderSpecifiers.add(new OrderSpecifier<>(direction, commentCountExpr));
+      case viewCount ->
+          orderSpecifiers.add(new OrderSpecifier<>(direction, newsArticle.viewCount));
+    }
+
+    // 같은 정렬값이 있을 때 페이지 경계를 안정적으로 자르기 위한 보조 정렬
+    orderSpecifiers.add(new OrderSpecifier<>(direction, newsArticle.createdAt));
+
+    return orderSpecifiers;
+  }
+
+
+}

--- a/src/main/java/com/springboot/monew/newsarticles/repository/qdsl/NewsArticleQDSLRepositoryImpl.java
+++ b/src/main/java/com/springboot/monew/newsarticles/repository/qdsl/NewsArticleQDSLRepositoryImpl.java
@@ -11,7 +11,9 @@ import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.springboot.monew.newsarticles.dto.ParsedCursor;
 import com.springboot.monew.newsarticles.dto.request.NewsArticlePageRequest;
 import com.springboot.monew.newsarticles.dto.response.NewsArticleCursorRow;
 import com.springboot.monew.newsarticles.enums.NewsArticleDirection;
@@ -56,34 +58,33 @@ public class NewsArticleQDSLRepositoryImpl implements NewsArticleQDSLRepository 
 
     // cursor, after 값이 있으면 다음 페이지 조건 생성
     // 정렬 기준(orderBy)에 따라 날짜/댓글수/조회수 기준 커서 조건이 달라진다.
-    BooleanExpression cursorCondition = buildCursorCondition(request, commentCountExpr);
-    if (cursorCondition != null) {
-      where.and(cursorCondition);
+    BooleanExpression whereCursorCondition = buildWhereCursorCondition(request);
+    if (whereCursorCondition != null) {
+      where.and(whereCursorCondition);
     }
 
-    return queryFactory
+    BooleanExpression havingCursorCondition = buildHavingCursorCondition(request, commentCountExpr);
+
+    JPAQuery<NewsArticleCursorRow> query = queryFactory
         .select(constructor(
             NewsArticleCursorRow.class,
             newsArticle.id,
             newsArticle.source,
-            newsArticle.originalLink,   // sourceUrl
+            newsArticle.originalLink,
             newsArticle.title,
-            newsArticle.publishedAt,    // publishDate
+            newsArticle.publishedAt,
             newsArticle.summary,
             commentCountExpr,
             newsArticle.viewCount,
-            articleView.id.isNotNull(), // viewedByMe
-            newsArticle.createdAt       // nextAfter 계산용 내부 필드
+            articleView.id.isNotNull(),
+            newsArticle.createdAt
         ))
         .from(newsArticle)
-        // 관심사 필터용 조인
         .leftJoin(articleInterest).on(articleInterest.newsArticle.eq(newsArticle))
-        // 댓글 수 집계용 조인
         .leftJoin(comment).on(
             comment.article.eq(newsArticle)
                 .and(comment.isDeleted.isFalse())
         )
-        // 현재 유저가 조회했는지 확인용 조인
         .leftJoin(articleView).on(
             articleView.newsArticle.eq(newsArticle)
                 .and(articleView.user.id.eq(userId))
@@ -99,9 +100,14 @@ public class NewsArticleQDSLRepositoryImpl implements NewsArticleQDSLRepository 
             newsArticle.viewCount,
             articleView.id,
             newsArticle.createdAt
-        )
+        );
+
+    if (havingCursorCondition != null) {
+      query.having(havingCursorCondition);
+    }
+
+    return query
         .orderBy(getOrderSpecifiers(request, commentCountExpr).toArray(OrderSpecifier[]::new))
-        // 다음 페이지 존재 여부 확인 위해 limit + 1 조회
         .limit(request.limit() + 1L)
         .fetch();
   }
@@ -187,69 +193,83 @@ public class NewsArticleQDSLRepositoryImpl implements NewsArticleQDSLRepository 
   }
 
   // 정렬 기준에 따른 커서 조건 생성
-  private BooleanExpression buildCursorCondition(
-      NewsArticlePageRequest request,
-      NumberExpression<Long> commentCountExpr
-  ) {
-    // cursor 자체가 없으면 커서 페이지네이션 조건을 적용할 수 없음
+  // publishDate 커서조건 -> where절
+  // viewCount 커서조건 -> where절
+  private BooleanExpression buildWhereCursorCondition(NewsArticlePageRequest request) {
     if (request.cursor() == null || request.cursor().isBlank()) {
       return null;
     }
 
     return switch (request.orderBy()) {
       case publishDate -> publishDateCursorCondition(request);
-      case commentCount -> commentCountCursorCondition(request, commentCountExpr);
       case viewCount -> viewCountCursorCondition(request);
+      case commentCount -> null;
+    };
+  }
+
+  // commentCount 커서조건 -> having절
+  // 집계함수라서 having절에 써야한다.
+  private BooleanExpression buildHavingCursorCondition(
+      NewsArticlePageRequest request,
+      NumberExpression<Long> commentCountExpr
+  ) {
+    if (request.cursor() == null || request.cursor().isBlank()) {
+      return null;
+    }
+
+    return switch (request.orderBy()) {
+      case commentCount -> commentCountCursorCondition(request, commentCountExpr);
+      case publishDate, viewCount -> null;
     };
   }
 
   // 날짜 정렬 기준 커서 조건
+  // after가 null로 들어와서 cursor로만 조회
   private BooleanExpression publishDateCursorCondition(NewsArticlePageRequest request) {
-    Instant cursorValue = Instant.parse(request.cursor());
+    ParsedCursor parsedCursor = parseCursor(request.cursor());
 
-    // after가 없으면 publishDate만으로 다음 페이지 조건 생성
-    if (request.after() == null || request.after().isBlank()) {
-      return request.direction() == NewsArticleDirection.DESC
-          ? newsArticle.publishedAt.lt(cursorValue)
-          : newsArticle.publishedAt.gt(cursorValue);
+    Instant cursorValue = Instant.parse(parsedCursor.value());
+
+    BooleanExpression primaryCondition = request.direction() == NewsArticleDirection.DESC
+        ? newsArticle.publishedAt.lt(cursorValue)
+        : newsArticle.publishedAt.gt(cursorValue);
+
+    if (parsedCursor.after() == null) {
+      return primaryCondition;
     }
 
-    Instant afterValue = Instant.parse(request.after());
+    BooleanExpression sameValueCondition = request.direction() == NewsArticleDirection.DESC
+        ? newsArticle.createdAt.lt(parsedCursor.after())
+        : newsArticle.createdAt.gt(parsedCursor.after());
 
-    if (request.direction() == NewsArticleDirection.DESC) {
-      return newsArticle.publishedAt.lt(cursorValue)
-          .or(newsArticle.publishedAt.eq(cursorValue)
-              .and(newsArticle.createdAt.lt(afterValue)));
-    }
-
-    return newsArticle.publishedAt.gt(cursorValue)
-        .or(newsArticle.publishedAt.eq(cursorValue)
-            .and(newsArticle.createdAt.gt(afterValue)));
+    return primaryCondition.or(
+        newsArticle.publishedAt.eq(cursorValue).and(sameValueCondition)
+    );
   }
 
 
   // 조회수 정렬 기준 커서 조건
+  // after가 null로 들어와서 cursor로만 조회
   private BooleanExpression viewCountCursorCondition(NewsArticlePageRequest request) {
-    Long cursorValue = Long.parseLong(request.cursor());
+    ParsedCursor parsedCursor = parseCursor(request.cursor());
 
-    // after가 없으면 viewCount만으로 다음 페이지 조건 생성
-    if (request.after() == null || request.after().isBlank()) {
-      return request.direction() == NewsArticleDirection.DESC
-          ? newsArticle.viewCount.lt(cursorValue)
-          : newsArticle.viewCount.gt(cursorValue);
+    Long cursorValue = Long.parseLong(parsedCursor.value());
+
+    BooleanExpression primaryCondition = request.direction() == NewsArticleDirection.DESC
+        ? newsArticle.viewCount.lt(cursorValue)
+        : newsArticle.viewCount.gt(cursorValue);
+
+    if (parsedCursor.after() == null) {
+      return primaryCondition;
     }
 
-    Instant afterValue = Instant.parse(request.after());
+    BooleanExpression sameValueCondition = request.direction() == NewsArticleDirection.DESC
+        ? newsArticle.createdAt.lt(parsedCursor.after())
+        : newsArticle.createdAt.gt(parsedCursor.after());
 
-    if (request.direction() == NewsArticleDirection.DESC) {
-      return newsArticle.viewCount.lt(cursorValue)
-          .or(newsArticle.viewCount.eq(cursorValue)
-              .and(newsArticle.createdAt.lt(afterValue)));
-    }
-
-    return newsArticle.viewCount.gt(cursorValue)
-        .or(newsArticle.viewCount.eq(cursorValue)
-            .and(newsArticle.createdAt.gt(afterValue)));
+    return primaryCondition.or(
+        newsArticle.viewCount.eq(cursorValue).and(sameValueCondition)
+    );
   }
 
   // 댓글 수 정렬 기준 커서 조건
@@ -258,26 +278,25 @@ public class NewsArticleQDSLRepositoryImpl implements NewsArticleQDSLRepository 
       NewsArticlePageRequest request,
       NumberExpression<Long> commentCountExpr
   ) {
-    Long cursorValue = Long.parseLong(request.cursor());
+    ParsedCursor parsedCursor = parseCursor(request.cursor());
 
-    // after가 없으면 commentCount만으로 다음 페이지 조건 생성
-    if (request.after() == null || request.after().isBlank()) {
-      return request.direction() == NewsArticleDirection.DESC
-          ? commentCountExpr.lt(cursorValue)
-          : commentCountExpr.gt(cursorValue);
+    Long cursorValue = Long.parseLong(parsedCursor.value());
+
+    BooleanExpression primaryCondition = request.direction() == NewsArticleDirection.DESC
+        ? commentCountExpr.lt(cursorValue)
+        : commentCountExpr.gt(cursorValue);
+
+    if (parsedCursor.after() == null) {
+      return primaryCondition;
     }
 
-    Instant afterValue = Instant.parse(request.after());
+    BooleanExpression sameValueCondition = request.direction() == NewsArticleDirection.DESC
+        ? newsArticle.createdAt.lt(parsedCursor.after())
+        : newsArticle.createdAt.gt(parsedCursor.after());
 
-    if (request.direction() == NewsArticleDirection.DESC) {
-      return commentCountExpr.lt(cursorValue)
-          .or(commentCountExpr.eq(cursorValue)
-              .and(newsArticle.createdAt.lt(afterValue)));
-    }
-
-    return commentCountExpr.gt(cursorValue)
-        .or(commentCountExpr.eq(cursorValue)
-            .and(newsArticle.createdAt.gt(afterValue)));
+    return primaryCondition.or(
+        commentCountExpr.eq(cursorValue).and(sameValueCondition)
+    );
   }
 
   // 정렬 기준 + 보조 정렬(createdAt) 생성
@@ -301,6 +320,19 @@ public class NewsArticleQDSLRepositoryImpl implements NewsArticleQDSLRepository 
     orderSpecifiers.add(new OrderSpecifier<>(direction, newsArticle.createdAt));
 
     return orderSpecifiers;
+  }
+
+  private ParsedCursor parseCursor(String cursor) {
+    if (cursor == null || cursor.isBlank()) {
+      return new ParsedCursor(null, null);
+    }
+
+    String[] parts = cursor.split("\\|");
+
+    String value = parts[0];
+    Instant after = parts.length > 1 ? Instant.parse(parts[1]) : null;
+
+    return new ParsedCursor(value, after);
   }
 
 

--- a/src/main/java/com/springboot/monew/newsarticles/repository/qdsl/NewsArticleQDSLRepositoryImpl.java
+++ b/src/main/java/com/springboot/monew/newsarticles/repository/qdsl/NewsArticleQDSLRepositoryImpl.java
@@ -34,26 +34,28 @@ public class NewsArticleQDSLRepositoryImpl implements NewsArticleQDSLRepository 
     // 동적 조건 조합을 위한 where 절
     BooleanBuilder where = new BooleanBuilder();
 
-    // 삭제되지 않은 기사만 조회
+    // 논리삭제 되지 않은 기사만 조회
     where.and(newsArticle.isDeleted.isFalse());
 
     // 검색 키워드 조건 (제목 또는 요약 부분일치)
     where.and(keywordContains(normalize(request.keyword())));
 
-    // 관심사 필터
+    // 관심사 ID가 있으면 해당 관심사와 연결된 기사만 조회
     where.and(interestIdEq(request.interestId()));
 
-    // 출처 필터
+    // 출처 필터가 있으면 해당 출처에 포함되는 기사만 조회
     where.and(sourceIn(request));
 
     // 날짜 범위 필터
     where.and(publishDateGoe(request.publishDateFrom()));
     where.and(publishDateLoe(request.publishDateTo()));
 
-    // 댓글 수 집계 표현식
+    // 댓글 수 정렬/조회에 사용할 댓글 개수 집계 표현식
+    // 댓글 ROW 중복 방지를 위해 countDistinct 사용
     NumberExpression<Long> commentCountExpr = comment.id.countDistinct();
 
-    // 커서 조건 추가
+    // cursor, after 값이 있으면 다음 페이지 조건 생성
+    // 정렬 기준(orderBy)에 따라 날짜/댓글수/조회수 기준 커서 조건이 달라진다.
     BooleanExpression cursorCondition = buildCursorCondition(request, commentCountExpr);
     if (cursorCondition != null) {
       where.and(cursorCondition);
@@ -189,7 +191,8 @@ public class NewsArticleQDSLRepositoryImpl implements NewsArticleQDSLRepository 
       NewsArticlePageRequest request,
       NumberExpression<Long> commentCountExpr
   ) {
-    if (request.cursor() == null || request.after() == null) {
+    // cursor 자체가 없으면 커서 페이지네이션 조건을 적용할 수 없음
+    if (request.cursor() == null || request.cursor().isBlank()) {
       return null;
     }
 
@@ -203,6 +206,14 @@ public class NewsArticleQDSLRepositoryImpl implements NewsArticleQDSLRepository 
   // 날짜 정렬 기준 커서 조건
   private BooleanExpression publishDateCursorCondition(NewsArticlePageRequest request) {
     Instant cursorValue = Instant.parse(request.cursor());
+
+    // after가 없으면 publishDate만으로 다음 페이지 조건 생성
+    if (request.after() == null || request.after().isBlank()) {
+      return request.direction() == NewsArticleDirection.DESC
+          ? newsArticle.publishedAt.lt(cursorValue)
+          : newsArticle.publishedAt.gt(cursorValue);
+    }
+
     Instant afterValue = Instant.parse(request.after());
 
     if (request.direction() == NewsArticleDirection.DESC) {
@@ -216,9 +227,18 @@ public class NewsArticleQDSLRepositoryImpl implements NewsArticleQDSLRepository 
             .and(newsArticle.createdAt.gt(afterValue)));
   }
 
+
   // 조회수 정렬 기준 커서 조건
   private BooleanExpression viewCountCursorCondition(NewsArticlePageRequest request) {
     Long cursorValue = Long.parseLong(request.cursor());
+
+    // after가 없으면 viewCount만으로 다음 페이지 조건 생성
+    if (request.after() == null || request.after().isBlank()) {
+      return request.direction() == NewsArticleDirection.DESC
+          ? newsArticle.viewCount.lt(cursorValue)
+          : newsArticle.viewCount.gt(cursorValue);
+    }
+
     Instant afterValue = Instant.parse(request.after());
 
     if (request.direction() == NewsArticleDirection.DESC) {
@@ -239,6 +259,14 @@ public class NewsArticleQDSLRepositoryImpl implements NewsArticleQDSLRepository 
       NumberExpression<Long> commentCountExpr
   ) {
     Long cursorValue = Long.parseLong(request.cursor());
+
+    // after가 없으면 commentCount만으로 다음 페이지 조건 생성
+    if (request.after() == null || request.after().isBlank()) {
+      return request.direction() == NewsArticleDirection.DESC
+          ? commentCountExpr.lt(cursorValue)
+          : commentCountExpr.gt(cursorValue);
+    }
+
     Instant afterValue = Instant.parse(request.after());
 
     if (request.direction() == NewsArticleDirection.DESC) {

--- a/src/main/java/com/springboot/monew/newsarticles/repository/qdsl/NewsArticleQDSLRepositoryImpl.java
+++ b/src/main/java/com/springboot/monew/newsarticles/repository/qdsl/NewsArticleQDSLRepositoryImpl.java
@@ -332,11 +332,24 @@ public class NewsArticleQDSLRepositoryImpl implements NewsArticleQDSLRepository 
     if (cursor == null || cursor.isBlank()) {
       return new ParsedCursor(null, null);
     }
-
+    // 1. |가 아예 없는 경우 통과
+    // 2. |가 여러개 있는 경우 통과
+    // 3. cursor = "10|" 인 경우 통과
+    // 4. cursor = "|2026-04-24T10:00:00Z"인 경우 통과
+    // ToDo: 위 4가지 경우를 막아야한다. -> 아래 if절로 3번까지 방어
     String[] parts = cursor.split("\\|");
 
+    //[value(cursor), after(보조 cursor)]형태가 아니면 예외처리
+    if(parts.length != 2) {
+      throw new IllegalArgumentException("잘못된 커서 형식입니다: cursor|after");
+    }
+
     String value = parts[0];
-    Instant after = parts.length > 1 ? parseInstantCursor(parts[1], "cursor.after") : null;
+    if (value.isBlank()) {
+      throw new IllegalArgumentException("cursor는 비어 있을 수 없습니다");
+    }
+
+    Instant after = parseInstantCursor(parts[1], "cursor.after");
 
     return new ParsedCursor(value, after);
   }

--- a/src/main/java/com/springboot/monew/newsarticles/repository/qdsl/NewsArticleQDSLRepositoryImpl.java
+++ b/src/main/java/com/springboot/monew/newsarticles/repository/qdsl/NewsArticleQDSLRepositoryImpl.java
@@ -224,12 +224,16 @@ public class NewsArticleQDSLRepositoryImpl implements NewsArticleQDSLRepository 
   }
 
   // 날짜 정렬 기준 커서 조건
-  // after가 null로 들어와서 cursor로만 조회
+  //ORDER BY published_at DESC, created_at DESC
   private BooleanExpression publishDateCursorCondition(NewsArticlePageRequest request) {
+
+    //parsedCursor = (value(주커서), after(보조커서)) 형태로 있다.
     ParsedCursor parsedCursor = parseCursor(request.cursor());
 
+    //주커서
     Instant cursorValue = Instant.parse(parsedCursor.value());
 
+    //마지막 row의 publishedAt이 2026.04.24라면 2026.04.24 > publishedAt
     BooleanExpression primaryCondition = request.direction() == NewsArticleDirection.DESC
         ? newsArticle.publishedAt.lt(cursorValue)
         : newsArticle.publishedAt.gt(cursorValue);
@@ -238,6 +242,7 @@ public class NewsArticleQDSLRepositoryImpl implements NewsArticleQDSLRepository 
       return primaryCondition;
     }
 
+    //주커서 값이 값은경우 createdAt으로 비교
     BooleanExpression sameValueCondition = request.direction() == NewsArticleDirection.DESC
         ? newsArticle.createdAt.lt(parsedCursor.after())
         : newsArticle.createdAt.gt(parsedCursor.after());

--- a/src/main/java/com/springboot/monew/newsarticles/service/NewsArticleService.java
+++ b/src/main/java/com/springboot/monew/newsarticles/service/NewsArticleService.java
@@ -312,9 +312,9 @@ public class NewsArticleService {
     Long commentCount = commentRepository.countByArticleIdAndIsDeletedFalse(articleId);
 
     // 4. 조회했던 기사인지 여부
-    Boolean viewdByMe = articleViewRepository.existsByNewsArticleIdAndUserId(articleId, userId);
+    Boolean viewedByMe = articleViewRepository.existsByNewsArticleIdAndUserId(articleId, userId);
 
-    return newsArticleMapper.toDto(article, commentCount, viewdByMe);
+    return newsArticleMapper.toDto(article, commentCount, viewedByMe);
 
   }
 

--- a/src/main/java/com/springboot/monew/newsarticles/service/NewsArticleService.java
+++ b/src/main/java/com/springboot/monew/newsarticles/service/NewsArticleService.java
@@ -296,6 +296,9 @@ public class NewsArticleService {
   @Transactional(readOnly = true)
   public NewsArticleDto findById(UUID articleId, UUID userId) {
 
+    // 요청 유저가 존재하는지 확인하고 삭제되지 않은 활성 사용자인지 검증
+    validateActiveUser(userId);
+
     //1. 기사 조회
     NewsArticle article = getNewsArticle(articleId);
 

--- a/src/main/java/com/springboot/monew/newsarticles/service/NewsArticleService.java
+++ b/src/main/java/com/springboot/monew/newsarticles/service/NewsArticleService.java
@@ -267,14 +267,17 @@ public class NewsArticleService {
 
       //정렬 기준(orderBy)에 따라 다음 페이지를 위한 cursor 값 설정
       //주커서: 정렬 기준 필드 값
-      nextCursor = switch(request.orderBy()){
+      String cursor = switch(request.orderBy()){
         case publishDate -> last.publishDate().toString();
         case commentCount -> String.valueOf(last.commentCount());
         case viewCount -> String.valueOf(last.viewCount());
       };
 
-      //보조 커서(after): 동일한 정렬값을 가진 데이터들 사이에서 순서를 안정적으로 유지하기 위한 값.
       nextAfter = last.createdAt().toString();
+
+      // cursor 안에 정렬값 + createdAt 포함
+      // 클라이언트에서 after를 안보내줘서 cursor에 cursor + after값을 넣었다.
+      nextCursor = cursor + "|" + nextAfter;
     }
 
     //전체 데이터 개수 조회

--- a/src/main/java/com/springboot/monew/newsarticles/service/NewsArticleService.java
+++ b/src/main/java/com/springboot/monew/newsarticles/service/NewsArticleService.java
@@ -4,6 +4,7 @@ import com.springboot.monew.comment.repository.CommentRepository;
 import com.springboot.monew.interest.entity.Interest;
 import com.springboot.monew.interest.repository.InterestRepository;
 import com.springboot.monew.newsarticles.dto.CollectedArticleWithInterest;
+import com.springboot.monew.newsarticles.dto.response.NewsArticleDto;
 import com.springboot.monew.newsarticles.dto.response.NewsArticleViewDto;
 import com.springboot.monew.newsarticles.entity.ArticleInterest;
 import com.springboot.monew.newsarticles.entity.ArticleView;
@@ -222,6 +223,27 @@ public class NewsArticleService {
     newsArticleRepository.incrementViewCount(articleId);
 
     return newsArticleViewMapper.toDto(savedArticleView, commentCount);
+
+  }
+  @Transactional(readOnly = true)
+  public NewsArticleDto findById(UUID articleId, UUID userId) {
+
+    //1. 기사 조회
+    NewsArticle article = getNewsArticle(articleId);
+
+    //2. 논리 삭제 체크
+    if (article.isDeleted()) {
+      throw new ArticleException(NewsArticleErrorCode.NEWS_ARTICLE_ALREADY_DELETED,
+          Map.of("articleId", articleId));
+    }
+
+    // 3. 댓글 수 조회
+    Long commentCount = commentRepository.countByArticleIdAndIsDeletedFalse(articleId);
+
+    // 4. 조회했던 기사인지 여부
+    Boolean viewdByMe = articleViewRepository.existsByNewsArticleIdAndUserId(articleId, userId);
+
+    return newsArticleMapper.toDto(article, commentCount, viewdByMe);
 
   }
 

--- a/src/main/java/com/springboot/monew/newsarticles/service/NewsArticleService.java
+++ b/src/main/java/com/springboot/monew/newsarticles/service/NewsArticleService.java
@@ -9,6 +9,7 @@ import com.springboot.monew.newsarticles.dto.response.NewsArticleViewDto;
 import com.springboot.monew.newsarticles.entity.ArticleInterest;
 import com.springboot.monew.newsarticles.entity.ArticleView;
 import com.springboot.monew.newsarticles.entity.NewsArticle;
+import com.springboot.monew.newsarticles.enums.ArticleSource;
 import com.springboot.monew.newsarticles.exception.ArticleException;
 import com.springboot.monew.newsarticles.exception.NewsArticleErrorCode;
 import com.springboot.monew.newsarticles.mapper.NewsArticleMapper;
@@ -245,6 +246,11 @@ public class NewsArticleService {
 
     return newsArticleMapper.toDto(article, commentCount, viewdByMe);
 
+  }
+
+  @Transactional(readOnly = true)
+  public List<ArticleSource> findAllSources() {
+    return List.of(ArticleSource.values());
   }
 
   // 뉴스기사 물리 삭제

--- a/src/main/java/com/springboot/monew/newsarticles/service/NewsArticleService.java
+++ b/src/main/java/com/springboot/monew/newsarticles/service/NewsArticleService.java
@@ -234,7 +234,7 @@ public class NewsArticleService {
   public CursorPageResponseNewsArticleDto list(NewsArticlePageRequest request, UUID userId){
 
     //요청 유저가 존재하는지 확인하고 삭제되지 않은 활성 사용자인지 검증
-    //validateActiveUser(userId);
+    validateActiveUser(userId);
 
     //요청 조건에 맞는 뉴스기사 목록을 limit + 1 개수만큼 조회
     //limit + 1만큼 조회하는 이유는 다음 페이지 존재여부(hasNext) 판단을 위해서
@@ -349,5 +349,15 @@ public class NewsArticleService {
     return newsArticleRepository.findById(articleId).orElseThrow(
         () -> new ArticleException(NewsArticleErrorCode.NEWS_ARTICLE_NOT_FOUND,
             Map.of("articleId", articleId)));
+  }
+
+  private void validateActiveUser(UUID userId) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND,
+            Map.of("userId", userId)));
+
+    if (user.isDeleted()) {
+      throw new UserException(UserErrorCode.USER_NOT_FOUND, Map.of("userId", userId));
+    }
   }
 }

--- a/src/main/java/com/springboot/monew/newsarticles/service/NewsArticleService.java
+++ b/src/main/java/com/springboot/monew/newsarticles/service/NewsArticleService.java
@@ -4,6 +4,9 @@ import com.springboot.monew.comment.repository.CommentRepository;
 import com.springboot.monew.interest.entity.Interest;
 import com.springboot.monew.interest.repository.InterestRepository;
 import com.springboot.monew.newsarticles.dto.CollectedArticleWithInterest;
+import com.springboot.monew.newsarticles.dto.request.NewsArticlePageRequest;
+import com.springboot.monew.newsarticles.dto.response.CursorPageResponseNewsArticleDto;
+import com.springboot.monew.newsarticles.dto.response.NewsArticleCursorRow;
 import com.springboot.monew.newsarticles.dto.response.NewsArticleDto;
 import com.springboot.monew.newsarticles.dto.response.NewsArticleViewDto;
 import com.springboot.monew.newsarticles.entity.ArticleInterest;
@@ -224,6 +227,67 @@ public class NewsArticleService {
     newsArticleRepository.incrementViewCount(articleId);
 
     return newsArticleViewMapper.toDto(savedArticleView, commentCount);
+
+  }
+
+  @Transactional(readOnly = true)
+  public CursorPageResponseNewsArticleDto list(NewsArticlePageRequest request, UUID userId){
+
+    //요청 유저가 존재하는지 확인하고 삭제되지 않은 활성 사용자인지 검증
+    //validateActiveUser(userId);
+
+    //요청 조건에 맞는 뉴스기사 목록을 limit + 1 개수만큼 조회
+    //limit + 1만큼 조회하는 이유는 다음 페이지 존재여부(hasNext) 판단을 위해서
+    List<NewsArticleCursorRow> rows = new ArrayList<>(newsArticleRepository.findNewsArticles(request, userId));
+
+    //조회된 개수가 요청 limit을 초과하면 다음 페이지가 존재한다고 판단
+    boolean hasNext = rows.size() > request.limit();
+
+    //다음 페이지가 존재하는 경우 반환 데이터는 limit 개수만큼 잘라내기
+    //limit + 1로 가져온 마지막 1개는 hasNext 판단용이라서 제거
+    if(hasNext){
+      rows = new ArrayList<>(rows.subList(0, request.limit()));
+    }
+
+    //내부 조회용 DTO(NewsArticleCursorRow)를 외부 응답용 DTO(NewsArticleDto)로 변환
+    // cretaedAt 내부 필드는 제외
+    List<NewsArticleDto> content = rows.stream()
+        .map(NewsArticleCursorRow::toDto)
+        .toList();
+
+    //다음 페이지를 위한 커서값 초기화
+    String nextCursor = null;
+    String nextAfter = null;
+
+    //다음 페이지 존재하고, 현재 페이지 데이터 비어있지 않은 경우에만 커서 계산
+    if(hasNext && !rows.isEmpty()){
+
+      //현재 페이지의 마지막 데이터를 기준으로 다음 페이지 커서를 생성
+      NewsArticleCursorRow last = rows.get(rows.size() - 1);
+
+      //정렬 기준(orderBy)에 따라 다음 페이지를 위한 cursor 값 설정
+      //주커서: 정렬 기준 필드 값
+      nextCursor = switch(request.orderBy()){
+        case publishDate -> last.publishDate().toString();
+        case commentCount -> String.valueOf(last.commentCount());
+        case viewCount -> String.valueOf(last.viewCount());
+      };
+
+      //보조 커서(after): 동일한 정렬값을 가진 데이터들 사이에서 순서를 안정적으로 유지하기 위한 값.
+      nextAfter = last.createdAt().toString();
+    }
+
+    //전체 데이터 개수 조회
+    long totalElements = newsArticleRepository.countNewsArticles(request);
+
+    return new CursorPageResponseNewsArticleDto(
+        content,
+        nextCursor,
+        nextAfter,
+        content.size(),
+        totalElements,
+        hasNext
+    );
 
   }
   @Transactional(readOnly = true)

--- a/src/main/java/com/springboot/monew/newsarticles/service/NewsArticleService.java
+++ b/src/main/java/com/springboot/monew/newsarticles/service/NewsArticleService.java
@@ -189,6 +189,9 @@ public class NewsArticleService {
   @Transactional
   public NewsArticleViewDto createView(UUID articleId, UUID userId){
 
+    //사용자 유효성 검증
+    validateActiveUser(userId);
+
     //뉴스기사 존재 확인
     NewsArticle newsArticle = getNewsArticle(articleId);
 


### PR DESCRIPTION
## 📌 작업 내용
- [x] 뉴스기사 단건조회 REST API 설계
- [x] 뉴스기사 목록조회 기능 구현
- [x] 출처 목록조회 구현 

## 🔧 변경 사항
- dto.ParsedCursor 추가
- controller(list(), findById(), findSource() 추가)
- service(list(), findById(),findAllSources() 추가 )
- repository.qdsl 추가  

## 반영 브랜치
`feature/#249/get-newsarticle-list` -> `dev`

## 💬 기타 참고 사항
cursor페이지네이션 구현시, 다음 페이지 요청 uri에 cursor값만 존재하고 after값은 없음.
즉 cursor가 동일할시, after(보조커서)값이 null이기에 데이터가 조회가 안된다.

따라서 nextCursor에 cursor + after값을 넣어주고, 조회할때 분리해서 cursor가 동일할때 after 값으로 조회되게 했다.
after값은 createdAt을 기준

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 커서 기반 페이지네이션을 지원하는 뉴스 기사 목록 조회 API 추가
  * 다음 페이지를 위한 nextCursor/nextAfter 제공 및 hasNext 표시
  * 키워드, 관심사, 출처, 발행일 범위로 필터링 가능
  * 발행일·댓글 수·조회 수 기준 정렬 기능 추가
  * 기사 목록에 댓글 수·조회 수 및 사용자가 본 여부 표시
  * 특정 뉴스 기사 상세 조회 API 추가(삭제된 기사 제외)
  * 사용 가능한 뉴스 출처 목록 조회 API 추가
  * 요청 파라미터 유효성 검사 및 최대/최소 한도 적용 (limit 1–100)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->