### PR TITLE
[Fix] 관심사 목록 조회 시 정렬 값이 구독자 수일 경우 발생하는 데이터 누락 문제 해결

### DIFF
--- a/src/main/java/com/springboot/monew/interest/repository/qdsl/InterestQDSLRepositoryImpl.java
+++ b/src/main/java/com/springboot/monew/interest/repository/qdsl/InterestQDSLRepositoryImpl.java
@@ -16,6 +16,7 @@ import com.springboot.monew.interest.entity.QInterestKeyword;
 import com.springboot.monew.interest.entity.QKeyword;
 import com.springboot.monew.newsarticles.entity.QArticleInterest;
 import java.time.Instant;
+import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -221,7 +222,12 @@ public class InterestQDSLRepositoryImpl implements InterestQDSLRepository {
       // 정렬값이 구독자 수일 경우 커서에서 구독자 수와 생성 시각 분리
       if (request.orderBy() == InterestOrderBy.subscriberCount && cursor.contains("|")) {
         String[] parts = cursor.split("\\|", 2);
-        return new CursorValue(parts[0], Instant.parse(parts[1]));
+
+        try {
+          return new CursorValue(parts[0], Instant.parse(parts[1]));
+        } catch (DateTimeParseException e) {
+          throw new IllegalArgumentException("Invalid subscriberCount cursor: " + cursor, e);
+        }
       }
 
       return new CursorValue(cursor, request.after());

--- a/src/main/java/com/springboot/monew/interest/repository/qdsl/InterestQDSLRepositoryImpl.java
+++ b/src/main/java/com/springboot/monew/interest/repository/qdsl/InterestQDSLRepositoryImpl.java
@@ -212,7 +212,19 @@ public class InterestQDSLRepositoryImpl implements InterestQDSLRepository {
 
     // 요청 객체에서 커서 값과 after 값을 꺼내 CursorValue로 변환
     private static CursorValue from(InterestPageRequest request) {
-      return new CursorValue(normalize(request.cursor()), request.after());
+      String cursor = normalize(request.cursor());
+
+      if (cursor == null) {
+        return new CursorValue(null, request.after());
+      }
+
+      // 정렬값이 구독자 수일 경우 커서에서 구독자 수와 생성 시각 분리
+      if (request.orderBy() == InterestOrderBy.subscriberCount && cursor.contains("|")) {
+        String[] parts = cursor.split("\\|", 2);
+        return new CursorValue(parts[0], Instant.parse(parts[1]));
+      }
+
+      return new CursorValue(cursor, request.after());
     }
 
     private static String normalize(String value) {

--- a/src/main/java/com/springboot/monew/interest/service/InterestService.java
+++ b/src/main/java/com/springboot/monew/interest/service/InterestService.java
@@ -7,6 +7,7 @@ import com.springboot.monew.interest.dto.response.CursorPageResponseInterestDto;
 import com.springboot.monew.interest.dto.response.InterestDto;
 import com.springboot.monew.interest.entity.Interest;
 import com.springboot.monew.interest.entity.InterestKeyword;
+import com.springboot.monew.interest.entity.InterestOrderBy;
 import com.springboot.monew.interest.entity.Keyword;
 import com.springboot.monew.interest.exception.InterestErrorCode;
 import com.springboot.monew.interest.exception.InterestException;
@@ -317,7 +318,15 @@ public class InterestService {
 
   private String getNextCursor(InterestPageRequest request, Interest interest) {
     // 요청한 정렬 기준에 맞는 커서 값을 관심사 엔티티에서 추출하여 반환
-    return request.orderBy().getCursor(interest);
+    String cursor = request.orderBy().getCursor(interest);
+
+    // 정렬값이 구독자 수일 경우 구독자 수가 같은 데이터의 누락을 막기 위해 생성 시각을 커서에 포함
+    // 현재 프론트엔트 코드에선 after를 전달하지 않음
+    if (request.orderBy() == InterestOrderBy.subscriberCount) {
+      return cursor + "|" + interest.getCreatedAt();
+    }
+
+    return cursor;
   }
 
   private void validateActiveUser(UUID userId) {


### PR DESCRIPTION
## 📌 해당 이슈카드
Closes #257

## 📌 작업 내용
- 관심사 목록 조회 시 정렬 값이 구독자 수일 경우 구독자 수가 동일한 데이터가 누락되는 문제를 해결
- `cursor`에 `createdAt`을 추가하여 `cursor + "|" + interest.getCreatedAt()` 형태로 구현
- `cursor` 값을 꺼낼 때는 `split()`으로 구독자 수와 생성 시각을 분리하여 사용하도록 구현

## 🔧 변경 사항


## 반영 브랜치
`fix/#257/Interest-list-fix` -> `dev`

## 💬 기타 참고 사항
- 보조 커서인 `nextAfter`가 존재하지만 프론트엔드 코드에서 해당 값을 전달하지 않아서 문제가 발생하였습니다. 그래서 프론트엔드를 수정하지 않고 해당 문제를 해결하지 위해 이 방법을 사용했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 구독자 수 기준 정렬 시 페이지 네비게이션 안정성 향상: 커서 처리 로직을 개선해 엣지 케이스에서 올바른 페이지 이동을 지원합니다.
  * 구독자 수 정렬에서 커서에 타임스탬프를 포함해 동일한 정렬 기준에서 일관된 페이징을 보장합니다.
  * 잘못된/손상된 커서 입력에 대해 명확한 오류 처리를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->