### PR TITLE
[Test] 관심사 기본 기능 테스트 구현

### DIFF
--- a/src/main/java/com/springboot/monew/interest/dto/response/CursorPageResponseInterestDto.java
+++ b/src/main/java/com/springboot/monew/interest/dto/response/CursorPageResponseInterestDto.java
@@ -8,9 +8,9 @@ public record CursorPageResponseInterestDto(
     List<InterestDto> content,
     String nextCursor,
     Instant nextAfter,
-    int size,
-    long totalElements,
-    boolean hasNext
+    Integer size,
+    Long totalElements,
+    Boolean hasNext
 ) {
 
 }

--- a/src/main/java/com/springboot/monew/interest/dto/response/InterestDto.java
+++ b/src/main/java/com/springboot/monew/interest/dto/response/InterestDto.java
@@ -8,8 +8,8 @@ public record InterestDto(
     UUID id,
     String name,
     List<String> keywords,
-    long subscriberCount,
-    boolean subscribedByMe
+    Long subscriberCount,
+    Boolean subscribedByMe
 ) {
 
 }

--- a/src/main/java/com/springboot/monew/interest/dto/response/SubscriptionDto.java
+++ b/src/main/java/com/springboot/monew/interest/dto/response/SubscriptionDto.java
@@ -10,7 +10,7 @@ public record SubscriptionDto(
     UUID interestId,
     String interestName,
     List<String> interestKeywords,
-    long interestSubscriberCount,
+    Long interestSubscriberCount,
     Instant createdAt
 ) {
 

--- a/src/test/java/com/springboot/monew/interest/controller/InterestControllerTest.java
+++ b/src/test/java/com/springboot/monew/interest/controller/InterestControllerTest.java
@@ -63,13 +63,13 @@ class InterestControllerTest {
         null,
         10
     );
-    InterestDto interestDto = new InterestDto(UUID.randomUUID(), "economy", List.of("macro"), 3, true);
+    InterestDto interestDto = new InterestDto(UUID.randomUUID(), "economy", List.of("macro"), 3L, true);
     CursorPageResponseInterestDto response = new CursorPageResponseInterestDto(
         List.of(interestDto),
         null,
         null,
         1,
-        1,
+        1L,
         false
     );
 
@@ -166,7 +166,7 @@ class InterestControllerTest {
     // given
     UUID interestId = UUID.randomUUID();
     InterestRegisterRequest request = new InterestRegisterRequest("금융", List.of("주식", "채권"));
-    InterestDto response = new InterestDto(interestId, "금융", List.of("주식", "채권"), 0, false);
+    InterestDto response = new InterestDto(interestId, "금융", List.of("주식", "채권"), 0L, false);
 
     given(interestService.create(any(InterestRegisterRequest.class))).willReturn(response);
 
@@ -226,7 +226,7 @@ class InterestControllerTest {
     // given
     UUID interestId = UUID.randomUUID();
     InterestUpdateRequest request = new InterestUpdateRequest(List.of("ETF", "채권"));
-    InterestDto response = new InterestDto(interestId, "금융", List.of("ETF", "채권"), 7, false);
+    InterestDto response = new InterestDto(interestId, "금융", List.of("ETF", "채권"), 7L, false);
 
     given(interestService.update(eq(interestId), any(InterestUpdateRequest.class))).willReturn(response);
 

--- a/src/test/java/com/springboot/monew/interest/controller/InterestControllerTest.java
+++ b/src/test/java/com/springboot/monew/interest/controller/InterestControllerTest.java
@@ -1,0 +1,352 @@
+package com.springboot.monew.interest.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.springboot.monew.interest.dto.request.InterestPageRequest;
+import com.springboot.monew.interest.dto.request.InterestRegisterRequest;
+import com.springboot.monew.interest.dto.request.InterestUpdateRequest;
+import com.springboot.monew.interest.dto.response.CursorPageResponseInterestDto;
+import com.springboot.monew.interest.dto.response.InterestDto;
+import com.springboot.monew.interest.dto.response.SubscriptionDto;
+import com.springboot.monew.interest.entity.InterestDirection;
+import com.springboot.monew.interest.entity.InterestOrderBy;
+import com.springboot.monew.interest.service.InterestService;
+import com.springboot.monew.interest.service.SubscriptionService;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(InterestController.class)
+class InterestControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @MockitoBean
+  private InterestService interestService;
+
+  @MockitoBean
+  private SubscriptionService subscriptionService;
+
+  @Test
+  @DisplayName("관심사 목록을 조회할 수 있다")
+  void list_ReturnsInterestPage_WhenValidRequest() throws Exception {
+    // given
+    UUID userId = UUID.randomUUID();
+    InterestPageRequest request = new InterestPageRequest(
+        "eco",
+        InterestOrderBy.name,
+        InterestDirection.ASC,
+        null,
+        null,
+        10
+    );
+    InterestDto interestDto = new InterestDto(UUID.randomUUID(), "economy", List.of("macro"), 3, true);
+    CursorPageResponseInterestDto response = new CursorPageResponseInterestDto(
+        List.of(interestDto),
+        null,
+        null,
+        1,
+        1,
+        false
+    );
+
+    given(interestService.list(request, userId)).willReturn(response);
+
+    // when
+    mockMvc.perform(get("/api/interests")
+            .header("Monew-Request-User-ID", userId)
+            .param("keyword", "eco")
+            .param("orderBy", "name")
+            .param("direction", "ASC")
+            .param("limit", "10"))
+        // then
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content[0].name").value("economy"))
+        .andExpect(jsonPath("$.content[0].keywords[0]").value("macro"))
+        .andExpect(jsonPath("$.content[0].subscriberCount").value(3))
+        .andExpect(jsonPath("$.content[0].subscribedByMe").value(true))
+        .andExpect(jsonPath("$.size").value(1))
+        .andExpect(jsonPath("$.hasNext").value(false));
+
+    verify(interestService).list(request, userId);
+  }
+
+  @Test
+  @DisplayName("사용자 요청 헤더가 없으면 관심사 목록 조회에 실패한다")
+  void list_ReturnsUnauthorized_WhenRequestUserIdHeaderIsMissing() throws Exception {
+    // given
+    String orderBy = "name";
+    String direction = "ASC";
+    String limit = "10";
+
+    // when
+    mockMvc.perform(get("/api/interests")
+            .param("orderBy", orderBy)
+            .param("direction", direction)
+            .param("limit", limit))
+        // then
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.status").value(401));
+
+    verify(interestService, never()).list(any(), any());
+  }
+
+  @Test
+  @DisplayName("limit가 0이면 관심사 목록 조회에 실패한다")
+  void list_ReturnsBadRequest_WhenLimitIsZero() throws Exception {
+    // given
+    UUID userId = UUID.randomUUID();
+    String orderBy = "name";
+    String direction = "ASC";
+    String limit = "0";
+
+    // when
+    mockMvc.perform(get("/api/interests")
+            .header("Monew-Request-User-ID", userId)
+            .param("orderBy", orderBy)
+            .param("direction", direction)
+            .param("limit", limit))
+        // then
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.status").value(400))
+        .andExpect(jsonPath("$.details.limit").isArray());
+
+    verify(interestService, never()).list(any(), any());
+  }
+
+  @Test
+  @DisplayName("limit가 최대 허용값을 초과하면 관심사 목록 조회에 실패한다")
+  void list_ReturnsBadRequest_WhenLimitExceedsMaximum() throws Exception {
+    // given
+    UUID userId = UUID.randomUUID();
+    String orderBy = "name";
+    String direction = "ASC";
+    String limit = "101";
+
+    // when
+    mockMvc.perform(get("/api/interests")
+            .header("Monew-Request-User-ID", userId)
+            .param("orderBy", orderBy)
+            .param("direction", direction)
+            .param("limit", limit))
+        // then
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.status").value(400))
+        .andExpect(jsonPath("$.details.limit").isArray());
+
+    verify(interestService, never()).list(any(), any());
+  }
+
+  @Test
+  @DisplayName("관심사를 생성할 수 있다")
+  void create_ReturnsCreatedInterest_WhenValidRequest() throws Exception {
+    // given
+    UUID interestId = UUID.randomUUID();
+    InterestRegisterRequest request = new InterestRegisterRequest("금융", List.of("주식", "채권"));
+    InterestDto response = new InterestDto(interestId, "금융", List.of("주식", "채권"), 0, false);
+
+    given(interestService.create(any(InterestRegisterRequest.class))).willReturn(response);
+
+    // when
+    mockMvc.perform(post("/api/interests")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        // then
+        .andExpect(status().isCreated())
+        .andExpect(header().string("Location", "/api/interests/" + interestId))
+        .andExpect(jsonPath("$.id").value(interestId.toString()))
+        .andExpect(jsonPath("$.name").value("금융"))
+        .andExpect(jsonPath("$.keywords[0]").value("주식"));
+
+    verify(interestService).create(any(InterestRegisterRequest.class));
+  }
+
+  @Test
+  @DisplayName("관심사 이름이 비어 있으면 생성에 실패한다")
+  void create_ReturnsBadRequest_WhenNameIsBlank() throws Exception {
+    // given
+    InterestRegisterRequest request = new InterestRegisterRequest("", List.of("주식"));
+
+    // when
+    mockMvc.perform(post("/api/interests")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        // then
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.status").value(400))
+        .andExpect(jsonPath("$.details.name").isArray());
+
+    verify(interestService, never()).create(any());
+  }
+
+  @Test
+  @DisplayName("키워드가 비어 있으면 생성에 실패한다")
+  void create_ReturnsBadRequest_WhenKeywordsAreEmpty() throws Exception {
+    // given
+    InterestRegisterRequest request = new InterestRegisterRequest("금융", List.of());
+
+    // when
+    mockMvc.perform(post("/api/interests")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        // then
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.status").value(400))
+        .andExpect(jsonPath("$.details.keywords").isArray());
+
+    verify(interestService, never()).create(any());
+  }
+
+  @Test
+  @DisplayName("관심사를 수정할 수 있다")
+  void update_ReturnsUpdatedInterest_WhenValidRequest() throws Exception {
+    // given
+    UUID interestId = UUID.randomUUID();
+    InterestUpdateRequest request = new InterestUpdateRequest(List.of("ETF", "채권"));
+    InterestDto response = new InterestDto(interestId, "금융", List.of("ETF", "채권"), 7, false);
+
+    given(interestService.update(eq(interestId), any(InterestUpdateRequest.class))).willReturn(response);
+
+    // when
+    mockMvc.perform(patch("/api/interests/{interestId}", interestId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        // then
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(interestId.toString()))
+        .andExpect(jsonPath("$.subscriberCount").value(7));
+
+    verify(interestService).update(eq(interestId), any(InterestUpdateRequest.class));
+  }
+
+  @Test
+  @DisplayName("수정 요청의 키워드가 비어 있으면 수정에 실패한다")
+  void update_ReturnsBadRequest_WhenKeywordsAreEmpty() throws Exception {
+    // given
+    UUID interestId = UUID.randomUUID();
+    InterestUpdateRequest request = new InterestUpdateRequest(List.of());
+
+    // when
+    mockMvc.perform(patch("/api/interests/{interestId}", interestId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        // then
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.status").value(400))
+        .andExpect(jsonPath("$.details.keywords").isArray());
+
+    verify(interestService, never()).update(eq(interestId), any());
+  }
+
+  @Test
+  @DisplayName("관심사를 삭제할 수 있다")
+  void delete_ReturnsNoContent_WhenInterestExists() throws Exception {
+    // given
+    UUID interestId = UUID.randomUUID();
+
+    // when
+    mockMvc.perform(delete("/api/interests/{interestId}", interestId))
+        // then
+        .andExpect(status().isNoContent());
+
+    verify(interestService).delete(interestId);
+  }
+
+  @Test
+  @DisplayName("관심사를 구독할 수 있다")
+  void subscribe_ReturnsSubscriptionDto_WhenValidRequest() throws Exception {
+    // given
+    UUID interestId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+    SubscriptionDto response = new SubscriptionDto(
+        UUID.randomUUID(),
+        interestId,
+        "금융",
+        List.of("주식"),
+        3L,
+        Instant.parse("2026-04-20T00:00:00Z")
+    );
+
+    given(subscriptionService.subscribe(interestId, userId)).willReturn(response);
+
+    // when
+    mockMvc.perform(post("/api/interests/{interestId}/subscriptions", interestId)
+            .header("Monew-Request-User-ID", userId))
+        // then
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.interestId").value(interestId.toString()))
+        .andExpect(jsonPath("$.interestName").value("금융"))
+        .andExpect(jsonPath("$.interestSubscriberCount").value(3));
+
+    verify(subscriptionService).subscribe(interestId, userId);
+  }
+
+  @Test
+  @DisplayName("사용자 요청 헤더가 없으면 관심사 구독에 실패한다")
+  void subscribe_ReturnsUnauthorized_WhenRequestUserIdHeaderIsMissing() throws Exception {
+    // given
+    UUID interestId = UUID.randomUUID();
+
+    // when
+    mockMvc.perform(post("/api/interests/{interestId}/subscriptions", interestId))
+        // then
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.status").value(401));
+
+    verify(subscriptionService, never()).subscribe(any(), any());
+  }
+
+  @Test
+  @DisplayName("관심사 구독을 취소할 수 있다")
+  void unsubscribe_ReturnsNoContent_WhenValidRequest() throws Exception {
+    // given
+    UUID interestId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+
+    // when
+    mockMvc.perform(delete("/api/interests/{interestId}/subscriptions", interestId)
+            .header("Monew-Request-User-ID", userId))
+        // then
+        .andExpect(status().isNoContent());
+
+    verify(subscriptionService).unsubscribe(interestId, userId);
+  }
+
+  @Test
+  @DisplayName("사용자 요청 헤더가 없으면 관심사 구독 취소에 실패한다")
+  void unsubscribe_ReturnsUnauthorized_WhenRequestUserIdHeaderIsMissing() throws Exception {
+    // given
+    UUID interestId = UUID.randomUUID();
+
+    // when
+    mockMvc.perform(delete("/api/interests/{interestId}/subscriptions", interestId))
+        // then
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.status").value(401));
+
+    verify(subscriptionService, never()).unsubscribe(any(), any());
+  }
+}

--- a/src/test/java/com/springboot/monew/interest/repository/InterestRepositoryTest.java
+++ b/src/test/java/com/springboot/monew/interest/repository/InterestRepositoryTest.java
@@ -1,0 +1,620 @@
+package com.springboot.monew.interest.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.springboot.monew.common.repository.BaseRepositoryTest;
+import com.springboot.monew.interest.dto.request.InterestPageRequest;
+import com.springboot.monew.interest.entity.Interest;
+import com.springboot.monew.interest.entity.InterestDirection;
+import com.springboot.monew.interest.entity.InterestKeyword;
+import com.springboot.monew.interest.entity.InterestOrderBy;
+import com.springboot.monew.interest.entity.Keyword;
+import java.time.Instant;
+import java.util.List;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class InterestRepositoryTest extends BaseRepositoryTest {
+
+  @Autowired
+  private InterestRepository interestRepository;
+
+  @Test
+  @DisplayName("관심사를 이름 오름차순으로 조회할 수 있다")
+  void findInterests_ReturnsInterestsSortedByNameAsc_WhenOrderByNameAsc() {
+    // given
+    saveInterest("Gamma");
+    saveInterest("Alpha");
+    saveInterest("Beta");
+    flushAndClear();
+
+    // when
+    List<Interest> result = interestRepository.findInterests(new InterestPageRequest(
+        null,
+        InterestOrderBy.name,
+        InterestDirection.ASC,
+        null,
+        null,
+        10
+    ));
+
+    // then
+    assertThat(result).extracting(Interest::getName).containsExactly("Alpha", "Beta", "Gamma");
+  }
+
+  @Test
+  @DisplayName("관심사를 이름 내림차순으로 조회할 수 있다")
+  void findInterests_ReturnsInterestsSortedByNameDesc_WhenOrderByNameDesc() {
+    // given
+    saveInterest("Gamma");
+    saveInterest("Alpha");
+    saveInterest("Beta");
+    flushAndClear();
+
+    // when
+    List<Interest> result = interestRepository.findInterests(new InterestPageRequest(
+        null,
+        InterestOrderBy.name,
+        InterestDirection.DESC,
+        null,
+        null,
+        10
+    ));
+
+    // then
+    assertThat(result).extracting(Interest::getName).containsExactly("Gamma", "Beta", "Alpha");
+  }
+
+  @Test
+  @DisplayName("관심사를 구독자 수 오름차순으로 조회할 수 있다")
+  void findInterests_ReturnsInterestsSortedBySubscriberCountAsc_WhenOrderBySubscriberCountAsc() {
+    // given
+    Interest low = saveInterest("low");
+    setSubscriberCount(low, 1);
+    Interest middle = saveInterest("middle");
+    setSubscriberCount(middle, 3);
+    Interest high = saveInterest("high");
+    setSubscriberCount(high, 5);
+    flushAndClear();
+
+    // when
+    List<Interest> result = interestRepository.findInterests(new InterestPageRequest(
+        null,
+        InterestOrderBy.subscriberCount,
+        InterestDirection.ASC,
+        null,
+        null,
+        10
+    ));
+
+    // then
+    assertThat(result).extracting(Interest::getName).containsExactly("low", "middle", "high");
+  }
+
+  @Test
+  @DisplayName("관심사를 구독자 수 내림차순으로 조회할 수 있다")
+  void findInterests_ReturnsInterestsSortedBySubscriberCountDesc_WhenOrderBySubscriberCountDesc() {
+    // given
+    Interest low = saveInterest("low-desc");
+    setSubscriberCount(low, 1);
+    Interest middle = saveInterest("middle-desc");
+    setSubscriberCount(middle, 3);
+    Interest high = saveInterest("high-desc");
+    setSubscriberCount(high, 5);
+    flushAndClear();
+
+    // when
+    List<Interest> result = interestRepository.findInterests(new InterestPageRequest(
+        null,
+        InterestOrderBy.subscriberCount,
+        InterestDirection.DESC,
+        null,
+        null,
+        10
+    ));
+
+    // then
+    assertThat(result).extracting(Interest::getName)
+        .containsExactly("high-desc", "middle-desc", "low-desc");
+  }
+
+  @Test
+  @DisplayName("관심사 이름으로 검색할 수 있다")
+  void findInterests_ReturnsMatchedInterests_WhenKeywordMatchesInterestName() {
+    // given
+    saveInterest("finance");
+    saveInterest("technology");
+    saveInterest("sports");
+    flushAndClear();
+
+    // when
+    List<Interest> result = interestRepository.findInterests(new InterestPageRequest(
+        "fin",
+        InterestOrderBy.name,
+        InterestDirection.ASC,
+        null,
+        null,
+        10
+    ));
+
+    // then
+    assertThat(result).extracting(Interest::getName).containsExactly("finance");
+  }
+
+  @Test
+  @DisplayName("키워드 이름으로 검색할 수 있다")
+  void findInterests_ReturnsMatchedInterests_WhenKeywordMatchesKeywordName() {
+    // given
+    Interest finance = saveInterest("finance-keyword");
+    linkKeyword(finance, "economy");
+    Interest tech = saveInterest("tech-keyword");
+    linkKeyword(tech, "ai");
+    flushAndClear();
+
+    // when
+    List<Interest> result = interestRepository.findInterests(new InterestPageRequest(
+        "eco",
+        InterestOrderBy.name,
+        InterestDirection.ASC,
+        null,
+        null,
+        10
+    ));
+
+    // then
+    assertThat(result).extracting(Interest::getName).containsExactly("finance-keyword");
+  }
+
+  @Test
+  @DisplayName("검색어가 비어 있으면 전체 관심사를 조회한다")
+  void findInterests_ReturnsAllInterests_WhenKeywordIsBlank() {
+    // given
+    saveInterest("alpha");
+    saveInterest("beta");
+    saveInterest("gamma");
+    flushAndClear();
+
+    // when
+    List<Interest> result = interestRepository.findInterests(new InterestPageRequest(
+        "   ",
+        InterestOrderBy.name,
+        InterestDirection.ASC,
+        null,
+        null,
+        10
+    ));
+
+    // then
+    assertThat(result).extracting(Interest::getName).containsExactly("alpha", "beta", "gamma");
+  }
+
+  @Test
+  @DisplayName("커서 이후의 관심사 목록을 조회할 수 있다")
+  void findInterests_ReturnsNextPage_WhenCursorExists() {
+    // given
+    Interest alpha = saveInterest("alpha");
+    saveInterest("beta");
+    saveInterest("gamma");
+    flushAndClear();
+
+    // when
+    Instant alphaCreatedAt = interestRepository.findById(alpha.getId()).orElseThrow()
+        .getCreatedAt();
+    List<Interest> result = interestRepository.findInterests(new InterestPageRequest(
+        null,
+        InterestOrderBy.name,
+        InterestDirection.ASC,
+        "alpha",
+        alphaCreatedAt,
+        10
+    ));
+
+    // then
+    assertThat(result).extracting(Interest::getName).containsExactly("beta", "gamma");
+  }
+
+  @Test
+  @DisplayName("이름 내림차순 커서 이후의 관심사 목록을 조회할 수 있다")
+  void findInterests_ReturnsNextPage_WhenOrderByNameDescAndCursorExists() {
+    // given
+    saveInterest("Alpha");
+    Interest beta = saveInterest("Beta");
+    saveInterest("Gamma");
+    flushAndClear();
+
+    Instant betaCreatedAt = interestRepository.findById(beta.getId()).orElseThrow().getCreatedAt();
+
+    InterestPageRequest request = new InterestPageRequest(
+        null,
+        InterestOrderBy.name,
+        InterestDirection.DESC,
+        "Beta",
+        betaCreatedAt,
+        10
+    );
+
+    // when
+    List<Interest> result = interestRepository.findInterests(request);
+
+    // then
+    assertThat(result)
+        .extracting(Interest::getName)
+        .containsExactly("Alpha");
+  }
+
+  @Test
+  @DisplayName("이름 커서만 있고 after가 없으면 이름 기준으로 다음 페이지를 조회한다")
+  void findInterests_ReturnsNextPage_WhenOrderByNameAndAfterIsNull() {
+    // given
+    saveInterest("Alpha");
+    saveInterest("Beta");
+    saveInterest("Gamma");
+    flushAndClear();
+
+    InterestPageRequest request = new InterestPageRequest(
+        null,
+        InterestOrderBy.name,
+        InterestDirection.ASC,
+        "Alpha",
+        null,
+        10
+    );
+
+    // when
+    List<Interest> result = interestRepository.findInterests(request);
+
+    // then
+    assertThat(result)
+        .extracting(Interest::getName)
+        .containsExactly("Beta", "Gamma");
+  }
+
+  @Test
+  @DisplayName("구독자 수 커서 이후의 관심사 목록을 조회할 수 있다")
+  void findInterests_ReturnsNextPage_WhenSubscriberCountCursorExists() {
+    // given
+    Interest high = saveInterest("high");
+    setSubscriberCount(high, 5);
+    Interest olderSameCount = saveInterest("older");
+    setSubscriberCount(olderSameCount, 3);
+    pause();
+    Interest newerSameCount = saveInterest("newer");
+    setSubscriberCount(newerSameCount, 3);
+    Interest low = saveInterest("low");
+    setSubscriberCount(low, 1);
+    flushAndClear();
+
+    // when
+    Instant newerCreatedAt = interestRepository.findById(newerSameCount.getId()).orElseThrow()
+        .getCreatedAt();
+    List<Interest> result = interestRepository.findInterests(new InterestPageRequest(
+        null,
+        InterestOrderBy.subscriberCount,
+        InterestDirection.DESC,
+        "3",
+        newerCreatedAt,
+        10
+    ));
+
+    // then
+    assertThat(result).extracting(Interest::getName).containsExactly("older", "low");
+  }
+
+  @Test
+  @DisplayName("생성 시각이 포함된 구독자 수 커서 이후의 관심사 목록을 조회할 수 있다")
+  void findInterests_ReturnsNextPage_WhenSubscriberCountCursorContainsCreatedAt() {
+    // given
+    Interest high = saveInterest("high-cursor");
+    setSubscriberCount(high, 5);
+    Interest olderSameCount = saveInterest("older-cursor");
+    setSubscriberCount(olderSameCount, 3);
+    pause();
+    Interest newerSameCount = saveInterest("newer-cursor");
+    setSubscriberCount(newerSameCount, 3);
+    Interest low = saveInterest("low-cursor");
+    setSubscriberCount(low, 1);
+    flushAndClear();
+
+    Instant newerCreatedAt = interestRepository.findById(newerSameCount.getId()).orElseThrow()
+        .getCreatedAt();
+    String cursor = "3|" + newerCreatedAt;
+
+    // when
+    List<Interest> result = interestRepository.findInterests(new InterestPageRequest(
+        null,
+        InterestOrderBy.subscriberCount,
+        InterestDirection.DESC,
+        cursor,
+        null,
+        10
+    ));
+
+    // then
+    assertThat(result).extracting(Interest::getName)
+        .containsExactly("older-cursor", "low-cursor");
+  }
+
+  @Test
+  @DisplayName("구독자 수 오름차순 커서 이후의 관심사 목록을 조회할 수 있다")
+  void findInterests_ReturnsNextPage_WhenOrderBySubscriberCountAscAndCursorExists() {
+    // given
+    Interest low = saveInterest("low-asc-cursor");
+    setSubscriberCount(low, 1);
+
+    Interest olderSameCount = saveInterest("older-asc-cursor");
+    setSubscriberCount(olderSameCount, 3);
+
+    pause();
+
+    Interest newerSameCount = saveInterest("newer-asc-cursor");
+    setSubscriberCount(newerSameCount, 3);
+
+    Interest high = saveInterest("high-asc-cursor");
+    setSubscriberCount(high, 5);
+
+    flushAndClear();
+
+    Instant olderCreatedAt = interestRepository.findById(olderSameCount.getId())
+        .orElseThrow()
+        .getCreatedAt();
+
+    InterestPageRequest request = new InterestPageRequest(
+        null,
+        InterestOrderBy.subscriberCount,
+        InterestDirection.ASC,
+        "3",
+        olderCreatedAt,
+        10
+    );
+
+    // when
+    List<Interest> result = interestRepository.findInterests(request);
+
+    // then
+    assertThat(result)
+        .extracting(Interest::getName)
+        .containsExactly("newer-asc-cursor", "high-asc-cursor");
+  }
+
+  @Test
+  @DisplayName("구독자 수 커서만 있고 after가 없으면 구독자 수 기준으로 다음 페이지를 조회한다")
+  void findInterests_ReturnsNextPage_WhenOrderBySubscriberCountAndAfterIsNull() {
+    // given
+    Interest low = saveInterest("low-asc-no-after");
+    setSubscriberCount(low, 1);
+
+    Interest middle = saveInterest("middle-asc-no-after");
+    setSubscriberCount(middle, 3);
+
+    Interest high = saveInterest("high-asc-no-after");
+    setSubscriberCount(high, 5);
+
+    flushAndClear();
+
+    InterestPageRequest request = new InterestPageRequest(
+        null,
+        InterestOrderBy.subscriberCount,
+        InterestDirection.ASC,
+        "3",
+        null,
+        10
+    );
+
+    // when
+    List<Interest> result = interestRepository.findInterests(request);
+
+    // then
+    assertThat(result)
+        .extracting(Interest::getName)
+        .containsExactly("high-asc-no-after");
+  }
+
+  @Test
+  @DisplayName("커서가 공백이면 첫 페이지를 조회한다")
+  void findInterests_ReturnsFirstPage_WhenCursorIsBlank() {
+    // given
+    saveInterest("Alpha-blank-cursor");
+    saveInterest("Beta-blank-cursor");
+    saveInterest("Gamma-blank-cursor");
+    flushAndClear();
+
+    InterestPageRequest request = new InterestPageRequest(
+        null,
+        InterestOrderBy.name,
+        InterestDirection.ASC,
+        "   ",
+        null,
+        10
+    );
+
+    // when
+    List<Interest> result = interestRepository.findInterests(request);
+
+    // then
+    assertThat(result)
+        .extracting(Interest::getName)
+        .containsExactly("Alpha-blank-cursor", "Beta-blank-cursor", "Gamma-blank-cursor");
+  }
+
+  @Test
+  @DisplayName("잘못된 구독자 수 커서를 전달하면 예외가 발생한다")
+  void findInterests_ThrowsException_WhenSubscriberCountCursorIsInvalid() {
+    // given
+    InterestPageRequest request = new InterestPageRequest(
+        null,
+        InterestOrderBy.subscriberCount,
+        InterestDirection.ASC,
+        "not-a-number",
+        null,
+        10
+    );
+
+    // when
+    ThrowingCallable action = () -> interestRepository.findInterests(request);
+
+    // then
+    assertThatThrownBy(action)
+        .isInstanceOf(InvalidDataAccessApiUsageException.class)
+        .hasMessageContaining("Invalid subscriberCount cursor");
+  }
+
+  @Test
+  @DisplayName("구독자 수 커서의 생성 시각 형식이 잘못되면 예외가 발생한다")
+  void findInterests_ThrowsException_WhenSubscriberCountCursorCreatedAtIsInvalid() {
+    // given
+    InterestPageRequest request = new InterestPageRequest(
+        null,
+        InterestOrderBy.subscriberCount,
+        InterestDirection.DESC,
+        "3|invalid-created-at",
+        null,
+        10
+    );
+
+    // when
+    ThrowingCallable action = () -> interestRepository.findInterests(request);
+
+    // then
+    assertThatThrownBy(action)
+        .isInstanceOf(InvalidDataAccessApiUsageException.class)
+        .hasMessageContaining("Invalid subscriberCount cursor");
+  }
+
+  @Test
+  @DisplayName("검색 조건에 맞는 관심사 수를 조회할 수 있다")
+  void countInterests_ReturnsMatchedCount_WhenKeywordExists() {
+    // given
+    Interest first = saveInterest("eco focus");
+    linkKeyword(first, "eco");
+    linkKeyword(first, "economy");
+    Interest second = saveInterest("finance");
+    linkKeyword(second, "eco system");
+    Interest third = saveInterest("sports");
+    linkKeyword(third, "baseball");
+    flushAndClear();
+
+    // when
+    long result = interestRepository.countInterests("eco");
+
+    // then
+    assertThat(result).isEqualTo(2L);
+  }
+
+  @Test
+  @DisplayName("검색어가 비어 있으면 전체 관심사 수를 조회한다")
+  void countInterests_ReturnsAllCount_WhenKeywordIsBlank() {
+    // given
+    saveInterest("alpha-count");
+    saveInterest("beta-count");
+    saveInterest("gamma-count");
+    flushAndClear();
+
+    // when
+    long result = interestRepository.countInterests("   ");
+
+    // then
+    assertThat(result).isEqualTo(3L);
+  }
+
+  @Test
+  @DisplayName("관심사의 구독자 수를 증가시킬 수 있다")
+  void incrementSubscriberCount_IncreasesSubscriberCount_WhenInterestExists() {
+    // given
+    Interest interest = saveInterest("increase");
+    flushAndClear();
+
+    // when
+    int updated = interestRepository.incrementSubscriberCount(interest.getId());
+    flushAndClear();
+
+    // then
+    assertThat(updated).isEqualTo(1);
+    assertThat(interestRepository.findSubscriberCountById(interest.getId())).isEqualTo(1L);
+  }
+
+  @Test
+  @DisplayName("관심사의 구독자 수를 감소시킬 수 있다")
+  void decrementSubscriberCount_DecreasesSubscriberCount_WhenSubscriberCountIsPositive() {
+    // given
+    Interest interest = saveInterest("decrease");
+    setSubscriberCount(interest, 2);
+    flushAndClear();
+
+    // when
+    int updated = interestRepository.decrementSubscriberCount(interest.getId());
+    flushAndClear();
+
+    // then
+    assertThat(updated).isEqualTo(1);
+    assertThat(interestRepository.findSubscriberCountById(interest.getId())).isEqualTo(1L);
+  }
+
+  @Test
+  @DisplayName("관심사의 구독자 수는 0 미만으로 감소하지 않는다")
+  void decrementSubscriberCount_KeepsZero_WhenSubscriberCountIsZero() {
+    // given
+    Interest interest = saveInterest("zero");
+    flushAndClear();
+
+    // when
+    int updated = interestRepository.decrementSubscriberCount(interest.getId());
+    flushAndClear();
+
+    // then
+    assertThat(updated).isEqualTo(1);
+    assertThat(interestRepository.findSubscriberCountById(interest.getId())).isZero();
+  }
+
+  @Test
+  @DisplayName("관심사의 구독자 수를 조회할 수 있다")
+  void findSubscriberCountById_ReturnsSubscriberCount_WhenInterestExists() {
+    // given
+    Interest interest = saveInterest("subscriber-count");
+    setSubscriberCount(interest, 7);
+    flushAndClear();
+
+    // when
+    Long result = interestRepository.findSubscriberCountById(interest.getId());
+
+    // then
+    assertThat(result).isEqualTo(7L);
+  }
+
+  private Interest saveInterest(String name) {
+    Interest interest = new Interest(name);
+    em.persist(interest);
+    em.flush();
+    return interest;
+  }
+
+  private Keyword saveKeyword(String name) {
+    Keyword keyword = new Keyword(name);
+    em.persist(keyword);
+    em.flush();
+    return keyword;
+  }
+
+  private void linkKeyword(Interest interest, String keywordName) {
+    em.persist(new InterestKeyword(interest, saveKeyword(keywordName)));
+    em.flush();
+  }
+
+  private void setSubscriberCount(Interest interest, long subscriberCount) {
+    ReflectionTestUtils.setField(interest, "subscriberCount", subscriberCount);
+    em.flush();
+  }
+
+  private void pause() {
+    try {
+      Thread.sleep(20);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("sleep interrupted", e);
+    }
+  }
+}

--- a/src/test/java/com/springboot/monew/interest/service/InterestServiceTest.java
+++ b/src/test/java/com/springboot/monew/interest/service/InterestServiceTest.java
@@ -684,18 +684,24 @@ class InterestServiceTest {
   void delete_DeletesInterest_WhenInterestExists() {
     // given
     UUID interestId = UUID.randomUUID();
-    Interest interest = interest(interestId, "경제", Instant.parse("2026-04-20T00:00:00Z"), 0);
+    UUID keywordId = UUID.randomUUID();
+
+    Interest interest = interest(interestId, "경제", Instant.parse("2026-04-20T00:00:00Z"), 1);
+    Keyword keyword = keyword(keywordId, "환율");
+    InterestKeyword interestKeyword = new InterestKeyword(interest, keyword);
+    List<InterestKeyword> interestKeywords = List.of(interestKeyword);
 
     given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
-    given(interestKeywordRepository.findAllByInterestWithKeyword(interest)).willReturn(List.of());
+    given(interestKeywordRepository.findAllByInterestWithKeyword(interest))
+        .willReturn(interestKeywords);
 
     // when
     interestService.delete(interestId);
 
     // then
-    verify(interestKeywordRepository).deleteAll(List.of());
+    verify(interestKeywordRepository).deleteAll(interestKeywords);
     verify(interestRepository).delete(interest);
-    verify(keywordRepository, never()).deleteOrphanKeywordsByIds(any());
+    verify(keywordRepository).deleteOrphanKeywordsByIds(List.of(keywordId));
   }
 
   @Test

--- a/src/test/java/com/springboot/monew/interest/service/InterestServiceTest.java
+++ b/src/test/java/com/springboot/monew/interest/service/InterestServiceTest.java
@@ -1,0 +1,775 @@
+package com.springboot.monew.interest.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.springboot.monew.interest.dto.request.InterestPageRequest;
+import com.springboot.monew.interest.dto.request.InterestRegisterRequest;
+import com.springboot.monew.interest.dto.request.InterestUpdateRequest;
+import com.springboot.monew.interest.dto.response.CursorPageResponseInterestDto;
+import com.springboot.monew.interest.dto.response.InterestDto;
+import com.springboot.monew.interest.entity.Interest;
+import com.springboot.monew.interest.entity.InterestDirection;
+import com.springboot.monew.interest.entity.InterestKeyword;
+import com.springboot.monew.interest.entity.InterestOrderBy;
+import com.springboot.monew.interest.entity.Keyword;
+import com.springboot.monew.interest.exception.InterestErrorCode;
+import com.springboot.monew.interest.exception.InterestException;
+import com.springboot.monew.interest.mapper.InterestDtoMapper;
+import com.springboot.monew.interest.repository.InterestKeywordRepository;
+import com.springboot.monew.interest.repository.InterestRepository;
+import com.springboot.monew.interest.repository.KeywordRepository;
+import com.springboot.monew.interest.repository.SubscriptionRepository;
+import com.springboot.monew.users.entity.User;
+import com.springboot.monew.users.exception.UserErrorCode;
+import com.springboot.monew.users.exception.UserException;
+import com.springboot.monew.users.repository.UserRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class InterestServiceTest {
+
+  @Mock
+  private InterestRepository interestRepository;
+
+  @Mock
+  private KeywordRepository keywordRepository;
+
+  @Mock
+  private InterestKeywordRepository interestKeywordRepository;
+
+  @Mock
+  private SubscriptionRepository subscriptionRepository;
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private InterestDtoMapper interestDtoMapper;
+
+  @InjectMocks
+  private InterestService interestService;
+
+  @Test
+  @DisplayName("활성 사용자는 관심사 목록을 조회할 수 있다")
+  void list_ReturnsInterestPage_WhenUserIsActive() {
+    // given
+    UUID userId = UUID.randomUUID();
+    InterestPageRequest request = new InterestPageRequest(
+        "eco",
+        InterestOrderBy.name,
+        InterestDirection.ASC,
+        null,
+        null,
+        10
+    );
+    User user = new User("user@example.com", "tester", "password");
+    Interest interest = interest(
+        UUID.randomUUID(),
+        "economy",
+        Instant.parse("2026-04-20T00:00:00Z"),
+        5
+    );
+    InterestKeyword interestKeyword = new InterestKeyword(interest,
+        keyword(UUID.randomUUID(), "macro"));
+    InterestDto interestDto = new InterestDto(interest.getId(), "economy", List.of("macro"), 5,
+        true);
+
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+    given(interestRepository.findInterests(request)).willReturn(List.of(interest));
+    given(interestKeywordRepository.findAllByInterestIdInWithKeyword(List.of(interest.getId())))
+        .willReturn(List.of(interestKeyword));
+    given(subscriptionRepository.findInterestIdsByUserIdAndInterestIdIn(userId,
+        List.of(interest.getId())))
+        .willReturn(List.of(interest.getId()));
+    given(interestDtoMapper.toInterestDto(interest, List.of("macro"), true))
+        .willReturn(interestDto);
+    given(interestRepository.countInterests("eco")).willReturn(1L);
+
+    // when
+    CursorPageResponseInterestDto result = interestService.list(request, userId);
+
+    // then
+    assertThat(result.content()).containsExactly(interestDto);
+    assertThat(result.nextCursor()).isNull();
+    assertThat(result.nextAfter()).isNull();
+    assertThat(result.size()).isEqualTo(1);
+    assertThat(result.totalElements()).isEqualTo(1L);
+    assertThat(result.hasNext()).isFalse();
+  }
+
+  @Test
+  @DisplayName("조회 결과가 limit를 초과하면 다음 커서가 포함된다")
+  void list_ReturnsCursorPageWithNextCursor_WhenHasNextTrue() {
+    // given
+    UUID userId = UUID.randomUUID();
+    InterestPageRequest request = new InterestPageRequest(
+        null,
+        InterestOrderBy.name,
+        InterestDirection.ASC,
+        null,
+        null,
+        2
+    );
+    User user = new User("user@example.com", "tester", "password");
+    Interest first = interest(
+        UUID.randomUUID(),
+        "economy",
+        Instant.parse("2026-04-20T00:00:00Z"),
+        1
+    );
+    Interest second = interest(
+        UUID.randomUUID(),
+        "finance",
+        Instant.parse("2026-04-21T00:00:00Z"),
+        2
+    );
+    Interest third = interest(
+        UUID.randomUUID(),
+        "market",
+        Instant.parse("2026-04-22T00:00:00Z"),
+        3
+    );
+    InterestDto firstDto = new InterestDto(first.getId(), "economy", List.of(), 1, false);
+    InterestDto secondDto = new InterestDto(second.getId(), "finance", List.of(), 2, false);
+
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+    given(interestRepository.findInterests(request)).willReturn(List.of(first, second, third));
+    given(interestKeywordRepository.findAllByInterestIdInWithKeyword(
+        List.of(first.getId(), second.getId())))
+        .willReturn(List.of());
+    given(subscriptionRepository.findInterestIdsByUserIdAndInterestIdIn(userId,
+        List.of(first.getId(), second.getId())))
+        .willReturn(List.of());
+    given(interestDtoMapper.toInterestDto(first, List.of(), false)).willReturn(firstDto);
+    given(interestDtoMapper.toInterestDto(second, List.of(), false)).willReturn(secondDto);
+    given(interestRepository.countInterests(null)).willReturn(3L);
+
+    // when
+    CursorPageResponseInterestDto result = interestService.list(request, userId);
+
+    // then
+    assertThat(result.content()).containsExactly(firstDto, secondDto);
+    assertThat(result.nextCursor()).isEqualTo("finance");
+    assertThat(result.nextAfter()).isEqualTo(second.getCreatedAt());
+    assertThat(result.size()).isEqualTo(2);
+    assertThat(result.totalElements()).isEqualTo(3L);
+    assertThat(result.hasNext()).isTrue();
+  }
+
+  @Test
+  @DisplayName("구독자 수 정렬 조회 결과가 limit를 초과하면 생성 시각을 포함한 다음 커서가 포함된다")
+  void list_ReturnsSubscriberCountCursorWithCreatedAt_WhenOrderBySubscriberCountAndHasNextTrue() {
+    // given
+    UUID userId = UUID.randomUUID();
+    InterestPageRequest request = new InterestPageRequest(
+        null,
+        InterestOrderBy.subscriberCount,
+        InterestDirection.DESC,
+        null,
+        null,
+        2
+    );
+    User user = new User("user@example.com", "tester", "password");
+    Interest first = interest(
+        UUID.randomUUID(),
+        "popular",
+        Instant.parse("2026-04-20T00:00:00Z"),
+        5
+    );
+    Interest second = interest(
+        UUID.randomUUID(),
+        "middle",
+        Instant.parse("2026-04-21T00:00:00Z"),
+        3
+    );
+    Interest third = interest(
+        UUID.randomUUID(),
+        "low",
+        Instant.parse("2026-04-22T00:00:00Z"),
+        1
+    );
+    InterestDto firstDto = new InterestDto(first.getId(), "popular", List.of(), 5, false);
+    InterestDto secondDto = new InterestDto(second.getId(), "middle", List.of(), 3, false);
+
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+    given(interestRepository.findInterests(request)).willReturn(List.of(first, second, third));
+    given(interestKeywordRepository.findAllByInterestIdInWithKeyword(
+        List.of(first.getId(), second.getId())))
+        .willReturn(List.of());
+    given(subscriptionRepository.findInterestIdsByUserIdAndInterestIdIn(userId,
+        List.of(first.getId(), second.getId())))
+        .willReturn(List.of());
+    given(interestDtoMapper.toInterestDto(first, List.of(), false)).willReturn(firstDto);
+    given(interestDtoMapper.toInterestDto(second, List.of(), false)).willReturn(secondDto);
+    given(interestRepository.countInterests(null)).willReturn(3L);
+
+    // when
+    CursorPageResponseInterestDto result = interestService.list(request, userId);
+
+    // then
+    assertThat(result.content()).containsExactly(firstDto, secondDto);
+    assertThat(result.nextCursor()).isEqualTo("3|2026-04-21T00:00:00Z");
+    assertThat(result.nextAfter()).isEqualTo(second.getCreatedAt());
+    assertThat(result.size()).isEqualTo(2);
+    assertThat(result.totalElements()).isEqualTo(3L);
+    assertThat(result.hasNext()).isTrue();
+  }
+
+  @Test
+  @DisplayName("조회 결과가 없으면 빈 목록을 반환한다")
+  void list_ReturnsEmptyCursorPage_WhenNoInterestsExist() {
+    // given
+    UUID userId = UUID.randomUUID();
+    InterestPageRequest request = new InterestPageRequest(
+        null,
+        InterestOrderBy.subscriberCount,
+        InterestDirection.DESC,
+        null,
+        null,
+        10
+    );
+    User user = new User("user@example.com", "tester", "password");
+
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+    given(interestRepository.findInterests(request)).willReturn(List.of());
+    given(interestRepository.countInterests(null)).willReturn(0L);
+
+    // when
+    CursorPageResponseInterestDto result = interestService.list(request, userId);
+
+    // then
+    assertThat(result.content()).isEmpty();
+    assertThat(result.nextCursor()).isNull();
+    assertThat(result.nextAfter()).isNull();
+    assertThat(result.size()).isZero();
+    assertThat(result.totalElements()).isZero();
+    assertThat(result.hasNext()).isFalse();
+
+    verify(interestKeywordRepository, never()).findAllByInterestIdInWithKeyword(any());
+    verify(subscriptionRepository, never()).findInterestIdsByUserIdAndInterestIdIn(any(), any());
+    verify(interestDtoMapper, never()).toInterestDto(any(), any(), anyBoolean());
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 사용자가 관심사 목록을 조회하면 예외가 발생한다")
+  void list_ThrowsException_WhenUserNotFound() {
+    // given
+    UUID userId = UUID.randomUUID();
+    InterestPageRequest request = new InterestPageRequest(
+        null,
+        InterestOrderBy.name,
+        InterestDirection.ASC,
+        null,
+        null,
+        10
+    );
+
+    given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+    // when
+    ThrowingCallable action = () -> interestService.list(request, userId);
+
+    // then
+    assertThatThrownBy(action)
+        .isInstanceOf(UserException.class)
+        .satisfies(throwable -> {
+          UserException exception = (UserException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("userId", userId));
+        });
+
+    verify(interestRepository, never()).findInterests(any());
+  }
+
+  @Test
+  @DisplayName("삭제된 사용자가 관심사 목록을 조회하면 예외가 발생한다")
+  void list_ThrowsException_WhenUserDeleted() {
+    // given
+    UUID userId = UUID.randomUUID();
+    InterestPageRequest request = new InterestPageRequest(
+        null,
+        InterestOrderBy.name,
+        InterestDirection.ASC,
+        null,
+        null,
+        10
+    );
+    User deletedUser = new User("deleted@example.com", "tester", "password");
+    deletedUser.delete();
+
+    given(userRepository.findById(userId)).willReturn(Optional.of(deletedUser));
+
+    // when
+    ThrowingCallable action = () -> interestService.list(request, userId);
+
+    // then
+    assertThatThrownBy(action)
+        .isInstanceOf(UserException.class)
+        .satisfies(throwable -> {
+          UserException exception = (UserException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("userId", userId));
+        });
+
+    verify(interestRepository, never()).findInterests(any());
+  }
+
+  @Test
+  @DisplayName("관심사를 생성할 수 있다")
+  void create_ReturnsInterestDto_WhenValidRequest() {
+    // given
+    InterestRegisterRequest request = new InterestRegisterRequest("금융", List.of("증권"));
+    Interest savedInterest = interest(
+        UUID.randomUUID(),
+        "금융",
+        Instant.parse("2026-04-20T00:00:00Z"),
+        0
+    );
+    Keyword savedKeyword = keyword(UUID.randomUUID(), "증권");
+    InterestDto expected = new InterestDto(savedInterest.getId(), "금융", List.of("증권"), 0, false);
+
+    given(interestRepository.existsByName("금융")).willReturn(false);
+    given(interestRepository.findAllNames()).willReturn(List.of("경제"));
+    given(interestRepository.save(
+        argThat(interest -> interest != null && interest.getName().equals("금융"))))
+        .willReturn(savedInterest);
+    given(keywordRepository.findByName("증권")).willReturn(Optional.of(savedKeyword));
+    given(interestDtoMapper.toInterestDto(savedInterest, List.of("증권"), false)).willReturn(
+        expected);
+
+    // when
+    InterestDto result = interestService.create(request);
+
+    // then
+    assertThat(result).isEqualTo(expected);
+    verify(interestKeywordRepository).save(any(InterestKeyword.class));
+  }
+
+  @Test
+  @DisplayName("기존 키워드를 재사용하여 관심사를 생성할 수 있다")
+  void create_ReturnsInterestDto_WhenKeywordAlreadyExists() {
+    // given
+    InterestRegisterRequest request = new InterestRegisterRequest("투자", List.of("주식", "채권"));
+    Interest savedInterest = interest(
+        UUID.randomUUID(),
+        "투자",
+        Instant.parse("2026-04-20T00:00:00Z"),
+        0
+    );
+    Keyword firstKeyword = keyword(UUID.randomUUID(), "주식");
+    Keyword secondKeyword = keyword(UUID.randomUUID(), "채권");
+    InterestDto expected = new InterestDto(savedInterest.getId(), "투자", request.keywords(), 0,
+        false);
+
+    given(interestRepository.existsByName("투자")).willReturn(false);
+    given(interestRepository.findAllNames()).willReturn(List.of());
+    given(interestRepository.save(any(Interest.class))).willReturn(savedInterest);
+    given(keywordRepository.findByName("주식")).willReturn(Optional.of(firstKeyword));
+    given(keywordRepository.findByName("채권")).willReturn(Optional.of(secondKeyword));
+    given(interestDtoMapper.toInterestDto(savedInterest, request.keywords(), false)).willReturn(
+        expected);
+
+    // when
+    InterestDto result = interestService.create(request);
+
+    // then
+    assertThat(result).isEqualTo(expected);
+    verify(keywordRepository, never()).saveAndFlush(any(Keyword.class));
+    verify(interestKeywordRepository, times(2)).save(any(InterestKeyword.class));
+  }
+
+  @Test
+  @DisplayName("새 키워드를 생성하여 관심사를 생성할 수 있다")
+  void create_ReturnsInterestDto_WhenKeywordDoesNotExist() {
+    // given
+    InterestRegisterRequest request = new InterestRegisterRequest("부동산", List.of("아파트", "분양"));
+    Interest savedInterest = interest(
+        UUID.randomUUID(),
+        "부동산",
+        Instant.parse("2026-04-20T00:00:00Z"),
+        0
+    );
+    Keyword apartment = keyword(UUID.randomUUID(), "아파트");
+    Keyword sale = keyword(UUID.randomUUID(), "분양");
+    InterestDto expected = new InterestDto(savedInterest.getId(), "부동산", request.keywords(), 0,
+        false);
+
+    given(interestRepository.existsByName("부동산")).willReturn(false);
+    given(interestRepository.findAllNames()).willReturn(List.of("경제"));
+    given(interestRepository.save(any(Interest.class))).willReturn(savedInterest);
+    given(keywordRepository.findByName("아파트")).willReturn(Optional.empty());
+    given(keywordRepository.findByName("분양")).willReturn(Optional.empty());
+    given(keywordRepository.saveAndFlush(
+        argThat(keyword -> keyword != null && keyword.getName().equals("아파트"))))
+        .willReturn(apartment);
+    given(keywordRepository.saveAndFlush(
+        argThat(keyword -> keyword != null && keyword.getName().equals("분양"))))
+        .willReturn(sale);
+    given(interestDtoMapper.toInterestDto(savedInterest, request.keywords(), false)).willReturn(
+        expected);
+
+    // when
+    InterestDto result = interestService.create(request);
+
+    // then
+    assertThat(result).isEqualTo(expected);
+    verify(keywordRepository, times(2)).saveAndFlush(any(Keyword.class));
+  }
+
+  @Test
+  @DisplayName("키워드 저장 중 무결성 예외가 발생해도 기존 키워드를 재조회하여 생성할 수 있다")
+  void create_ReturnsInterestDto_WhenKeywordIntegrityViolationOccurs() {
+    // given
+    InterestRegisterRequest request = new InterestRegisterRequest("산업", List.of("반도체"));
+    Interest savedInterest = interest(
+        UUID.randomUUID(),
+        "산업",
+        Instant.parse("2026-04-20T00:00:00Z"),
+        0
+    );
+    Keyword recoveredKeyword = keyword(UUID.randomUUID(), "반도체");
+    InterestDto expected = new InterestDto(savedInterest.getId(), "산업", List.of("반도체"), 0, false);
+
+    given(interestRepository.existsByName("산업")).willReturn(false);
+    given(interestRepository.findAllNames()).willReturn(List.of());
+    given(interestRepository.save(any(Interest.class))).willReturn(savedInterest);
+    given(keywordRepository.findByName("반도체")).willReturn(Optional.empty(),
+        Optional.of(recoveredKeyword));
+    given(keywordRepository.saveAndFlush(any(Keyword.class)))
+        .willThrow(new DataIntegrityViolationException("duplicate"));
+    given(interestDtoMapper.toInterestDto(savedInterest, List.of("반도체"), false)).willReturn(
+        expected);
+
+    // when
+    InterestDto result = interestService.create(request);
+
+    // then
+    assertThat(result).isEqualTo(expected);
+    verify(keywordRepository).saveAndFlush(any(Keyword.class));
+    verify(interestKeywordRepository).save(any(InterestKeyword.class));
+  }
+
+  @Test
+  @DisplayName("중복된 관심사 이름으로 생성하면 예외가 발생한다")
+  void create_ThrowsException_WhenInterestNameDuplicated() {
+    // given
+    InterestRegisterRequest request = new InterestRegisterRequest("경제", List.of("증시"));
+
+    given(interestRepository.existsByName("경제")).willReturn(true);
+
+    // when
+    ThrowingCallable action = () -> interestService.create(request);
+
+    // then
+    assertThatThrownBy(action)
+        .isInstanceOf(InterestException.class)
+        .satisfies(throwable -> {
+          InterestException exception = (InterestException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(
+              InterestErrorCode.INTEREST_NAME_DUPLICATION);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("name", "경제"));
+        });
+
+    verify(interestRepository, never()).save(any(Interest.class));
+  }
+
+  @Test
+  @DisplayName("유사한 관심사 이름이 존재하면 예외가 발생한다")
+  void create_ThrowsException_WhenSimilarInterestNameExists() {
+    // given
+    InterestRegisterRequest request = new InterestRegisterRequest("finance", List.of("stock"));
+
+    given(interestRepository.existsByName("finance")).willReturn(false);
+    given(interestRepository.findAllNames()).willReturn(List.of("finanse"));
+
+    // when
+    ThrowingCallable action = () -> interestService.create(request);
+
+    // then
+    assertThatThrownBy(action)
+        .isInstanceOf(InterestException.class)
+        .satisfies(throwable -> {
+          InterestException exception = (InterestException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(
+              InterestErrorCode.INTEREST_NAME_DUPLICATION);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("name", "finance"));
+        });
+  }
+
+  @Test
+  @DisplayName("요청 키워드에 중복이 있으면 예외가 발생한다")
+  void create_ThrowsException_WhenDuplicateKeywords() {
+    // given
+    InterestRegisterRequest request = new InterestRegisterRequest("금융", List.of("주식", "주식"));
+
+    given(interestRepository.existsByName("금융")).willReturn(false);
+    given(interestRepository.findAllNames()).willReturn(List.of());
+
+    // when
+    ThrowingCallable action = () -> interestService.create(request);
+
+    // then
+    assertThatThrownBy(action)
+        .isInstanceOf(InterestException.class)
+        .satisfies(throwable -> {
+          InterestException exception = (InterestException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(InterestErrorCode.DUPLICATE_KEYWORDS);
+          assertThat(exception.getDetails()).isEmpty();
+        });
+  }
+
+  @Test
+  @DisplayName("관심사를 수정할 수 있다")
+  void update_ReturnsUpdatedInterestDto_WhenValidRequest() {
+    // given
+    UUID interestId = UUID.randomUUID();
+    Interest interest = interest(interestId, "투자", Instant.parse("2026-04-20T00:00:00Z"), 0);
+    Keyword oldKeyword = keyword(UUID.randomUUID(), "주식");
+    Keyword newKeyword = keyword(UUID.randomUUID(), "채권");
+    InterestKeyword oldLink = new InterestKeyword(interest, oldKeyword);
+    InterestUpdateRequest request = new InterestUpdateRequest(List.of("채권"));
+    InterestDto expected = new InterestDto(interestId, "투자", List.of("채권"), 0, false);
+
+    given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
+    given(interestKeywordRepository.findAllByInterestWithKeyword(interest)).willReturn(
+        List.of(oldLink));
+    given(keywordRepository.findByName("채권")).willReturn(Optional.empty());
+    given(keywordRepository.saveAndFlush(
+        argThat(keyword -> keyword != null && keyword.getName().equals("채권"))))
+        .willReturn(newKeyword);
+    given(interestDtoMapper.toInterestDto(interest, List.of("채권"), false)).willReturn(expected);
+
+    // when
+    InterestDto result = interestService.update(interestId, request);
+
+    // then
+    assertThat(result).isEqualTo(expected);
+    verify(interestKeywordRepository).deleteAll(List.of(oldLink));
+    verify(interestKeywordRepository).save(any(InterestKeyword.class));
+  }
+
+  @Test
+  @DisplayName("기존 키워드는 유지하고 새 키워드를 추가하여 관심사를 수정할 수 있다")
+  void update_ReturnsUpdatedInterestDto_WhenKeepsExistingKeywordsAndAddsNewKeywords() {
+    // given
+    UUID interestId = UUID.randomUUID();
+    Interest interest = interest(interestId, "금융", Instant.parse("2026-04-20T00:00:00Z"), 0);
+    Keyword existingKeyword = keyword(UUID.randomUUID(), "주식");
+    Keyword newKeyword = keyword(UUID.randomUUID(), "ETF");
+    InterestKeyword existingLink = new InterestKeyword(interest, existingKeyword);
+    InterestUpdateRequest request = new InterestUpdateRequest(List.of("주식", "ETF"));
+    InterestDto expected = new InterestDto(interestId, "금융", request.keywords(), 0, false);
+
+    given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
+    given(interestKeywordRepository.findAllByInterestWithKeyword(interest)).willReturn(
+        List.of(existingLink));
+    given(keywordRepository.findByName("ETF")).willReturn(Optional.empty());
+    given(keywordRepository.saveAndFlush(
+        argThat(keyword -> keyword != null && keyword.getName().equals("ETF"))))
+        .willReturn(newKeyword);
+    given(interestDtoMapper.toInterestDto(interest, request.keywords(), false)).willReturn(
+        expected);
+
+    // when
+    InterestDto result = interestService.update(interestId, request);
+
+    // then
+    assertThat(result).isEqualTo(expected);
+    verify(interestKeywordRepository, never()).deleteAll(any());
+    verify(interestKeywordRepository).save(any(InterestKeyword.class));
+    verify(keywordRepository, never()).deleteOrphanKeywordsByIds(any());
+  }
+
+  @Test
+  @DisplayName("수정 과정에서 더 이상 사용되지 않는 키워드는 삭제한다")
+  void update_DeletesOrphanKeywords_WhenKeywordsAreRemoved() {
+    // given
+    UUID interestId = UUID.randomUUID();
+    Interest interest = interest(interestId, "산업", Instant.parse("2026-04-20T00:00:00Z"), 0);
+    Keyword keepKeyword = keyword(UUID.randomUUID(), "반도체");
+    Keyword removeKeyword = keyword(UUID.randomUUID(), "철강");
+    InterestKeyword keepLink = new InterestKeyword(interest, keepKeyword);
+    InterestKeyword removeLink = new InterestKeyword(interest, removeKeyword);
+    InterestUpdateRequest request = new InterestUpdateRequest(List.of("반도체"));
+    InterestDto expected = new InterestDto(interestId, "산업", List.of("반도체"), 0, false);
+
+    given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
+    given(interestKeywordRepository.findAllByInterestWithKeyword(interest)).willReturn(
+        List.of(keepLink, removeLink));
+    given(interestDtoMapper.toInterestDto(interest, List.of("반도체"), false)).willReturn(expected);
+
+    // when
+    InterestDto result = interestService.update(interestId, request);
+
+    // then
+    assertThat(result).isEqualTo(expected);
+    verify(interestKeywordRepository).deleteAll(List.of(removeLink));
+    verify(keywordRepository).deleteOrphanKeywordsByIds(List.of(removeKeyword.getId()));
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 관심사를 수정하면 예외가 발생한다")
+  void update_ThrowsException_WhenInterestNotFound() {
+    // given
+    UUID interestId = UUID.randomUUID();
+    InterestUpdateRequest request = new InterestUpdateRequest(List.of("채권"));
+
+    given(interestRepository.findById(interestId)).willReturn(Optional.empty());
+
+    // when
+    ThrowingCallable action = () -> interestService.update(interestId, request);
+
+    // then
+    assertThatThrownBy(action)
+        .isInstanceOf(InterestException.class)
+        .satisfies(throwable -> {
+          InterestException exception = (InterestException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(InterestErrorCode.INTEREST_NOT_FOUND);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("interestId", interestId));
+        });
+  }
+
+  @Test
+  @DisplayName("수정 요청 키워드에 중복이 있으면 예외가 발생한다")
+  void update_ThrowsException_WhenDuplicateKeywords() {
+    // given
+    UUID interestId = UUID.randomUUID();
+    Interest interest = interest(interestId, "경제", Instant.parse("2026-04-20T00:00:00Z"), 0);
+    InterestUpdateRequest request = new InterestUpdateRequest(List.of("증시", "증시"));
+
+    given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
+
+    // when
+    ThrowingCallable action = () -> interestService.update(interestId, request);
+
+    // then
+    assertThatThrownBy(action)
+        .isInstanceOf(InterestException.class)
+        .satisfies(throwable -> {
+          InterestException exception = (InterestException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(InterestErrorCode.DUPLICATE_KEYWORDS);
+          assertThat(exception.getDetails()).isEmpty();
+        });
+
+    verify(interestKeywordRepository, never()).findAllByInterestWithKeyword(any());
+  }
+
+  @Test
+  @DisplayName("관심사를 삭제할 수 있다")
+  void delete_DeletesInterest_WhenInterestExists() {
+    // given
+    UUID interestId = UUID.randomUUID();
+    Interest interest = interest(interestId, "경제", Instant.parse("2026-04-20T00:00:00Z"), 0);
+
+    given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
+    given(interestKeywordRepository.findAllByInterestWithKeyword(interest)).willReturn(List.of());
+
+    // when
+    interestService.delete(interestId);
+
+    // then
+    verify(interestKeywordRepository).deleteAll(List.of());
+    verify(interestRepository).delete(interest);
+    verify(keywordRepository, never()).deleteOrphanKeywordsByIds(any());
+  }
+
+  @Test
+  @DisplayName("관심사 삭제 시 연결된 관심사 키워드도 함께 삭제한다")
+  void delete_DeletesInterestKeywords_WhenInterestExists() {
+    // given
+    UUID interestId = UUID.randomUUID();
+    Interest interest = interest(interestId, "부동산", Instant.parse("2026-04-20T00:00:00Z"), 0);
+    Keyword keyword = keyword(UUID.randomUUID(), "아파트");
+    InterestKeyword link = new InterestKeyword(interest, keyword);
+
+    given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
+    given(interestKeywordRepository.findAllByInterestWithKeyword(interest)).willReturn(
+        List.of(link));
+
+    // when
+    interestService.delete(interestId);
+
+    // then
+    verify(interestKeywordRepository).deleteAll(List.of(link));
+    verify(interestRepository).delete(interest);
+  }
+
+  @Test
+  @DisplayName("관심사 삭제 후 더 이상 사용되지 않는 키워드는 삭제한다")
+  void delete_DeletesOrphanKeywords_WhenInterestDeleted() {
+    // given
+    UUID interestId = UUID.randomUUID();
+    Interest interest = interest(interestId, "테크", Instant.parse("2026-04-20T00:00:00Z"), 0);
+    Keyword firstKeyword = keyword(UUID.randomUUID(), "AI");
+    Keyword secondKeyword = keyword(UUID.randomUUID(), "로봇");
+    InterestKeyword firstLink = new InterestKeyword(interest, firstKeyword);
+    InterestKeyword secondLink = new InterestKeyword(interest, secondKeyword);
+
+    given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
+    given(interestKeywordRepository.findAllByInterestWithKeyword(interest)).willReturn(
+        List.of(firstLink, secondLink));
+
+    // when
+    interestService.delete(interestId);
+
+    // then
+    verify(keywordRepository).deleteOrphanKeywordsByIds(
+        List.of(firstKeyword.getId(), secondKeyword.getId()));
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 관심사를 삭제하면 예외가 발생한다")
+  void delete_ThrowsException_WhenInterestNotFound() {
+    // given
+    UUID interestId = UUID.randomUUID();
+
+    given(interestRepository.findById(interestId)).willReturn(Optional.empty());
+
+    // when
+    ThrowingCallable action = () -> interestService.delete(interestId);
+
+    // then
+    assertThatThrownBy(action)
+        .isInstanceOf(InterestException.class)
+        .satisfies(throwable -> {
+          InterestException exception = (InterestException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(InterestErrorCode.INTEREST_NOT_FOUND);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("interestId", interestId));
+        });
+  }
+
+  private Interest interest(UUID id, String name, Instant createdAt, long subscriberCount) {
+    Interest interest = new Interest(name);
+    ReflectionTestUtils.setField(interest, "id", id);
+    ReflectionTestUtils.setField(interest, "createdAt", createdAt);
+    ReflectionTestUtils.setField(interest, "subscriberCount", subscriberCount);
+    return interest;
+  }
+
+  private Keyword keyword(UUID id, String name) {
+    Keyword keyword = new Keyword(name);
+    ReflectionTestUtils.setField(keyword, "id", id);
+    return keyword;
+  }
+}

--- a/src/test/java/com/springboot/monew/interest/service/InterestServiceTest.java
+++ b/src/test/java/com/springboot/monew/interest/service/InterestServiceTest.java
@@ -43,6 +43,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -66,6 +67,9 @@ class InterestServiceTest {
 
   @Mock
   private InterestDtoMapper interestDtoMapper;
+
+  @Mock
+  private ApplicationEventPublisher eventPublisher;
 
   @InjectMocks
   private InterestService interestService;

--- a/src/test/java/com/springboot/monew/interest/service/InterestServiceTest.java
+++ b/src/test/java/com/springboot/monew/interest/service/InterestServiceTest.java
@@ -96,7 +96,7 @@ class InterestServiceTest {
     );
     InterestKeyword interestKeyword = new InterestKeyword(interest,
         keyword(UUID.randomUUID(), "macro"));
-    InterestDto interestDto = new InterestDto(interest.getId(), "economy", List.of("macro"), 5,
+    InterestDto interestDto = new InterestDto(interest.getId(), "economy", List.of("macro"), 5L,
         true);
 
     given(userRepository.findById(userId)).willReturn(Optional.of(user));
@@ -154,8 +154,8 @@ class InterestServiceTest {
         Instant.parse("2026-04-22T00:00:00Z"),
         3
     );
-    InterestDto firstDto = new InterestDto(first.getId(), "economy", List.of(), 1, false);
-    InterestDto secondDto = new InterestDto(second.getId(), "finance", List.of(), 2, false);
+    InterestDto firstDto = new InterestDto(first.getId(), "economy", List.of(), 1L, false);
+    InterestDto secondDto = new InterestDto(second.getId(), "finance", List.of(), 2L, false);
 
     given(userRepository.findById(userId)).willReturn(Optional.of(user));
     given(interestRepository.findInterests(request)).willReturn(List.of(first, second, third));
@@ -213,8 +213,8 @@ class InterestServiceTest {
         Instant.parse("2026-04-22T00:00:00Z"),
         1
     );
-    InterestDto firstDto = new InterestDto(first.getId(), "popular", List.of(), 5, false);
-    InterestDto secondDto = new InterestDto(second.getId(), "middle", List.of(), 3, false);
+    InterestDto firstDto = new InterestDto(first.getId(), "popular", List.of(), 5L, false);
+    InterestDto secondDto = new InterestDto(second.getId(), "middle", List.of(), 3L, false);
 
     given(userRepository.findById(userId)).willReturn(Optional.of(user));
     given(interestRepository.findInterests(request)).willReturn(List.of(first, second, third));
@@ -351,7 +351,7 @@ class InterestServiceTest {
         0
     );
     Keyword savedKeyword = keyword(UUID.randomUUID(), "증권");
-    InterestDto expected = new InterestDto(savedInterest.getId(), "금융", List.of("증권"), 0, false);
+    InterestDto expected = new InterestDto(savedInterest.getId(), "금융", List.of("증권"), 0L, false);
 
     given(interestRepository.existsByName("금융")).willReturn(false);
     given(interestRepository.findAllNames()).willReturn(List.of("경제"));
@@ -383,7 +383,7 @@ class InterestServiceTest {
     );
     Keyword firstKeyword = keyword(UUID.randomUUID(), "주식");
     Keyword secondKeyword = keyword(UUID.randomUUID(), "채권");
-    InterestDto expected = new InterestDto(savedInterest.getId(), "투자", request.keywords(), 0,
+    InterestDto expected = new InterestDto(savedInterest.getId(), "투자", request.keywords(), 0L,
         false);
 
     given(interestRepository.existsByName("투자")).willReturn(false);
@@ -416,7 +416,7 @@ class InterestServiceTest {
     );
     Keyword apartment = keyword(UUID.randomUUID(), "아파트");
     Keyword sale = keyword(UUID.randomUUID(), "분양");
-    InterestDto expected = new InterestDto(savedInterest.getId(), "부동산", request.keywords(), 0,
+    InterestDto expected = new InterestDto(savedInterest.getId(), "부동산", request.keywords(), 0L,
         false);
 
     given(interestRepository.existsByName("부동산")).willReturn(false);
@@ -453,7 +453,7 @@ class InterestServiceTest {
         0
     );
     Keyword recoveredKeyword = keyword(UUID.randomUUID(), "반도체");
-    InterestDto expected = new InterestDto(savedInterest.getId(), "산업", List.of("반도체"), 0, false);
+    InterestDto expected = new InterestDto(savedInterest.getId(), "산업", List.of("반도체"), 0L, false);
 
     given(interestRepository.existsByName("산업")).willReturn(false);
     given(interestRepository.findAllNames()).willReturn(List.of());
@@ -553,7 +553,7 @@ class InterestServiceTest {
     Keyword newKeyword = keyword(UUID.randomUUID(), "채권");
     InterestKeyword oldLink = new InterestKeyword(interest, oldKeyword);
     InterestUpdateRequest request = new InterestUpdateRequest(List.of("채권"));
-    InterestDto expected = new InterestDto(interestId, "투자", List.of("채권"), 0, false);
+    InterestDto expected = new InterestDto(interestId, "투자", List.of("채권"), 0L, false);
 
     given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
     given(interestKeywordRepository.findAllByInterestWithKeyword(interest)).willReturn(
@@ -583,7 +583,7 @@ class InterestServiceTest {
     Keyword newKeyword = keyword(UUID.randomUUID(), "ETF");
     InterestKeyword existingLink = new InterestKeyword(interest, existingKeyword);
     InterestUpdateRequest request = new InterestUpdateRequest(List.of("주식", "ETF"));
-    InterestDto expected = new InterestDto(interestId, "금융", request.keywords(), 0, false);
+    InterestDto expected = new InterestDto(interestId, "금융", request.keywords(), 0L, false);
 
     given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
     given(interestKeywordRepository.findAllByInterestWithKeyword(interest)).willReturn(
@@ -616,7 +616,7 @@ class InterestServiceTest {
     InterestKeyword keepLink = new InterestKeyword(interest, keepKeyword);
     InterestKeyword removeLink = new InterestKeyword(interest, removeKeyword);
     InterestUpdateRequest request = new InterestUpdateRequest(List.of("반도체"));
-    InterestDto expected = new InterestDto(interestId, "산업", List.of("반도체"), 0, false);
+    InterestDto expected = new InterestDto(interestId, "산업", List.of("반도체"), 0L, false);
 
     given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
     given(interestKeywordRepository.findAllByInterestWithKeyword(interest)).willReturn(

--- a/src/test/java/com/springboot/monew/interest/service/SubscriptionServiceTest.java
+++ b/src/test/java/com/springboot/monew/interest/service/SubscriptionServiceTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -55,6 +56,9 @@ class SubscriptionServiceTest {
 
   @Mock
   private SubscriptionDtoMapper subscriptionDtoMapper;
+
+  @Mock
+  private ApplicationEventPublisher eventPublisher;
 
   @InjectMocks
   private SubscriptionService subscriptionService;

--- a/src/test/java/com/springboot/monew/interest/service/SubscriptionServiceTest.java
+++ b/src/test/java/com/springboot/monew/interest/service/SubscriptionServiceTest.java
@@ -1,0 +1,507 @@
+package com.springboot.monew.interest.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.springboot.monew.interest.dto.response.SubscriptionDto;
+import com.springboot.monew.interest.entity.Interest;
+import com.springboot.monew.interest.entity.InterestKeyword;
+import com.springboot.monew.interest.entity.Keyword;
+import com.springboot.monew.interest.entity.Subscription;
+import com.springboot.monew.interest.exception.InterestErrorCode;
+import com.springboot.monew.interest.exception.InterestException;
+import com.springboot.monew.interest.mapper.SubscriptionDtoMapper;
+import com.springboot.monew.interest.repository.InterestKeywordRepository;
+import com.springboot.monew.interest.repository.InterestRepository;
+import com.springboot.monew.interest.repository.SubscriptionRepository;
+import com.springboot.monew.users.entity.User;
+import com.springboot.monew.users.exception.UserErrorCode;
+import com.springboot.monew.users.exception.UserException;
+import com.springboot.monew.users.repository.UserRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class SubscriptionServiceTest {
+
+  @Mock
+  private SubscriptionRepository subscriptionRepository;
+
+  @Mock
+  private InterestRepository interestRepository;
+
+  @Mock
+  private InterestKeywordRepository interestKeywordRepository;
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private SubscriptionDtoMapper subscriptionDtoMapper;
+
+  @InjectMocks
+  private SubscriptionService subscriptionService;
+
+  @Test
+  @DisplayName("관심사를 구독할 수 있다")
+  void subscribe_ReturnsSubscriptionDto_WhenValidRequest() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID interestId = UUID.randomUUID();
+    User user = new User("user@example.com", "tester", "password");
+    Interest interest = interest(interestId, "금융");
+    Subscription subscription = subscription(
+        UUID.randomUUID(),
+        user,
+        interest,
+        Instant.parse("2026-04-20T00:00:00Z")
+    );
+    InterestKeyword firstLink = new InterestKeyword(interest, keyword(UUID.randomUUID(), "주식"));
+    InterestKeyword secondLink = new InterestKeyword(interest, keyword(UUID.randomUUID(), "채권"));
+    SubscriptionDto expected = new SubscriptionDto(
+        subscription.getId(),
+        interestId,
+        "금융",
+        List.of("주식", "채권"),
+        2L,
+        subscription.getCreatedAt()
+    );
+
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+    given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
+    given(subscriptionRepository.existsByUserIdAndInterestId(userId, interestId)).willReturn(false);
+    given(subscriptionRepository.saveAndFlush(any(Subscription.class))).willReturn(subscription);
+    given(interestRepository.incrementSubscriberCount(interestId)).willReturn(1);
+    given(interestKeywordRepository.findAllByInterestWithKeyword(interest)).willReturn(List.of(firstLink, secondLink));
+    given(interestRepository.findSubscriberCountById(interestId)).willReturn(2L);
+    given(subscriptionDtoMapper.toSubscriptionDto(subscription, List.of("주식", "채권"), 2L))
+        .willReturn(expected);
+
+    // when
+    SubscriptionDto result = subscriptionService.subscribe(interestId, userId);
+
+    // then
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 사용자가 구독하면 예외가 발생한다")
+  void subscribe_ThrowsException_WhenUserNotFound() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID interestId = UUID.randomUUID();
+
+    given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+    // when
+    ThrowingCallable action = () -> subscriptionService.subscribe(interestId, userId);
+
+    // then
+    assertThatThrownBy(action)
+        .isInstanceOf(UserException.class)
+        .satisfies(throwable -> {
+          UserException exception = (UserException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("userId", userId));
+        });
+
+    verify(interestRepository, never()).findById(any());
+  }
+
+  @Test
+  @DisplayName("삭제된 사용자가 구독하면 예외가 발생한다")
+  void subscribe_ThrowsException_WhenUserDeleted() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID interestId = UUID.randomUUID();
+    User deletedUser = new User("deleted@example.com", "tester", "password");
+    deletedUser.delete();
+
+    given(userRepository.findById(userId)).willReturn(Optional.of(deletedUser));
+
+    // when
+    ThrowingCallable action = () -> subscriptionService.subscribe(interestId, userId);
+
+    // then
+    assertThatThrownBy(action)
+        .isInstanceOf(UserException.class)
+        .satisfies(throwable -> {
+          UserException exception = (UserException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("userId", userId));
+        });
+
+    verify(interestRepository, never()).findById(any());
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 관심사를 구독하면 예외가 발생한다")
+  void subscribe_ThrowsException_WhenInterestNotFound() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID interestId = UUID.randomUUID();
+    User user = new User("user@example.com", "tester", "password");
+
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+    given(interestRepository.findById(interestId)).willReturn(Optional.empty());
+
+    // when
+    ThrowingCallable action = () -> subscriptionService.subscribe(interestId, userId);
+
+    // then
+    assertThatThrownBy(action)
+        .isInstanceOf(InterestException.class)
+        .satisfies(throwable -> {
+          InterestException exception = (InterestException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(InterestErrorCode.INTEREST_NOT_FOUND);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("interestId", interestId));
+        });
+  }
+
+  @Test
+  @DisplayName("이미 구독한 관심사를 다시 구독하면 예외가 발생한다")
+  void subscribe_ThrowsException_WhenSubscriptionAlreadyExists() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID interestId = UUID.randomUUID();
+    User user = new User("user@example.com", "tester", "password");
+    Interest interest = interest(interestId, "금융");
+
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+    given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
+    given(subscriptionRepository.existsByUserIdAndInterestId(userId, interestId)).willReturn(true);
+
+    // when
+    ThrowingCallable action = () -> subscriptionService.subscribe(interestId, userId);
+
+    // then
+    assertThatThrownBy(action)
+        .isInstanceOf(InterestException.class)
+        .satisfies(throwable -> {
+          InterestException exception = (InterestException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(InterestErrorCode.SUBSCRIPTION_ALREADY_EXISTS);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("interestId", interestId, "userId", userId));
+        });
+
+    verify(subscriptionRepository, never()).saveAndFlush(any(Subscription.class));
+  }
+
+  @Test
+  @DisplayName("구독 저장 중 무결성 예외가 발생하고 실제로 중복 구독이면 예외로 변환한다")
+  void subscribe_ThrowsException_WhenIntegrityViolationFromDuplicateSubscription() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID interestId = UUID.randomUUID();
+    User user = new User("user@example.com", "tester", "password");
+    Interest interest = interest(interestId, "산업");
+
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+    given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
+    given(subscriptionRepository.existsByUserIdAndInterestId(userId, interestId))
+        .willReturn(false, true);
+    given(subscriptionRepository.saveAndFlush(any(Subscription.class)))
+        .willThrow(new DataIntegrityViolationException("duplicate"));
+
+    // when
+    ThrowingCallable action = () -> subscriptionService.subscribe(interestId, userId);
+
+    // then
+    assertThatThrownBy(action)
+        .isInstanceOf(InterestException.class)
+        .satisfies(throwable -> {
+          InterestException exception = (InterestException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(InterestErrorCode.SUBSCRIPTION_ALREADY_EXISTS);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("interestId", interestId, "userId", userId));
+        });
+  }
+
+  @Test
+  @DisplayName("구독 저장 중 무결성 예외가 발생하고 관심사가 없으면 예외로 변환한다")
+  void subscribe_ThrowsException_WhenIntegrityViolationFromInterestNotFound() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID interestId = UUID.randomUUID();
+    User user = new User("user@example.com", "tester", "password");
+    Interest interest = interest(interestId, "테크");
+
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+    given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
+    given(subscriptionRepository.existsByUserIdAndInterestId(userId, interestId))
+        .willReturn(false, false);
+    given(subscriptionRepository.saveAndFlush(any(Subscription.class)))
+        .willThrow(new DataIntegrityViolationException("fk"));
+    given(interestRepository.existsById(interestId)).willReturn(false);
+
+    // when
+    ThrowingCallable action = () -> subscriptionService.subscribe(interestId, userId);
+
+    // then
+    assertThatThrownBy(action)
+        .isInstanceOf(InterestException.class)
+        .satisfies(throwable -> {
+          InterestException exception = (InterestException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(InterestErrorCode.INTEREST_NOT_FOUND);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("interestId", interestId));
+        });
+  }
+
+  @Test
+  @DisplayName("구독 저장 중 예상 밖의 무결성 예외가 발생하면 원래 예외를 다시 던진다")
+  void subscribe_RethrowsDataIntegrityViolationException_WhenUnexpectedPersistenceConflictOccurs() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID interestId = UUID.randomUUID();
+    User user = new User("user@example.com", "tester", "password");
+    Interest interest = new Interest("금융");
+    DataIntegrityViolationException expectedException =
+        new DataIntegrityViolationException("unexpected conflict");
+
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+    given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
+    given(subscriptionRepository.existsByUserIdAndInterestId(userId, interestId))
+        .willReturn(false);
+    given(subscriptionRepository.saveAndFlush(any(Subscription.class)))
+        .willThrow(expectedException);
+    given(interestRepository.existsById(interestId)).willReturn(true);
+
+    // when
+    ThrowingCallable action = () -> subscriptionService.subscribe(interestId, userId);
+
+    // then
+    assertThatThrownBy(action)
+        .isSameAs(expectedException);
+
+    verify(interestRepository, never()).incrementSubscriberCount(interestId);
+  }
+
+  @Test
+  @DisplayName("구독자 수 증가 결과가 0이면 예외가 발생한다")
+  void subscribe_ThrowsException_WhenSubscriberCountIncrementFails() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID interestId = UUID.randomUUID();
+    User user = new User("user@example.com", "tester", "password");
+    Interest interest = interest(interestId, "부동산");
+    Subscription subscription = subscription(
+        UUID.randomUUID(),
+        user,
+        interest,
+        Instant.parse("2026-04-20T00:00:00Z")
+    );
+
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+    given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
+    given(subscriptionRepository.existsByUserIdAndInterestId(userId, interestId)).willReturn(false);
+    given(subscriptionRepository.saveAndFlush(any(Subscription.class))).willReturn(subscription);
+    given(interestRepository.incrementSubscriberCount(interestId)).willReturn(0);
+
+    // when
+    ThrowingCallable action = () -> subscriptionService.subscribe(interestId, userId);
+
+    // then
+    assertThatThrownBy(action)
+        .isInstanceOf(InterestException.class)
+        .satisfies(throwable -> {
+          InterestException exception = (InterestException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(InterestErrorCode.INTEREST_NOT_FOUND);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("interestId", interestId));
+        });
+
+    verify(subscriptionDtoMapper, never()).toSubscriptionDto(any(), any(), anyLong());
+  }
+
+  @Test
+  @DisplayName("구독자 수 조회 결과가 없으면 예외가 발생한다")
+  void subscribe_ThrowsException_WhenSubscriberCountIsNull() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID interestId = UUID.randomUUID();
+    User user = new User("user@example.com", "tester", "password");
+    Interest interest = interest(interestId, "문화");
+    Subscription subscription = subscription(
+        UUID.randomUUID(),
+        user,
+        interest,
+        Instant.parse("2026-04-20T00:00:00Z")
+    );
+
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+    given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
+    given(subscriptionRepository.existsByUserIdAndInterestId(userId, interestId)).willReturn(false);
+    given(subscriptionRepository.saveAndFlush(any(Subscription.class))).willReturn(subscription);
+    given(interestRepository.incrementSubscriberCount(interestId)).willReturn(1);
+    given(interestKeywordRepository.findAllByInterestWithKeyword(interest)).willReturn(List.of());
+    given(interestRepository.findSubscriberCountById(interestId)).willReturn(null);
+
+    // when
+    ThrowingCallable action = () -> subscriptionService.subscribe(interestId, userId);
+
+    // then
+    assertThatThrownBy(action)
+        .isInstanceOf(InterestException.class)
+        .satisfies(throwable -> {
+          InterestException exception = (InterestException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(InterestErrorCode.INTEREST_NOT_FOUND);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("interestId", interestId));
+        });
+  }
+
+  @Test
+  @DisplayName("관심사 구독을 취소할 수 있다")
+  void unsubscribe_DeletesSubscription_WhenValidRequest() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID interestId = UUID.randomUUID();
+    User user = new User("user@example.com", "tester", "password");
+
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+    given(subscriptionRepository.deleteByUserIdAndInterestId(userId, interestId)).willReturn(1);
+    given(interestRepository.decrementSubscriberCount(interestId)).willReturn(1);
+
+    // when
+    subscriptionService.unsubscribe(interestId, userId);
+
+    // then
+    verify(subscriptionRepository).deleteByUserIdAndInterestId(userId, interestId);
+    verify(interestRepository).decrementSubscriberCount(interestId);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 사용자가 구독을 취소하면 예외가 발생한다")
+  void unsubscribe_ThrowsException_WhenUserNotFound() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID interestId = UUID.randomUUID();
+
+    given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+    // when
+    ThrowingCallable action = () -> subscriptionService.unsubscribe(interestId, userId);
+
+    // then
+    assertThatThrownBy(action)
+        .isInstanceOf(UserException.class)
+        .satisfies(throwable -> {
+          UserException exception = (UserException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("userId", userId));
+        });
+
+    verify(subscriptionRepository, never()).deleteByUserIdAndInterestId(any(), any());
+    verify(interestRepository, never()).decrementSubscriberCount(any());
+  }
+
+  @Test
+  @DisplayName("삭제된 사용자가 구독을 취소하면 예외가 발생한다")
+  void unsubscribe_ThrowsException_WhenUserDeleted() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID interestId = UUID.randomUUID();
+    User deletedUser = new User("deleted@example.com", "tester", "password");
+    deletedUser.delete();
+
+    given(userRepository.findById(userId)).willReturn(Optional.of(deletedUser));
+
+    // when
+    ThrowingCallable action = () -> subscriptionService.unsubscribe(interestId, userId);
+
+    // then
+    assertThatThrownBy(action)
+        .isInstanceOf(UserException.class)
+        .satisfies(throwable -> {
+          UserException exception = (UserException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("userId", userId));
+        });
+
+    verify(subscriptionRepository, never()).deleteByUserIdAndInterestId(any(), any());
+    verify(interestRepository, never()).decrementSubscriberCount(any());
+  }
+
+  @Test
+  @DisplayName("구독하지 않은 관심사를 취소하면 예외가 발생한다")
+  void unsubscribe_ThrowsException_WhenSubscriptionNotFound() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID interestId = UUID.randomUUID();
+    User user = new User("user@example.com", "tester", "password");
+
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+    given(subscriptionRepository.deleteByUserIdAndInterestId(userId, interestId)).willReturn(0);
+
+    // when
+    ThrowingCallable action = () -> subscriptionService.unsubscribe(interestId, userId);
+
+    // then
+    assertThatThrownBy(action)
+        .isInstanceOf(InterestException.class)
+        .satisfies(throwable -> {
+          InterestException exception = (InterestException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(InterestErrorCode.SUBSCRIPTION_NOT_FOUND);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("interestId", interestId, "userId", userId));
+        });
+
+    verify(interestRepository, never()).decrementSubscriberCount(any());
+  }
+
+  @Test
+  @DisplayName("구독자 수 감소 결과가 0이면 예외가 발생한다")
+  void unsubscribe_ThrowsException_WhenSubscriberCountDecrementFails() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID interestId = UUID.randomUUID();
+    User user = new User("user@example.com", "tester", "password");
+
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+    given(subscriptionRepository.deleteByUserIdAndInterestId(userId, interestId)).willReturn(1);
+    given(interestRepository.decrementSubscriberCount(interestId)).willReturn(0);
+
+    // when
+    ThrowingCallable action = () -> subscriptionService.unsubscribe(interestId, userId);
+
+    // then
+    assertThatThrownBy(action)
+        .isInstanceOf(InterestException.class)
+        .satisfies(throwable -> {
+          InterestException exception = (InterestException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(InterestErrorCode.INTEREST_NOT_FOUND);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("interestId", interestId));
+        });
+  }
+
+  private Interest interest(UUID id, String name) {
+    Interest interest = new Interest(name);
+    ReflectionTestUtils.setField(interest, "id", id);
+    return interest;
+  }
+
+  private Keyword keyword(UUID id, String name) {
+    Keyword keyword = new Keyword(name);
+    ReflectionTestUtils.setField(keyword, "id", id);
+    return keyword;
+  }
+
+  private Subscription subscription(UUID id, User user, Interest interest, Instant createdAt) {
+    Subscription subscription = new Subscription(user, interest);
+    ReflectionTestUtils.setField(subscription, "id", id);
+    ReflectionTestUtils.setField(subscription, "createdAt", createdAt);
+    return subscription;
+  }
+}

--- a/src/test/java/com/springboot/monew/interest/util/StringSimilarityUtilTest.java
+++ b/src/test/java/com/springboot/monew/interest/util/StringSimilarityUtilTest.java
@@ -1,0 +1,199 @@
+package com.springboot.monew.interest.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class StringSimilarityUtilTest {
+
+  @Test
+  @DisplayName("null이 포함되면 유사도는 0.0이다")
+  void similarity_ReturnsZero_WhenEitherValueIsNull() {
+    // given
+    String value = "finance";
+
+    // when
+    double leftNullResult = StringSimilarityUtil.similarity(null, value);
+    double rightNullResult = StringSimilarityUtil.similarity(value, null);
+
+    // then
+    assertThat(leftNullResult).isZero();
+    assertThat(rightNullResult).isZero();
+  }
+
+  @Test
+  @DisplayName("두 문자열이 모두 비어 있으면 유사도는 1.0이다")
+  void similarity_ReturnsOne_WhenBothValuesAreEmpty() {
+    // given
+    String first = "";
+    String second = "";
+
+    // when
+    double result = StringSimilarityUtil.similarity(first, second);
+
+    // then
+    assertThat(result).isEqualTo(1.0);
+  }
+
+  @Test
+  @DisplayName("영어 문자열이 완전히 같으면 유사도는 1.0이다")
+  void similarity_ReturnsOne_WhenEnglishWordsAreIdentical() {
+    // given
+    String first = "finance";
+    String second = "finance";
+
+    // when
+    double result = StringSimilarityUtil.similarity(first, second);
+
+    // then
+    assertThat(result).isEqualTo(1.0);
+  }
+
+  @Test
+  @DisplayName("한글 문자열이 완전히 같으면 유사도는 1.0이다")
+  void similarity_ReturnsOne_WhenKoreanWordsAreIdentical() {
+    // given
+    String first = "경제뉴스";
+    String second = "경제뉴스";
+
+    // when
+    double result = StringSimilarityUtil.similarity(first, second);
+
+    // then
+    assertThat(result).isEqualTo(1.0);
+  }
+
+  @Test
+  @DisplayName("영어 문자열의 한 글자만 다르면 기대한 비율로 계산된다")
+  void similarity_ReturnsExpectedRatio_WhenEnglishWordsDifferByOneCharacter() {
+    // given
+    String first = "finance";
+    String second = "finanse";
+
+    // when
+    double result = StringSimilarityUtil.similarity(first, second);
+
+    // then
+    assertThat(result).isEqualTo(6.0 / 7.0);
+  }
+
+  @Test
+  @DisplayName("한글 문자열의 한 글자만 다르면 기대한 비율로 계산된다")
+  void similarity_ReturnsExpectedRatio_WhenKoreanWordsDifferByOneCharacter() {
+    // given
+    String first = "경제뉴스";
+    String second = "경제뉴수";
+
+    // when
+    double result = StringSimilarityUtil.similarity(first, second);
+
+    // then
+    assertThat(result).isEqualTo(3.0 / 4.0);
+  }
+
+  @Test
+  @DisplayName("영어 문자열이 많이 다르면 유사도는 낮다")
+  void similarity_ReturnsLowValue_WhenEnglishWordsAreDifferent() {
+    // given
+    String first = "finance";
+    String second = "sports";
+
+    // when
+    double result = StringSimilarityUtil.similarity(first, second);
+
+    // then
+    assertThat(result).isLessThan(0.5);
+  }
+
+  @Test
+  @DisplayName("한글 문자열이 많이 다르면 유사도는 낮다")
+  void similarity_ReturnsLowValue_WhenKoreanWordsAreDifferent() {
+    // given
+    String first = "경제";
+    String second = "스포츠";
+
+    // when
+    double result = StringSimilarityUtil.similarity(first, second);
+
+    // then
+    assertThat(result).isLessThan(0.5);
+  }
+
+  @Test
+  @DisplayName("영어 문자열이 기준치 이상이면 유사하다고 판단한다")
+  void isSimilarEnough_ReturnsTrue_WhenEnglishSimilarityIsAboveThreshold() {
+    // given
+    String first = "finance";
+    String second = "finanse";
+    double threshold = 0.8;
+
+    // when
+    boolean result = StringSimilarityUtil.isSimilarEnough(first, second, threshold);
+
+    // then
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  @DisplayName("한글 문자열이 기준치 이상이면 유사하다고 판단한다")
+  void isSimilarEnough_ReturnsTrue_WhenKoreanSimilarityIsAboveThreshold() {
+    // given
+    String first = "경제뉴스";
+    String second = "경제뉴수";
+    double threshold = 0.7;
+
+    // when
+    boolean result = StringSimilarityUtil.isSimilarEnough(first, second, threshold);
+
+    // then
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  @DisplayName("영어 문자열이 기준치 미만이면 유사하지 않다고 판단한다")
+  void isSimilarEnough_ReturnsFalse_WhenEnglishSimilarityIsBelowThreshold() {
+    // given
+    String first = "finance";
+    String second = "sports";
+    double threshold = 0.8;
+
+    // when
+    boolean result = StringSimilarityUtil.isSimilarEnough(first, second, threshold);
+
+    // then
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  @DisplayName("한글 문자열이 기준치 미만이면 유사하지 않다고 판단한다")
+  void isSimilarEnough_ReturnsFalse_WhenKoreanSimilarityIsBelowThreshold() {
+    // given
+    String first = "경제";
+    String second = "스포츠";
+    double threshold = 0.8;
+
+    // when
+    boolean result = StringSimilarityUtil.isSimilarEnough(first, second, threshold);
+
+    // then
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  @DisplayName("영문과 한글이 섞여 있어도 같은 규칙으로 계산한다")
+  void similarity_ReturnsSimilarEnoughResult_WhenLanguagesAreMixed() {
+    // given
+    String first = "finance금융";
+    String second = "finanse금융";
+    double threshold = 0.8;
+
+    // when
+    double similarity = StringSimilarityUtil.similarity(first, second);
+    boolean similarEnough = StringSimilarityUtil.isSimilarEnough(first, second, threshold);
+
+    // then
+    assertThat(similarity).isGreaterThanOrEqualTo(threshold);
+    assertThat(similarEnough).isTrue();
+  }
+}


### PR DESCRIPTION
## 📌 해당 이슈카드
Closes #92 #110 #127 #137 #139 #145 #268 

## 📌 작업 내용
- 관심사 기본 기능(등록, 수정, 삭제, 목록 조회, 구독, 구독 취소)의 테스트 구현
- 관심사 컨트롤러 테스트
- 관심사 유사도 검사 테스트
- 관심사 레포지토리 테스트
- 관심사 서비스 테스트
- 관심사 구독 서비스 테스트

## 🔧 변경 사항
- 응답 DTO Wrapper 타입으로 변경

## 반영 브랜치
`test/#268/Interest-test` -> `dev`

## 💬 기타 참고 사항
- 테스트마다 PR을 생성하도록 분리하면 PR 요청과 리뷰에 번거로움이 많이 발생할 것 같아 한번에 구현하였습니다.
- 테스트가 모두 성공하는 것을 확인했습니다.
- `Interest`의 모든 테스트 커버리지가 80% 이상인 것을 확인했습니다.
- `InterestQDSLRepositoryImpl.findByIdWithArticleCount()`는 윤섭님께서 구현을 하신 부분이여서 일단 테스트를 하지 않았기 때문에 해당 부분만 테스트 커버리지가 0%인 상태입니다. 윤섭님께 해당 내용 전달하겠습니다.

<img width="1012" height="133" alt="스크린샷 2026-04-27 103205" src="https://github.com/user-attachments/assets/db707b6a-0db2-4294-8c0f-2dbbe3dceec3" />
<img width="1166" height="297" alt="스크린샷 2026-04-27 103217" src="https://github.com/user-attachments/assets/4730b4b4-2e9f-46bb-9f51-48cc5357dd5e" />
<img width="1155" height="149" alt="스크린샷 2026-04-27 103231" src="https://github.com/user-attachments/assets/fe515bd1-4d11-4e52-b2c8-5f450e53ae4c" />
<img width="1186" height="375" alt="스크린샷 2026-04-27 103248" src="https://github.com/user-attachments/assets/a3c7f7cc-7044-4d0b-89bd-e0d0989862e0" />
<img width="1026" height="156" alt="스크린샷 2026-04-27 103258" src="https://github.com/user-attachments/assets/fbbce6c0-4b68-4d30-a1c9-2c51a5d1fd13" />
<img width="1029" height="138" alt="스크린샷 2026-04-27 103320" src="https://github.com/user-attachments/assets/1a238503-6b09-4c61-b373-200c909479e9" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **테스트**
  * 관심사 관련 컨트롤러·리포지토리·서비스와 구독 흐름 전반에 대한 포괄적 단위·통합 테스트 추가
  * 문자열 유사도 유틸리티 테스트 추가로 유사도 판단 안정성 강화
* **API 변경**
  * 일부 응답 DTO의 숫자·불리언 필드가 nullable로 변경되어 값이 명시적으로 비어있을 수 있음
<!-- end of auto-generated comment: release notes by coderabbit.ai -->