### PR TITLE
[Feat] 사용자 활동 문서 갱신 기반 구조 구현

### DIFF
--- a/src/main/java/com/springboot/monew/users/document/UserActivityDocument.java
+++ b/src/main/java/com/springboot/monew/users/document/UserActivityDocument.java
@@ -5,6 +5,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.function.Predicate;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -29,6 +30,9 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @Document(collection = "user_activities")
 public class UserActivityDocument {
 
+  // 최근 활동 목록은 최대 10개까지만 유지한다.
+  private static final int RECENT_ACTIVITY_LIMIT = 10;
+
   @Id
   private UUID id;
 
@@ -51,6 +55,108 @@ public class UserActivityDocument {
     this.email = email;
     this.nickname = nickname;
     this.createdAt = createdAt;
+  }
+
+  // 사용자 닉네임 변경 시 활동 문서의 닉네임을 갱신한다.
+  public void updateNickname(String nickname) {
+    this.nickname = nickname;
+  }
+
+  // 관심사 구독 성공 시 subscriptions에 추가한다.
+  public void addSubscription(SubscriptionItem item) {
+    addRecentItem(
+        subscriptions,
+        item,
+        subscription -> subscription.interestId().equals(item.interestId())
+    );
+  }
+
+  // 관심사 구독 취소 시 subscriptions에서 제거한다.
+  public void removeSubscription(UUID interestId) {
+    subscriptions.removeIf(subscription -> subscription.interestId().equals(interestId));
+  }
+
+  // 댓글 작성 성공 시 comments에 추가한다.
+  public void addComment(CommentItem item) {
+    addRecentItem(
+        comments,
+        item,
+        comment -> comment.id().equals(item.id())
+    );
+  }
+
+  // 댓글 수정 성공 시 comments의 해당 댓글 정보를 갱신한다.
+  public void updateComment(CommentItem item) {
+    comments.removeIf(comment -> comment.id().equals(item.id()));
+    comments.add(0, item);
+    trimToLimit(comments);
+  }
+
+  // 댓글 삭제 성공 시 comments에서 제거한다.
+  public void removeComment(UUID commentId) {
+    comments.removeIf(comment -> comment.id().equals(commentId));
+  }
+
+  // 댓글 좋아요 성공 시 commentLikes에 추가한다.
+  public void addCommentLike(CommentLikeItem item) {
+    addRecentItem(
+        commentLikes,
+        item,
+        commentLike -> commentLike.id().equals(item.id())
+    );
+  }
+
+  // 댓글 좋아요 취소 시 commentLikes에서 제거한다.
+  public void removeCommentLike(UUID commentId) {
+    commentLikes.removeIf(commentLike ->
+        commentLike.commentId().equals(commentId));
+  }
+
+  // 기사 조회 성공 시 articleViews에 추가한다.
+  public void addArticleView(ArticleViewItem item) {
+    addRecentItem(
+        articleViews,
+        item,
+        articleView -> articleView.articleId().equals(item.articleId())
+    );
+  }
+
+  // 내 댓글이 좋아요/좋아요 취소를 받았을 때 comments 안의 likeCount를 갱신한다.
+  public void updateCommentLikeCount(UUID commentId, long likeCount) {
+    comments.replaceAll(comment -> {
+      if (!comment.id().equals(commentId)) {
+        return comment;
+      }
+
+      return new CommentItem(
+          comment.id(),
+          comment.articleId(),
+          comment.articleTitle(),
+          comment.userId(),
+          comment.userNickname(),
+          comment.content(),
+          likeCount,
+          comment.createdAt()
+      );
+    });
+  }
+
+  // 중복 활동을 제거한 뒤 최신 활동을 맨 앞에 추가하고 최대 개수를 유지한다.
+  // 제네릭을 받아서 true/false를 반환하는 Predicate 함수를 사용
+  private <T> void addRecentItem(List<T> items, T newItem, Predicate<T> duplicatedCondition) {
+    items.removeIf(duplicatedCondition);
+    items.add(0, newItem);
+    trimToLimit(items);
+  }
+
+  // 최근 활동 목록이 최대 개수를 초과하면 오래된 항목을 제거한다.
+  private <T> void trimToLimit(List<T> items) {
+    if (items.size() <= RECENT_ACTIVITY_LIMIT) {
+      return;
+    }
+
+    // 최근 활동 내역 10건 이후로는 다 제거
+    items.subList(RECENT_ACTIVITY_LIMIT, items.size()).clear();
   }
 
   public record SubscriptionItem(

--- a/src/main/java/com/springboot/monew/users/event/ArticleView/ArticleViewedEvent.java
+++ b/src/main/java/com/springboot/monew/users/event/ArticleView/ArticleViewedEvent.java
@@ -1,0 +1,11 @@
+package com.springboot.monew.users.event.ArticleView;
+
+import com.springboot.monew.users.document.UserActivityDocument.ArticleViewItem;
+import java.util.UUID;
+
+public record ArticleViewedEvent(
+    UUID userId,
+    ArticleViewItem item
+) {
+
+}

--- a/src/main/java/com/springboot/monew/users/event/UserActivityEventListener.java
+++ b/src/main/java/com/springboot/monew/users/event/UserActivityEventListener.java
@@ -1,6 +1,6 @@
 package com.springboot.monew.users.event;
 
-import com.springboot.monew.users.event.ArticleView.ArticleViewedEvent;
+import com.springboot.monew.users.event.articleView.ArticleViewedEvent;
 import com.springboot.monew.users.event.comment.CommentCreatedEvent;
 import com.springboot.monew.users.event.comment.CommentDeletedEvent;
 import com.springboot.monew.users.event.comment.CommentLikeCountUpdatedEvent;

--- a/src/main/java/com/springboot/monew/users/event/UserActivityEventListener.java
+++ b/src/main/java/com/springboot/monew/users/event/UserActivityEventListener.java
@@ -1,0 +1,95 @@
+package com.springboot.monew.users.event;
+
+import com.springboot.monew.users.event.ArticleView.ArticleViewedEvent;
+import com.springboot.monew.users.event.comment.CommentCreatedEvent;
+import com.springboot.monew.users.event.comment.CommentDeletedEvent;
+import com.springboot.monew.users.event.comment.CommentLikeCountUpdatedEvent;
+import com.springboot.monew.users.event.comment.CommentLikedEvent;
+import com.springboot.monew.users.event.comment.CommentUnlikedEvent;
+import com.springboot.monew.users.event.comment.CommentUpdatedEvent;
+import com.springboot.monew.users.event.interest.InterestSubscribedEvent;
+import com.springboot.monew.users.event.interest.InterestUnsubscribedEvent;
+import com.springboot.monew.users.event.user.UserNicknameUpdatedEvent;
+import com.springboot.monew.users.event.user.UserRegisteredEvent;
+import com.springboot.monew.users.service.UserActivityUpdateService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class UserActivityEventListener {
+
+  private final UserActivityUpdateService userActivityUpdateService;
+
+  // 회원가입 이벤트를 수신하여 사용자 활동 문서 생성
+  @TransactionalEventListener
+  public void handle(UserRegisteredEvent event) {
+    userActivityUpdateService.createUserActivity(event.user());
+  }
+
+  // 닉네임 변경 이벤트를 수신하여 사용자 활동 문서의 닉네임을 갱신
+  @TransactionalEventListener
+  public void handle(UserNicknameUpdatedEvent event) {
+    userActivityUpdateService.updateUserNickname(event.userId(), event.nickname());
+  }
+
+  // 관심사 구독 이벤트를 수신하여 사용자 활동 문서에 구독 내역을 추가
+  @TransactionalEventListener
+  public void handle(InterestSubscribedEvent event) {
+    userActivityUpdateService.addSubscription(event.userId(), event.item());
+  }
+
+  // 관심사 구독 취소 이벤트를 수신하여 사용자 활동 문서에서 구독 내역을 제거
+  @TransactionalEventListener
+  public void handle(InterestUnsubscribedEvent event) {
+    userActivityUpdateService.removeSubscription(event.userId(), event.interestId());
+  }
+
+  // 댓글 작성 이벤트를 수신하여 사용자 활동 문서에 댓글 내역을 추가
+  @TransactionalEventListener
+  public void handle(CommentCreatedEvent event) {
+    userActivityUpdateService.addComment(event.userId(), event.item());
+  }
+
+
+  // 댓글 수정 이벤트를 수신하여 사용자 활동 문서의 댓글 내역을 갱신
+  @TransactionalEventListener
+  public void handle(CommentUpdatedEvent event) {
+    userActivityUpdateService.updateComment(event.userId(), event.item());
+  }
+
+  // 댓글 삭제 이벤트를 수신하여 사용자 활동 문서에서 댓글 내역을 제거
+  @TransactionalEventListener
+  public void handle(CommentDeletedEvent event) {
+    userActivityUpdateService.removeComment(event.userId(), event.commentId());
+  }
+
+  // 댓글 좋아요 이벤트를 수신하여 사용자 활동 문서에 좋아요 내역을 추가
+  @TransactionalEventListener
+  public void handle(CommentLikedEvent event) {
+    userActivityUpdateService.addCommentLike(event.userId(), event.item());
+  }
+
+  // 댓글 좋아요 취소 이벤트를 수신하여 사용자 활동 문서에서 좋아요 내역을 제거한다.
+  @TransactionalEventListener
+  public void handle(CommentUnlikedEvent event) {
+    userActivityUpdateService.removeCommentLike(event.userId(), event.commentId());
+  }
+
+  // 댓글 좋아요 수 변경 이벤트를 수신하여 사용자 활동 문서의 댓글 좋아요 수를 갱신
+  @TransactionalEventListener
+  public void handle(CommentLikeCountUpdatedEvent event) {
+    userActivityUpdateService.updateCommentLikeCount(
+        event.userId(),
+        event.commentId(),
+        event.likeCount()
+    );
+  }
+
+  // 기사 조회 이벤트를 수신하여 사용자 활동 문서에 기사 조회 내역을 추가
+  @TransactionalEventListener
+  public void handle(ArticleViewedEvent event) {
+    userActivityUpdateService.addArticleView(event.userId(), event.item());
+  }
+}

--- a/src/main/java/com/springboot/monew/users/event/articleView/ArticleViewedEvent.java
+++ b/src/main/java/com/springboot/monew/users/event/articleView/ArticleViewedEvent.java
@@ -1,4 +1,4 @@
-package com.springboot.monew.users.event.ArticleView;
+package com.springboot.monew.users.event.articleView;
 
 import com.springboot.monew.users.document.UserActivityDocument.ArticleViewItem;
 import java.util.UUID;

--- a/src/main/java/com/springboot/monew/users/event/comment/CommentCreatedEvent.java
+++ b/src/main/java/com/springboot/monew/users/event/comment/CommentCreatedEvent.java
@@ -1,0 +1,11 @@
+package com.springboot.monew.users.event.comment;
+
+import com.springboot.monew.users.document.UserActivityDocument.CommentItem;
+import java.util.UUID;
+
+public record CommentCreatedEvent(
+    UUID userId,
+    CommentItem item
+) {
+
+}

--- a/src/main/java/com/springboot/monew/users/event/comment/CommentDeletedEvent.java
+++ b/src/main/java/com/springboot/monew/users/event/comment/CommentDeletedEvent.java
@@ -1,0 +1,10 @@
+package com.springboot.monew.users.event.comment;
+
+import java.util.UUID;
+
+public record CommentDeletedEvent(
+    UUID userId,
+    UUID commentId
+) {
+
+}

--- a/src/main/java/com/springboot/monew/users/event/comment/CommentLikeCountUpdatedEvent.java
+++ b/src/main/java/com/springboot/monew/users/event/comment/CommentLikeCountUpdatedEvent.java
@@ -1,0 +1,11 @@
+package com.springboot.monew.users.event.comment;
+
+import java.util.UUID;
+
+public record CommentLikeCountUpdatedEvent(
+    UUID userId,
+    UUID commentId,
+    long likeCount
+) {
+
+}

--- a/src/main/java/com/springboot/monew/users/event/comment/CommentLikedEvent.java
+++ b/src/main/java/com/springboot/monew/users/event/comment/CommentLikedEvent.java
@@ -1,0 +1,11 @@
+package com.springboot.monew.users.event.comment;
+
+import com.springboot.monew.users.document.UserActivityDocument.CommentLikeItem;
+import java.util.UUID;
+
+public record CommentLikedEvent(
+    UUID userId,
+    CommentLikeItem item
+) {
+
+}

--- a/src/main/java/com/springboot/monew/users/event/comment/CommentUnlikedEvent.java
+++ b/src/main/java/com/springboot/monew/users/event/comment/CommentUnlikedEvent.java
@@ -1,0 +1,10 @@
+package com.springboot.monew.users.event.comment;
+
+import java.util.UUID;
+
+public record CommentUnlikedEvent(
+    UUID userId,
+    UUID commentId
+) {
+
+}

--- a/src/main/java/com/springboot/monew/users/event/comment/CommentUpdatedEvent.java
+++ b/src/main/java/com/springboot/monew/users/event/comment/CommentUpdatedEvent.java
@@ -1,0 +1,11 @@
+package com.springboot.monew.users.event.comment;
+
+import com.springboot.monew.users.document.UserActivityDocument.CommentItem;
+import java.util.UUID;
+
+public record CommentUpdatedEvent(
+    UUID userId,
+    CommentItem item
+) {
+ 
+}

--- a/src/main/java/com/springboot/monew/users/event/interest/InterestSubscribedEvent.java
+++ b/src/main/java/com/springboot/monew/users/event/interest/InterestSubscribedEvent.java
@@ -1,0 +1,11 @@
+package com.springboot.monew.users.event.interest;
+
+import com.springboot.monew.users.document.UserActivityDocument.SubscriptionItem;
+import java.util.UUID;
+
+public record InterestSubscribedEvent(
+    UUID userId,
+    SubscriptionItem item
+) {
+
+}

--- a/src/main/java/com/springboot/monew/users/event/interest/InterestUnsubscribedEvent.java
+++ b/src/main/java/com/springboot/monew/users/event/interest/InterestUnsubscribedEvent.java
@@ -1,0 +1,10 @@
+package com.springboot.monew.users.event.interest;
+
+import java.util.UUID;
+
+public record InterestUnsubscribedEvent(
+    UUID userId,
+    UUID interestId
+) {
+
+}

--- a/src/main/java/com/springboot/monew/users/event/user/UserNicknameUpdatedEvent.java
+++ b/src/main/java/com/springboot/monew/users/event/user/UserNicknameUpdatedEvent.java
@@ -1,0 +1,10 @@
+package com.springboot.monew.users.event.user;
+
+import java.util.UUID;
+
+public record UserNicknameUpdatedEvent(
+    UUID userId,
+    String nickname
+) {
+
+}

--- a/src/main/java/com/springboot/monew/users/event/user/UserRegisteredEvent.java
+++ b/src/main/java/com/springboot/monew/users/event/user/UserRegisteredEvent.java
@@ -1,0 +1,9 @@
+package com.springboot.monew.users.event.user;
+
+import com.springboot.monew.users.entity.User;
+
+public record UserRegisteredEvent(
+    User user
+) {
+
+}

--- a/src/main/java/com/springboot/monew/users/service/UserActivityUpdateService.java
+++ b/src/main/java/com/springboot/monew/users/service/UserActivityUpdateService.java
@@ -1,0 +1,117 @@
+package com.springboot.monew.users.service;
+
+import com.springboot.monew.users.document.UserActivityDocument;
+import com.springboot.monew.users.document.UserActivityDocument.ArticleViewItem;
+import com.springboot.monew.users.document.UserActivityDocument.CommentItem;
+import com.springboot.monew.users.document.UserActivityDocument.CommentLikeItem;
+import com.springboot.monew.users.document.UserActivityDocument.SubscriptionItem;
+import com.springboot.monew.users.entity.User;
+import com.springboot.monew.users.exception.UserErrorCode;
+import com.springboot.monew.users.exception.UserException;
+import com.springboot.monew.users.repository.UserActivityRepository;
+import com.springboot.monew.users.repository.UserRepository;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserActivityUpdateService {
+
+  private final UserActivityRepository userActivityRepository;
+
+  // 회원가입 성공 시 사용자 활동 내역 문서를 새로 생성한다.
+  public void createUserActivity(User user) {
+    UserActivityDocument document = new UserActivityDocument(
+        user.getId(),
+        user.getEmail(),
+        user.getNickname(),
+        user.getCreatedAt()
+    );
+
+    userActivityRepository.save(document);
+  }
+
+  // 사용자 닉네임이 변경되면 활동 내역 문서의 사용자 기본 정보도 갱신한다.
+  public void updateUserNickname(UUID userId, String nickname) {
+    UserActivityDocument document = getDocument(userId);
+    document.updateNickname(nickname);
+    userActivityRepository.save(document);
+  }
+
+  // 관심사 구독 시 사용자 활동 문서에 구독 내역을 추가한다.
+  public void addSubscription(UUID userId, SubscriptionItem item) {
+    UserActivityDocument document = getDocument(userId);
+    document.addSubscription(item);
+    userActivityRepository.save(document);
+  }
+
+  // 관심사 구독 취소 시 사용자 활동 문서에서 구독 내역을 제거한다.
+  public void removeSubscription(UUID userId, UUID interestId) {
+    UserActivityDocument document = getDocument(userId);
+    document.removeSubscription(interestId);
+    userActivityRepository.save(document);
+  }
+
+  // 댓글 작성 시 사용자 활동 문서에 댓글 내역을 추가한다.
+  public void addComment(UUID userId, CommentItem item) {
+    UserActivityDocument document = getDocument(userId);
+    document.addComment(item);
+    userActivityRepository.save(document);
+  }
+
+  // 댓글 수정 시 사용자 활동 문서의 댓글 내역을 갱신한다.
+  public void updateComment(UUID userId, CommentItem item) {
+    UserActivityDocument document = getDocument(userId);
+    document.updateComment(item);
+    userActivityRepository.save(document);
+  }
+
+  // 댓글 삭제 시 사용자 활동 문서에서 댓글 내역을 제거한다.
+  public void removeComment(UUID userId, UUID commentId) {
+    UserActivityDocument document = getDocument(userId);
+    document.removeComment(commentId);
+    userActivityRepository.save(document);
+  }
+
+  // 댓글 좋아요 시 사용자 활동 문서에 좋아요 내역을 추가한다.
+  public void addCommentLike(UUID userId, CommentLikeItem item) {
+    UserActivityDocument document = getDocument(userId);
+    document.addCommentLike(item);
+    userActivityRepository.save(document);
+  }
+
+  // 댓글 좋아요 취소 시 사용자 활동 문서에서 좋아요 내역을 제거한다.
+  public void removeCommentLike(UUID userId, UUID commentId) {
+    UserActivityDocument document = getDocument(userId);
+    document.removeCommentLike(commentId);
+    userActivityRepository.save(document);
+  }
+
+  // 댓글 좋아요 수 변경 시 사용자 활동 문서의 댓글 좋아요 수를 갱신한다.
+  public void updateCommentLikeCount(UUID userId, UUID commentId, long likeCount) {
+    UserActivityDocument document = getDocument(userId);
+    document.updateCommentLikeCount(commentId, likeCount);
+    userActivityRepository.save(document);
+  }
+
+  // 기사 조회 시 사용자 활동 문서에 기사 조회 내역을 추가한다.
+  public void addArticleView(UUID userId, ArticleViewItem item) {
+    UserActivityDocument document = getDocument(userId);
+    document.addArticleView(item);
+    userActivityRepository.save(document);
+  }
+
+  // 사용자 활동 내역 문서를 조회한다. 없으면 회원가입 시 문서 생성이 누락된 상태로 보고 예외를 던진다.
+  private UserActivityDocument getDocument(UUID userId) {
+    return userActivityRepository.findById(userId)
+        .orElseThrow(() -> new UserException(
+            UserErrorCode.USER_NOT_FOUND,
+            Map.of("userId", userId)
+        ));
+  }
+
+}

--- a/src/main/java/com/springboot/monew/users/service/UserActivityUpdateService.java
+++ b/src/main/java/com/springboot/monew/users/service/UserActivityUpdateService.java
@@ -9,7 +9,6 @@ import com.springboot.monew.users.entity.User;
 import com.springboot.monew.users.exception.UserErrorCode;
 import com.springboot.monew.users.exception.UserException;
 import com.springboot.monew.users.repository.UserActivityRepository;
-import com.springboot.monew.users.repository.UserRepository;
 import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/springboot/monew/users/service/UserService.java
+++ b/src/main/java/com/springboot/monew/users/service/UserService.java
@@ -5,6 +5,8 @@ import com.springboot.monew.users.dto.request.UserRegisterRequest;
 import com.springboot.monew.users.dto.request.UserUpdateRequest;
 import com.springboot.monew.users.dto.response.UserDto;
 import com.springboot.monew.users.entity.User;
+import com.springboot.monew.users.event.user.UserNicknameUpdatedEvent;
+import com.springboot.monew.users.event.user.UserRegisteredEvent;
 import com.springboot.monew.users.exception.UserErrorCode;
 import com.springboot.monew.users.exception.UserException;
 import com.springboot.monew.users.mapper.UserMapper;
@@ -15,6 +17,7 @@ import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +29,7 @@ public class UserService {
 
   private final UserRepository userRepository;
   private final UserMapper userMapper;
+  private final ApplicationEventPublisher applicationEventPublisher;
 
   // 사용자 회원가입
   @Transactional
@@ -40,6 +44,8 @@ public class UserService {
     );
 
     User savedUser = userRepository.save(user);
+    // 회원가입 후 사용자 활동 문서 생성을 위해 이벤트 발행
+    applicationEventPublisher.publishEvent(new UserRegisteredEvent(savedUser));
     log.info("회원가입 완료 - userId={}, email={}", savedUser.getId(), savedUser.getEmail());
     return userMapper.toDto(savedUser);
   }
@@ -108,6 +114,10 @@ public class UserService {
     }
 
     user.updateNickname(request.nickname());
+    // 닉네임 수정 후 사용자 활동 문서 갱신을 위해 이벤트 발행
+    applicationEventPublisher.publishEvent(
+        new UserNicknameUpdatedEvent(user.getId(), user.getNickname())
+    );
     log.info("닉네임 수정 완료 - userId={}, nickname={}", user.getId(), user.getNickname());
     return userMapper.toDto(user);
   }

--- a/src/test/java/com/springboot/monew/users/service/UserServiceTest.java
+++ b/src/test/java/com/springboot/monew/users/service/UserServiceTest.java
@@ -14,6 +14,8 @@ import com.springboot.monew.users.dto.request.UserRegisterRequest;
 import com.springboot.monew.users.dto.request.UserUpdateRequest;
 import com.springboot.monew.users.dto.response.UserDto;
 import com.springboot.monew.users.entity.User;
+import com.springboot.monew.users.event.user.UserNicknameUpdatedEvent;
+import com.springboot.monew.users.event.user.UserRegisteredEvent;
 import com.springboot.monew.users.exception.UserErrorCode;
 import com.springboot.monew.users.exception.UserException;
 import com.springboot.monew.users.mapper.UserMapper;
@@ -29,9 +31,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 @ExtendWith(MockitoExtension.class)
 public class UserServiceTest {
+
+  @Mock
+  private ApplicationEventPublisher applicationEventPublisher;
 
   @Mock
   private UserRepository userRepository;
@@ -132,6 +138,7 @@ public class UserServiceTest {
     verify(userRepository).existsByNickname(request.nickname());
     verify(userRepository).save(any(User.class));
     verify(userMapper).toDto(savedUser);
+    verify(applicationEventPublisher).publishEvent(any(UserRegisteredEvent.class));
   }
 
   @Test
@@ -251,6 +258,7 @@ public class UserServiceTest {
     verify(userRepository).findById(userId);
     verify(userRepository).existsByNickname(request.nickname());
     verify(userMapper).toDto(user);
+    verify(applicationEventPublisher).publishEvent(any(UserNicknameUpdatedEvent.class));
   }
 
   @Test
@@ -372,6 +380,7 @@ public class UserServiceTest {
     verify(userRepository).findById(userId);
     verify(userRepository, never()).existsByNickname(anyString());
     verify(userMapper).toDto(user);
+    verify(applicationEventPublisher).publishEvent(any(UserNicknameUpdatedEvent.class));
   }
 
   @Test


### PR DESCRIPTION
## 📌 해당 이슈카드

Closes #91

## 📌 작업 내용

- UserActivityDocument에 사용자 활동 상태 변경 메서드를 추가했습니다.
- UserActivityUpdateService를 구현해 사용자 활동 문서 생성 및 갱신 로직을 분리했습니다.
- 사용자 활동 이벤트 객체를 정의하고 UserActivityEventListener를 구현했습니다.
- 회원가입과 닉네임 수정 시 사용자 활동 이벤트가 발행되도록 연결했습니다.
- 사용자 활동 문서가 최근순 정렬과 최대 10건 유지 규칙을 따르도록 반영했습니다.
- 사용자 활동 조회 구조에서 문서가 없는 경우 빈 리스트를 반환하도록 정리했습니다.

## 🔧 변경 사항

- UserActivityDocument에 구독, 댓글, 댓글 좋아요, 기사 조회 내역의 추가/수정/삭제 메서드를 추가했습니다.
- UserActivityUpdateService에서 문서 조회 후 상태 변경 메서드를 호출하고 MongoDB에 저장하도록 구현했습니다.
- 사용자 활동 관련 이벤트를 user, interest, comment, ArticleView 패키지로 분리했습니다.
- UserActivityEventListener에 @TransactionalEventListener를 적용해 RDB 트랜잭션 커밋 이후 MongoDB 문서가 갱신되도록 구성했습니다.
- UserService에서 회원가입 및 닉네임 수정 시 사용자 활동 이벤트를 발행하도록 수정했습니다.

## 반영 브랜치
`feature/#91/user-activity-sync` -> `dev`

## 💬 기타 참고 사항

- 관심사 구독/취소, 댓글, 댓글 좋아요, 기사 조회 서비스의 이벤트 발행 연결은 후속 작업으로 진행할 예정입니다.
- 사용자 활동 조회는 MongoDB UserActivityDocument를 읽는 구조이며, 문서가 없는 경우 빈 활동 내역을 반환합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새 기능

* **사용자 활동 추적**: 댓글, 구독, 좋아요, 기사 조회 등 사용자의 주요 활동이 자동으로 기록됩니다.
* **프로필 변경 기록**: 닉네임 변경 등 사용자 정보 수정 사항이 추적됩니다.
* **활동 기록 관리**: 최근 활동은 최대 10개 항목으로 자동으로 관리됩니다.
* **이벤트 기반 업데이트**: 사용자 활동 상태가 이벤트 시스템을 통해 실시간으로 동기화됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->