### PR TITLE
[Hotfix] 댓글 커서 페이지네이션 무한 로딩 및 likedByMe 필드명 불일치 수정

### DIFF
--- a/src/main/java/com/springboot/monew/comment/dto/CommentDto.java
+++ b/src/main/java/com/springboot/monew/comment/dto/CommentDto.java
@@ -11,5 +11,5 @@ public record CommentDto(
     String userNickname,
     String content,
     Long likeCount,
-    Boolean likeByMe,
+    Boolean likedByMe,
     Instant createdAt) {}

--- a/src/main/java/com/springboot/monew/comment/entity/CommentOrderBy.java
+++ b/src/main/java/com/springboot/monew/comment/entity/CommentOrderBy.java
@@ -10,7 +10,7 @@ public enum CommentOrderBy {
   likeCount {
     @Override
     public String getCursor(Comment comment) {
-      return String.valueOf(comment.getLikeCount());
+      return comment.getLikeCount() + "|" + comment.getCreatedAt().toString();
     }
   };
 

--- a/src/main/java/com/springboot/monew/comment/mapper/CommentMapper.java
+++ b/src/main/java/com/springboot/monew/comment/mapper/CommentMapper.java
@@ -11,6 +11,6 @@ public interface CommentMapper {
   @Mapping(source = "comment.article.id", target = "articleId")
   @Mapping(source = "comment.user.id", target = "userId")
   @Mapping(source = "comment.user.nickname", target = "userNickname")
-  @Mapping(source = "likeByMe", target = "likeByMe")
+  @Mapping(source = "likeByMe", target = "likedByMe")
   CommentDto toCommentDto(Comment comment, boolean likeByMe);
 }

--- a/src/main/java/com/springboot/monew/comment/repository/qdsl/CommentQDSLRepositoryImpl.java
+++ b/src/main/java/com/springboot/monew/comment/repository/qdsl/CommentQDSLRepositoryImpl.java
@@ -41,25 +41,37 @@ public class CommentQDSLRepositoryImpl implements CommentQDSLRepository{
 
   private BooleanExpression cursorCondition(CommentOrderBy orderBy,
       CommentDirection direction, String cursor, Instant after) {
-    if (cursor == null || after == null) {return null;}
 
-    if(orderBy == CommentOrderBy.likeCount) {
-      long likeCountCursor = Long.parseLong(cursor);
+    if (orderBy == CommentOrderBy.likeCount) {
+      if (cursor == null) return null;
+
+      // "likeCount|createdAt" 파싱, after는 fallback
+      String[] parts = cursor.split("\\|", 2);
+      long likeCountCursor = Long.parseLong(parts[0]);
+      Instant afterCursor = parts.length > 1 ? Instant.parse(parts[1]) : after;
+
       if (direction == CommentDirection.ASC) {
-        return qComment.likeCount.gt(likeCountCursor)
-            .or(qComment.likeCount.eq(likeCountCursor)
-                .and(qComment.createdAt.lt(after)));
+        BooleanExpression primary = qComment.likeCount.gt(likeCountCursor);
+        if (afterCursor == null) return primary;
+        return primary.or(qComment.likeCount.eq(likeCountCursor)
+            .and(qComment.createdAt.lt(afterCursor)));
       } else {
-        return qComment.likeCount.lt(likeCountCursor)
-            .or(qComment.likeCount.eq(likeCountCursor)
-                .and(qComment.createdAt.gt(after)));
+        BooleanExpression primary = qComment.likeCount.lt(likeCountCursor);
+        if (afterCursor == null) return primary;
+        return primary.or(qComment.likeCount.eq(likeCountCursor)
+            .and(qComment.createdAt.gt(afterCursor)));
       }
     }
 
+    // createdAt 정렬
+    Instant createdAtCursor = after != null ? after : (cursor != null ? Instant.parse(cursor) : null);
+    if (createdAtCursor == null) return null;
+
     return direction == CommentDirection.DESC
-        ? qComment.createdAt.lt(after)
-        : qComment.createdAt.gt(after);
+        ? qComment.createdAt.lt(createdAtCursor)
+        : qComment.createdAt.gt(createdAtCursor);
   }
+
 
   // 정렬 조건
   private OrderSpecifier<?>[] orderByCondition(CommentOrderBy orderBy, CommentDirection direction) {

--- a/src/test/java/com/springboot/monew/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/springboot/monew/comment/service/CommentServiceTest.java
@@ -562,7 +562,7 @@ class CommentServiceTest {
     assertThat(result.content().get(0).likedByMe()).isFalse();
     assertThat(result.content().get(1).likedByMe()).isTrue();
     assertThat(result.hasNext()).isTrue();
-    assertThat(result.nextCursor()).isEqualTo("5");
+    assertThat(result.nextCursor()).isEqualTo("5|" + comment1CreatedAt.toString());
     assertThat(result.nextAfter()).isEqualTo(comment1CreatedAt);
     assertThat(result.totalElements()).isEqualTo(3L);
   }

--- a/src/test/java/com/springboot/monew/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/springboot/monew/comment/service/CommentServiceTest.java
@@ -101,7 +101,7 @@ class CommentServiceTest {
     // then
     assertThat(result).isEqualTo(expected);
     assertThat(result.content()).isEqualTo(request.content());
-    assertThat(result.likeByMe()).isEqualTo(false);
+    assertThat(result.likedByMe()).isEqualTo(false);
     assertThat(result.likeCount()).isEqualTo(0L);
 
     verify(articleRepository).findById(article.getId());
@@ -207,7 +207,7 @@ class CommentServiceTest {
     // then
     assertThat(result).isEqualTo(expected);
     assertThat(result.content()).isEqualTo(expected.content());
-    assertThat(result.likeByMe()).isEqualTo(expected.likeByMe());
+    assertThat(result.likedByMe()).isEqualTo(expected.likedByMe());
     assertThat(result.likeCount()).isEqualTo(expected.likeCount());
 
     verify(commentRepository).findByIdAndIsDeletedFalse(comment.getId());
@@ -476,7 +476,7 @@ class CommentServiceTest {
     assertThat(result.content()).hasSize(2);                                   // 댓글 2개 반환
     assertThat(result.content().get(0).id()).isEqualTo(commentId1);            // 첫 번째 댓글 id 확인
     assertThat(result.content().get(1).id()).isEqualTo(commentId2);            // 두 번째 댓글 id 확인
-    assertThat(result.content().get(0).likeByMe()).isTrue();                   // 좋아요 누른 댓글은 likeByMe = true
+    assertThat(result.content().get(0).likedByMe()).isTrue();                   // 좋아요 누른 댓글은 likeByMe = true
     assertThat(result.nextCursor()).isNull();
     assertThat(result.nextAfter()).isNull();
   }
@@ -559,8 +559,8 @@ class CommentServiceTest {
     assertThat(result.content()).hasSize(2);
     assertThat(result.content().get(0).id()).isEqualTo(commentId2);
     assertThat(result.content().get(1).id()).isEqualTo(commentId1);
-    assertThat(result.content().get(0).likeByMe()).isFalse();
-    assertThat(result.content().get(1).likeByMe()).isTrue();
+    assertThat(result.content().get(0).likedByMe()).isFalse();
+    assertThat(result.content().get(1).likedByMe()).isTrue();
     assertThat(result.hasNext()).isTrue();
     assertThat(result.nextCursor()).isEqualTo("5");
     assertThat(result.nextAfter()).isEqualTo(comment1CreatedAt);


### PR DESCRIPTION
## 관련 이슈 번호
- Closes #264 

## 📌 작업 내용
- 댓글 커서 페이지네이션 무한 로딩 버그 수정 및 likedByMe 필드명 불일치 수정  

## 🔧 변경 사항
- CommentDto: likeByMe → likedByMe 필드명 수정 (프론트엔드 스펙 일치)                          
- CommentMapper: likedByMe 매핑 타겟 수정
- CommentOrderBy: likeCount 정렬 시 createdAt 보조 커서 인코딩 추가 (likeCount|createdAt 형식) 
- CommentQDSLRepositoryImpl: cursor 파싱 로직 수정으로 무한 로딩 버그 해결                     
- CommentServiceTest: likedByMe 필드명 반영

## 반영 브랜치
- feature/#264/comment-hotfix -> dev 

## 💬 기타 참고 사항
- createdAt 정렬: cursor 문자열을 Instant로 파싱하여 after 대체                                
- likeCount 정렬: cursor에 likeCount|createdAt 인코딩하여 동일 likeCount 중복 페이지 방지


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 좋아요 수 기반 댓글 정렬 시 커서 포맷이 개선되어 (좋아요수|생성일시)로 변경되어 페이지네이션 안정성이 향상되었습니다.

* **Refactor**
  * 댓글 응답의 사용자 좋아요 여부 필드명이 변경되어 클라이언트에서 해당 플래그명을 업데이트해야 합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->