### PR TITLE
[Docs] Swagger API 문서화 

### DIFF
--- a/src/main/java/com/springboot/monew/comment/controller/CommentApiDocs.java
+++ b/src/main/java/com/springboot/monew/comment/controller/CommentApiDocs.java
@@ -8,7 +8,9 @@ import com.springboot.monew.comment.dto.CursorPageResponseCommentDto;
 import com.springboot.monew.common.exception.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -29,31 +31,137 @@ public interface CommentApiDocs {
           커서 기반 페이지네이션으로 댓글 목록을 조회합니다.""",
       operationId = "list_1"
   )
+  @Parameters({
+      @Parameter(
+          name = "articleId",
+          description = "조회할 뉴스 기사 ID (필수)",
+          required = true,
+          example = "550e8400-e29b-41d4-a716-446655440000",
+          schema = @Schema(type = "string", format = "uuid")
+      ),
+      @Parameter(
+          name = "orderBy",
+          description = """
+              정렬 기준 (필수)
+              - `createdAt` : 등록일 순
+              - `likeCount` : 좋아요 수 순""",
+          required = true,
+          schema = @Schema(type = "string", allowableValues = {"createdAt", "likeCount"})
+      ),
+      @Parameter(
+          name = "direction",
+          description = """
+              정렬 방향 (필수)
+              - `ASC` : 오름차순
+              - `DESC` : 내림차순""",
+          required = true,
+          schema = @Schema(type = "string", allowableValues = {"ASC", "DESC"})
+      ),
+      @Parameter(
+          name = "cursor",
+          description = """
+              이전 페이지의 마지막 커서 값 (첫 페이지 조회 시 생략)
+              - orderBy=`createdAt` 형식: `2024-01-15T10:30:00.000000000Z`
+              - orderBy=`likeCount` 형식: `5|2024-01-15T10:30:00.000000000Z`""",
+          example = "2024-01-15T10:30:00.000000000Z"
+      ),
+      @Parameter(
+          name = "after",
+          description = "이전 페이지의 마지막 항목 createdAt (cursor와 함께 사용)",
+          example = "2024-01-15T10:30:00.000Z"
+      ),
+      @Parameter(
+          name = "limit",
+          description = "페이지당 조회 개수 (기본값: 50, 최소: 1, 최대: 100)",
+          schema = @Schema(type = "integer", minimum = "1", maximum = "100", defaultValue = "50")
+      )
+  })
   @ApiResponses({
       @ApiResponse(
           responseCode = "200",
           description = "댓글 목록 조회 성공",
-          content = @Content(schema = @Schema(implementation = CursorPageResponseCommentDto.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = CursorPageResponseCommentDto.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "content": [
+                      {
+                        "id": "550e8400-e29b-41d4-a716-446655440000",
+                        "articleId": "660e8400-e29b-41d4-a716-446655440001",
+                        "userId": "770e8400-e29b-41d4-a716-446655440002",
+                        "userNickname": "홍길동",
+                        "content": "좋은 기사네요!",
+                        "likeCount": 5,
+                        "likedByMe": false,
+                        "createdAt": "2024-01-15T10:30:00.000Z"
+                      }
+                    ],
+                    "nextCursor": "2024-01-15T10:30:00.000000000Z",
+                    "nextAfter": "2024-01-15T10:30:00.000Z",
+                    "size": 1,
+                    "totalElements": 42,
+                    "hasNext": true
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "400",
           description = """
               잘못된 요청
-              - 필수 쿼리 파라미터 누락 또는 형식 오류
-              - limit이 1 미만이거나 허용 범위 초과
-              - orderBy 값이 허용된 값이 아님 (createdAt, likeCount)
-              - after 커서 형식 불일치""",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+              - 필수 파라미터 누락 또는 형식 오류
+              - limit 범위 초과 (1~100)
+              - orderBy 값이 허용된 값이 아님 (createdAt, likeCount)""",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "BAD_REQUEST",
+                    "message": "입력값 검증에 실패하였습니다.",
+                    "details": {
+                      "articleId": ["널이어서는 안됩니다"],
+                      "limit": ["1에서 100 사이여야 합니다"]
+                    },
+                    "exceptionType": "MethodArgumentNotValidException",
+                    "status": 400
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "401",
           description = "Monew-Request-User-ID 헤더 누락",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "UNAUTHORIZED",
+                    "message": "Required request header 'Monew-Request-User-ID' for method parameter type UUID is not present",
+                    "details": {},
+                    "exceptionType": "MissingRequestHeaderException",
+                    "status": 401
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "500",
           description = "서버 내부 오류",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "INTERNAL_SERVER_ERROR",
+                    "message": "서버 내부 오류가 발생했습니다.",
+                    "details": {},
+                    "exceptionType": "Exception",
+                    "status": 500
+                  }""")
+          )
       )
   })
   CursorPageResponseCommentDto<CommentDto> list(
@@ -73,16 +181,44 @@ public interface CommentApiDocs {
       @ApiResponse(
           responseCode = "201",
           description = "댓글 등록 성공",
-          content = @Content(schema = @Schema(implementation = CommentDto.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = CommentDto.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "id": "550e8400-e29b-41d4-a716-446655440000",
+                    "articleId": "660e8400-e29b-41d4-a716-446655440001",
+                    "userId": "770e8400-e29b-41d4-a716-446655440002",
+                    "userNickname": "홍길동",
+                    "content": "좋은 기사네요!",
+                    "likeCount": 0,
+                    "likedByMe": false,
+                    "createdAt": "2024-01-15T10:30:00.000Z"
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "400",
           description = """
               잘못된 요청
               - content가 null이거나 빈 문자열
-              - content 길이 초과
               - articleId 또는 userId 형식 오류 (UUID 아님)""",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "BAD_REQUEST",
+                    "message": "입력값 검증에 실패하였습니다.",
+                    "details": {
+                      "content": ["공백일 수 없습니다"],
+                      "articleId": ["널이어서는 안됩니다"]
+                    },
+                    "exceptionType": "MethodArgumentNotValidException",
+                    "status": 400
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "404",
@@ -90,17 +226,55 @@ public interface CommentApiDocs {
               리소스 없음
               - 뉴스 기사를 찾을 수 없음 (NA01)
               - 사용자를 찾을 수 없음 (UR03)""",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "NA01",
+                    "message": "뉴스기사를 찾을 수 없습니다.",
+                    "details": {
+                      "articleId": "660e8400-e29b-41d4-a716-446655440001"
+                    },
+                    "exceptionType": "ArticleException",
+                    "status": 404
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "415",
           description = "지원하지 않는 Content-Type (application/json 필요)",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "UNSUPPORTED_MEDIA_TYPE",
+                    "message": "Content-Type 'text/plain' is not supported",
+                    "details": {},
+                    "exceptionType": "HttpMediaTypeNotSupportedException",
+                    "status": 415
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "500",
           description = "서버 내부 오류",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "INTERNAL_SERVER_ERROR",
+                    "message": "서버 내부 오류가 발생했습니다.",
+                    "details": {},
+                    "exceptionType": "Exception",
+                    "status": 500
+                  }""")
+          )
       )
   })
   ResponseEntity<CommentDto> create(
@@ -122,18 +296,58 @@ public interface CommentApiDocs {
       ),
       @ApiResponse(
           responseCode = "400",
-          description = "이미 삭제된 댓글입니다 (CM05)",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          description = "이미 삭제된 댓글 (CM05)",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "CM05",
+                    "message": "이미 삭제한 댓글입니다.",
+                    "details": {
+                      "commentId": "550e8400-e29b-41d4-a716-446655440000"
+                    },
+                    "exceptionType": "CommentException",
+                    "status": 400
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "404",
           description = "댓글을 찾을 수 없음 (CM01)",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "CM01",
+                    "message": "댓글을 찾을 수 없습니다.",
+                    "details": {
+                      "commentId": "550e8400-e29b-41d4-a716-446655440000"
+                    },
+                    "exceptionType": "CommentException",
+                    "status": 404
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "500",
           description = "서버 내부 오류",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "INTERNAL_SERVER_ERROR",
+                    "message": "서버 내부 오류가 발생했습니다.",
+                    "details": {},
+                    "exceptionType": "Exception",
+                    "status": 500
+                  }""")
+          )
       )
   })
   ResponseEntity<Void> softDelete(
@@ -152,41 +366,146 @@ public interface CommentApiDocs {
       @ApiResponse(
           responseCode = "200",
           description = "댓글 수정 성공",
-          content = @Content(schema = @Schema(implementation = CommentDto.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = CommentDto.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "id": "550e8400-e29b-41d4-a716-446655440000",
+                    "articleId": "660e8400-e29b-41d4-a716-446655440001",
+                    "userId": "770e8400-e29b-41d4-a716-446655440002",
+                    "userNickname": "홍길동",
+                    "content": "수정된 댓글 내용입니다.",
+                    "likeCount": 3,
+                    "likedByMe": true,
+                    "createdAt": "2024-01-15T10:30:00.000Z"
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "400",
           description = """
               잘못된 요청
               - content가 null이거나 빈 문자열
-              - content 길이 초과
-              - 이미 삭제된 댓글입니다 (CM05)""",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+              - 이미 삭제된 댓글 (CM05)""",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = {
+                  @ExampleObject(name = "validationError", summary = "입력값 검증 실패", value = """
+                      {
+                        "timestamp": "2024-01-15T10:30:00.000Z",
+                        "code": "BAD_REQUEST",
+                        "message": "입력값 검증에 실패하였습니다.",
+                        "details": {
+                          "content": ["공백일 수 없습니다"]
+                        },
+                        "exceptionType": "MethodArgumentNotValidException",
+                        "status": 400
+                      }"""),
+                  @ExampleObject(name = "alreadyDeleted", summary = "이미 삭제된 댓글 (CM05)", value = """
+                      {
+                        "timestamp": "2024-01-15T10:30:00.000Z",
+                        "code": "CM05",
+                        "message": "이미 삭제한 댓글입니다.",
+                        "details": {
+                          "commentId": "550e8400-e29b-41d4-a716-446655440000"
+                        },
+                        "exceptionType": "CommentException",
+                        "status": 400
+                      }""")
+              }
+          )
       ),
       @ApiResponse(
           responseCode = "401",
           description = "Monew-Request-User-ID 헤더 누락",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "UNAUTHORIZED",
+                    "message": "Required request header 'Monew-Request-User-ID' for method parameter type UUID is not present",
+                    "details": {},
+                    "exceptionType": "MissingRequestHeaderException",
+                    "status": 401
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "403",
-          description = "본인의 댓글이 아닙니다 (CM02)",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          description = "본인의 댓글이 아님 (CM02)",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "CM02",
+                    "message": "본인의 댓글이 아닙니다.",
+                    "details": {
+                      "commentId": "550e8400-e29b-41d4-a716-446655440000",
+                      "userId": "770e8400-e29b-41d4-a716-446655440002"
+                    },
+                    "exceptionType": "CommentException",
+                    "status": 403
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "404",
           description = "댓글을 찾을 수 없음 (CM01)",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "CM01",
+                    "message": "댓글을 찾을 수 없습니다.",
+                    "details": {
+                      "commentId": "550e8400-e29b-41d4-a716-446655440000"
+                    },
+                    "exceptionType": "CommentException",
+                    "status": 404
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "415",
           description = "지원하지 않는 Content-Type (application/json 필요)",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "UNSUPPORTED_MEDIA_TYPE",
+                    "message": "Content-Type 'text/plain' is not supported",
+                    "details": {},
+                    "exceptionType": "HttpMediaTypeNotSupportedException",
+                    "status": 415
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "500",
           description = "서버 내부 오류",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "INTERNAL_SERVER_ERROR",
+                    "message": "서버 내부 오류가 발생했습니다.",
+                    "details": {},
+                    "exceptionType": "Exception",
+                    "status": 500
+                  }""")
+          )
       )
   })
   ResponseEntity<CommentDto> update(
@@ -211,12 +530,38 @@ public interface CommentApiDocs {
       @ApiResponse(
           responseCode = "404",
           description = "댓글을 찾을 수 없음 (CM01)",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "CM01",
+                    "message": "댓글을 찾을 수 없습니다.",
+                    "details": {
+                      "commentId": "550e8400-e29b-41d4-a716-446655440000"
+                    },
+                    "exceptionType": "CommentException",
+                    "status": 404
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "500",
           description = "서버 내부 오류",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "INTERNAL_SERVER_ERROR",
+                    "message": "서버 내부 오류가 발생했습니다.",
+                    "details": {},
+                    "exceptionType": "Exception",
+                    "status": 500
+                  }""")
+          )
       )
   })
   ResponseEntity<Void> hardDelete(

--- a/src/main/java/com/springboot/monew/comment/controller/CommentApiDocs.java
+++ b/src/main/java/com/springboot/monew/comment/controller/CommentApiDocs.java
@@ -1,8 +1,225 @@
 package com.springboot.monew.comment.controller;
 
-import io.swagger.v3.oas.annotations.tags.Tag;
+import com.springboot.monew.comment.dto.CommentDto;
+import com.springboot.monew.comment.dto.CommentPageRequest;
+import com.springboot.monew.comment.dto.CommentRegisterRequest;
+import com.springboot.monew.comment.dto.CommentUpdateRequest;
+import com.springboot.monew.comment.dto.CursorPageResponseCommentDto;
+import com.springboot.monew.common.exception.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 
-@Tag(name = "댓글", description = "댓글 관련 API")
 public interface CommentApiDocs {
-  // Todo : 문서화 시 작업 예정
+
+  @Operation(
+      summary = "댓글 목록 조회",
+      description = """
+          `GET /api/comments`
+
+          커서 기반 페이지네이션으로 댓글 목록을 조회합니다.""",
+      operationId = "list_1"
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "댓글 목록 조회 성공",
+          content = @Content(schema = @Schema(implementation = CursorPageResponseCommentDto.class))
+      ),
+      @ApiResponse(
+          responseCode = "400",
+          description = """
+              잘못된 요청
+              - 필수 쿼리 파라미터 누락 또는 형식 오류
+              - limit이 1 미만이거나 허용 범위 초과
+              - orderBy 값이 허용된 값이 아님 (createdAt, likeCount)
+              - after 커서 형식 불일치""",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "401",
+          description = "Monew-Request-User-ID 헤더 누락",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "500",
+          description = "서버 내부 오류",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      )
+  })
+  CursorPageResponseCommentDto<CommentDto> list(
+      @Valid CommentPageRequest request,
+      @Parameter(description = "요청자 ID") @RequestHeader("Monew-Request-User-ID") UUID userId
+  );
+
+  @Operation(
+      summary = "댓글 등록",
+      description = """
+          `POST /api/comments`
+
+          새로운 댓글을 등록합니다.""",
+      operationId = "create_2"
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "201",
+          description = "댓글 등록 성공",
+          content = @Content(schema = @Schema(implementation = CommentDto.class))
+      ),
+      @ApiResponse(
+          responseCode = "400",
+          description = """
+              잘못된 요청
+              - content가 null이거나 빈 문자열
+              - content 길이 초과
+              - articleId 또는 userId 형식 오류 (UUID 아님)""",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "404",
+          description = """
+              리소스 없음
+              - 뉴스 기사를 찾을 수 없음 (NA01)
+              - 사용자를 찾을 수 없음 (UR03)""",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "415",
+          description = "지원하지 않는 Content-Type (application/json 필요)",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "500",
+          description = "서버 내부 오류",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      )
+  })
+  ResponseEntity<CommentDto> create(
+      @Valid @RequestBody CommentRegisterRequest request
+  );
+
+  @Operation(
+      summary = "댓글 논리 삭제",
+      description = """
+          `DELETE /api/comments/{commentId}`
+
+          댓글을 논리적으로 삭제합니다. 이미 삭제된 댓글은 삭제할 수 없습니다.""",
+      operationId = "softDelete_1"
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "204",
+          description = "댓글 논리 삭제 성공"
+      ),
+      @ApiResponse(
+          responseCode = "400",
+          description = "이미 삭제된 댓글입니다 (CM05)",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "404",
+          description = "댓글을 찾을 수 없음 (CM01)",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "500",
+          description = "서버 내부 오류",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      )
+  })
+  ResponseEntity<Void> softDelete(
+      @Parameter(description = "댓글 ID") @PathVariable UUID commentId
+  );
+
+  @Operation(
+      summary = "댓글 수정",
+      description = """
+          `PATCH /api/comments/{commentId}`
+
+          댓글 내용을 수정합니다. 본인의 댓글만 수정할 수 있습니다.""",
+      operationId = "update_1"
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "댓글 수정 성공",
+          content = @Content(schema = @Schema(implementation = CommentDto.class))
+      ),
+      @ApiResponse(
+          responseCode = "400",
+          description = """
+              잘못된 요청
+              - content가 null이거나 빈 문자열
+              - content 길이 초과
+              - 이미 삭제된 댓글입니다 (CM05)""",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "401",
+          description = "Monew-Request-User-ID 헤더 누락",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "403",
+          description = "본인의 댓글이 아닙니다 (CM02)",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "404",
+          description = "댓글을 찾을 수 없음 (CM01)",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "415",
+          description = "지원하지 않는 Content-Type (application/json 필요)",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "500",
+          description = "서버 내부 오류",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      )
+  })
+  ResponseEntity<CommentDto> update(
+      @Parameter(description = "댓글 ID") @PathVariable UUID commentId,
+      @Parameter(description = "요청자 ID") @RequestHeader("Monew-Request-User-ID") UUID userId,
+      @Valid @RequestBody CommentUpdateRequest request
+  );
+
+  @Operation(
+      summary = "댓글 물리 삭제",
+      description = """
+          `DELETE /api/comments/{commentId}/hard`
+
+          댓글을 물리적으로 삭제합니다. 데이터베이스에서 완전히 제거됩니다.""",
+      operationId = "hardDelete_2"
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "204",
+          description = "댓글 물리 삭제 성공"
+      ),
+      @ApiResponse(
+          responseCode = "404",
+          description = "댓글을 찾을 수 없음 (CM01)",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "500",
+          description = "서버 내부 오류",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      )
+  })
+  ResponseEntity<Void> hardDelete(
+      @Parameter(description = "댓글 ID") @PathVariable UUID commentId
+  );
 }

--- a/src/main/java/com/springboot/monew/comment/controller/CommentController.java
+++ b/src/main/java/com/springboot/monew/comment/controller/CommentController.java
@@ -2,6 +2,7 @@ package com.springboot.monew.comment.controller;
 
 import com.springboot.monew.comment.dto.*;
 import com.springboot.monew.comment.service.CommentService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.net.URI;
 import java.util.UUID;
@@ -10,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "댓글 관리", description = "댓글 관련 API")
 @Slf4j
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/springboot/monew/comment/controller/CommentLikeApiDocs.java
+++ b/src/main/java/com/springboot/monew/comment/controller/CommentLikeApiDocs.java
@@ -1,5 +1,97 @@
 package com.springboot.monew.comment.controller;
 
+import com.springboot.monew.comment.dto.CommentLikeDto;
+import com.springboot.monew.common.exception.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+
 public interface CommentLikeApiDocs {
-// Todo : 문서화 시 작업 예정
+
+  @Operation(
+      summary = "댓글 좋아요",
+      description = """
+          `POST /api/comments/{commentId}/comment-likes`
+
+          댓글에 좋아요를 추가합니다. 동일한 댓글에 중복 좋아요는 불가합니다.""",
+      operationId = "like"
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "201",
+          description = "댓글 좋아요 성공",
+          content = @Content(schema = @Schema(implementation = CommentLikeDto.class))
+      ),
+      @ApiResponse(
+          responseCode = "401",
+          description = "Monew-Request-User-ID 헤더 누락",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "404",
+          description = """
+              리소스 없음
+              - 댓글을 찾을 수 없음 (CM01)
+              - 사용자를 찾을 수 없음 (UR03)""",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "409",
+          description = "이미 좋아요를 누른 댓글입니다 (CM03)",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "500",
+          description = "서버 내부 오류",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      )
+  })
+  ResponseEntity<CommentLikeDto> like(
+      @Parameter(description = "댓글 ID") @PathVariable UUID commentId,
+      @Parameter(description = "요청자 ID") @RequestHeader("Monew-Request-User-ID") UUID userId
+  );
+
+  @Operation(
+      summary = "댓글 좋아요 취소",
+      description = """
+          `DELETE /api/comments/{commentId}/comment-likes`
+
+          댓글 좋아요를 취소합니다. 좋아요를 누르지 않은 댓글은 취소할 수 없습니다.""",
+      operationId = "unlike"
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "댓글 좋아요 취소 성공"
+      ),
+      @ApiResponse(
+          responseCode = "401",
+          description = "Monew-Request-User-ID 헤더 누락",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "404",
+          description = """
+              리소스 없음
+              - 댓글을 찾을 수 없음 (CM01)
+              - 좋아요를 누르지 않은 댓글입니다 (CM04)""",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "500",
+          description = "서버 내부 오류",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      )
+  })
+  void unlike(
+      @Parameter(description = "댓글 ID") @PathVariable UUID commentId,
+      @Parameter(description = "요청자 ID") @RequestHeader("Monew-Request-User-ID") UUID userId
+  );
 }

--- a/src/main/java/com/springboot/monew/comment/controller/CommentLikeApiDocs.java
+++ b/src/main/java/com/springboot/monew/comment/controller/CommentLikeApiDocs.java
@@ -5,6 +5,7 @@ import com.springboot.monew.common.exception.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -27,12 +28,34 @@ public interface CommentLikeApiDocs {
       @ApiResponse(
           responseCode = "201",
           description = "댓글 좋아요 성공",
-          content = @Content(schema = @Schema(implementation = CommentLikeDto.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = CommentLikeDto.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "id": "aa0e8400-e29b-41d4-a716-446655440000",
+                    "commentId": "550e8400-e29b-41d4-a716-446655440000",
+                    "userId": "770e8400-e29b-41d4-a716-446655440002",
+                    "createdAt": "2024-01-15T10:30:00.000Z"
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "401",
           description = "Monew-Request-User-ID 헤더 누락",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "UNAUTHORIZED",
+                    "message": "Required request header 'Monew-Request-User-ID' for method parameter type UUID is not present",
+                    "details": {},
+                    "exceptionType": "MissingRequestHeaderException",
+                    "status": 401
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "404",
@@ -40,17 +63,58 @@ public interface CommentLikeApiDocs {
               리소스 없음
               - 댓글을 찾을 수 없음 (CM01)
               - 사용자를 찾을 수 없음 (UR03)""",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "CM01",
+                    "message": "댓글을 찾을 수 없습니다.",
+                    "details": {
+                      "commentId": "550e8400-e29b-41d4-a716-446655440000"
+                    },
+                    "exceptionType": "CommentException",
+                    "status": 404
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "409",
-          description = "이미 좋아요를 누른 댓글입니다 (CM03)",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          description = "이미 좋아요를 누른 댓글 (CM03)",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "CM03",
+                    "message": "이미 좋아요를 눌렀습니다.",
+                    "details": {
+                      "commentId": "550e8400-e29b-41d4-a716-446655440000",
+                      "userId": "770e8400-e29b-41d4-a716-446655440002"
+                    },
+                    "exceptionType": "CommentException",
+                    "status": 409
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "500",
           description = "서버 내부 오류",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "INTERNAL_SERVER_ERROR",
+                    "message": "서버 내부 오류가 발생했습니다.",
+                    "details": {},
+                    "exceptionType": "Exception",
+                    "status": 500
+                  }""")
+          )
       )
   })
   ResponseEntity<CommentLikeDto> like(
@@ -74,20 +138,72 @@ public interface CommentLikeApiDocs {
       @ApiResponse(
           responseCode = "401",
           description = "Monew-Request-User-ID 헤더 누락",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "UNAUTHORIZED",
+                    "message": "Required request header 'Monew-Request-User-ID' for method parameter type UUID is not present",
+                    "details": {},
+                    "exceptionType": "MissingRequestHeaderException",
+                    "status": 401
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "404",
           description = """
               리소스 없음
               - 댓글을 찾을 수 없음 (CM01)
-              - 좋아요를 누르지 않은 댓글입니다 (CM04)""",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+              - 좋아요를 누르지 않은 댓글 (CM04)""",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = {
+                  @ExampleObject(name = "commentNotFound", summary = "댓글 없음 (CM01)", value = """
+                      {
+                        "timestamp": "2024-01-15T10:30:00.000Z",
+                        "code": "CM01",
+                        "message": "댓글을 찾을 수 없습니다.",
+                        "details": {
+                          "commentId": "550e8400-e29b-41d4-a716-446655440000"
+                        },
+                        "exceptionType": "CommentException",
+                        "status": 404
+                      }"""),
+                  @ExampleObject(name = "likeNotFound", summary = "좋아요 없음 (CM04)", value = """
+                      {
+                        "timestamp": "2024-01-15T10:30:00.000Z",
+                        "code": "CM04",
+                        "message": "좋아요를 누르지 않았습니다.",
+                        "details": {
+                          "commentId": "550e8400-e29b-41d4-a716-446655440000",
+                          "userId": "770e8400-e29b-41d4-a716-446655440002"
+                        },
+                        "exceptionType": "CommentException",
+                        "status": 404
+                      }""")
+              }
+          )
       ),
       @ApiResponse(
           responseCode = "500",
           description = "서버 내부 오류",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "INTERNAL_SERVER_ERROR",
+                    "message": "서버 내부 오류가 발생했습니다.",
+                    "details": {},
+                    "exceptionType": "Exception",
+                    "status": 500
+                  }""")
+          )
       )
   })
   void unlike(

--- a/src/main/java/com/springboot/monew/comment/controller/CommentLikeController.java
+++ b/src/main/java/com/springboot/monew/comment/controller/CommentLikeController.java
@@ -2,6 +2,7 @@ package com.springboot.monew.comment.controller;
 
 import com.springboot.monew.comment.dto.CommentLikeDto;
 import com.springboot.monew.comment.service.CommentLikeService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.net.URI;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -14,11 +15,12 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "댓글 관리", description = "댓글 관련 API")
 @Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/comments/{commentId}/comment-likes")
-public class CommentLikeController {
+public class CommentLikeController implements CommentLikeApiDocs {
   private final CommentLikeService commentLikeService;
 
   // 관심사 댓글 좋아요 API

--- a/src/main/java/com/springboot/monew/comment/dto/CursorPageResponseCommentDto.java
+++ b/src/main/java/com/springboot/monew/comment/dto/CursorPageResponseCommentDto.java
@@ -4,7 +4,6 @@ import java.time.Instant;
 import java.util.List;
 
 // 페이지네이션 응답 Dto
-// Todo: 디폴트 값 설정 추가
 public record CursorPageResponseCommentDto<T>(
     List<T> content,
     String nextCursor,

--- a/src/main/java/com/springboot/monew/comment/dto/CursorPageResponseCommentDto.java
+++ b/src/main/java/com/springboot/monew/comment/dto/CursorPageResponseCommentDto.java
@@ -9,6 +9,6 @@ public record CursorPageResponseCommentDto<T>(
     List<T> content,
     String nextCursor,
     Instant nextAfter,
-    int size,
-    long totalElements,
-    boolean hasNext) {}
+    Integer size,
+    Long totalElements,
+    Boolean hasNext) {}

--- a/src/main/java/com/springboot/monew/interest/controller/InterestApiDocs.java
+++ b/src/main/java/com/springboot/monew/interest/controller/InterestApiDocs.java
@@ -9,7 +9,9 @@ import com.springboot.monew.interest.dto.response.InterestDto;
 import com.springboot.monew.interest.dto.response.SubscriptionDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -30,31 +32,134 @@ public interface InterestApiDocs {
           커서 기반 페이지네이션으로 관심사 목록을 조회합니다.""",
       operationId = "list_2"
   )
+  @Parameters({
+      @Parameter(
+          name = "keyword",
+          description = "관심사 이름 검색 키워드 (선택, 부분 일치)",
+          example = "인공지능"
+      ),
+      @Parameter(
+          name = "orderBy",
+          description = """
+              정렬 기준 (필수)
+              - `name` : 관심사 이름 순
+              - `subscriberCount` : 구독자 수 순""",
+          required = true,
+          schema = @Schema(type = "string", allowableValues = {"name", "subscriberCount"})
+      ),
+      @Parameter(
+          name = "direction",
+          description = """
+              정렬 방향 (필수)
+              - `ASC` : 오름차순
+              - `DESC` : 내림차순""",
+          required = true,
+          schema = @Schema(type = "string", allowableValues = {"ASC", "DESC"})
+      ),
+      @Parameter(
+          name = "cursor",
+          description = """
+              이전 페이지의 마지막 커서 값 (첫 페이지 조회 시 생략)
+              - orderBy=`name` 형식: `인공지능`
+              - orderBy=`subscriberCount` 형식: `1000`""",
+          example = "인공지능"
+      ),
+      @Parameter(
+          name = "after",
+          description = "이전 페이지의 마지막 항목 createdAt (cursor와 함께 사용)",
+          example = "2024-01-15T10:30:00.000Z"
+      ),
+      @Parameter(
+          name = "limit",
+          description = "페이지당 조회 개수 (필수, 최소: 1, 최대: 100)",
+          required = true,
+          schema = @Schema(type = "integer", minimum = "1", maximum = "100")
+      )
+  })
   @ApiResponses({
       @ApiResponse(
           responseCode = "200",
           description = "관심사 목록 조회 성공",
-          content = @Content(schema = @Schema(implementation = CursorPageResponseInterestDto.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = CursorPageResponseInterestDto.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "content": [
+                      {
+                        "id": "550e8400-e29b-41d4-a716-446655440000",
+                        "name": "인공지능",
+                        "keywords": ["AI", "머신러닝", "딥러닝"],
+                        "subscriberCount": 1024,
+                        "subscribedByMe": true,
+                        "createdAt": "2024-01-15T10:30:00.000Z"
+                      }
+                    ],
+                    "nextCursor": "인공지능",
+                    "nextAfter": "2024-01-15T10:30:00.000Z",
+                    "size": 1,
+                    "totalElements": 15,
+                    "hasNext": false
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "400",
           description = """
               잘못된 요청
-              - 필수 쿼리 파라미터 누락 또는 형식 오류
-              - limit이 1 미만이거나 허용 범위 초과
-              - orderBy 값이 허용된 값이 아님 (name, subscriberCount)
-              - after 커서 형식 불일치""",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+              - 필수 파라미터 누락 또는 형식 오류
+              - limit 범위 초과 (1~100)
+              - orderBy 값이 허용된 값이 아님 (name, subscriberCount)""",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "BAD_REQUEST",
+                    "message": "입력값 검증에 실패하였습니다.",
+                    "details": {
+                      "orderBy": ["널이어서는 안됩니다"],
+                      "limit": ["1에서 100 사이여야 합니다"]
+                    },
+                    "exceptionType": "MethodArgumentNotValidException",
+                    "status": 400
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "401",
           description = "Monew-Request-User-ID 헤더 누락",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "UNAUTHORIZED",
+                    "message": "Required request header 'Monew-Request-User-ID' for method parameter type UUID is not present",
+                    "details": {},
+                    "exceptionType": "MissingRequestHeaderException",
+                    "status": 401
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "500",
           description = "서버 내부 오류",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "INTERNAL_SERVER_ERROR",
+                    "message": "서버 내부 오류가 발생했습니다.",
+                    "details": {},
+                    "exceptionType": "Exception",
+                    "status": 500
+                  }""")
+          )
       )
   })
   CursorPageResponseInterestDto list(
@@ -74,32 +179,110 @@ public interface InterestApiDocs {
       @ApiResponse(
           responseCode = "201",
           description = "관심사 등록 성공",
-          content = @Content(schema = @Schema(implementation = InterestDto.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = InterestDto.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "id": "550e8400-e29b-41d4-a716-446655440000",
+                    "name": "인공지능",
+                    "keywords": ["AI", "머신러닝", "딥러닝"],
+                    "subscriberCount": 0,
+                    "subscribedByMe": false,
+                    "createdAt": "2024-01-15T10:30:00.000Z"
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "400",
           description = """
               잘못된 요청
               - name이 null이거나 빈 문자열
-              - name 길이 초과
               - keywords가 null이거나 비어 있음
-              - keywords 목록에 중복된 키워드가 존재 (IN02)""",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+              - keywords에 중복된 값 존재 (IN02)""",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = {
+                  @ExampleObject(name = "validationError", summary = "입력값 검증 실패", value = """
+                      {
+                        "timestamp": "2024-01-15T10:30:00.000Z",
+                        "code": "BAD_REQUEST",
+                        "message": "입력값 검증에 실패하였습니다.",
+                        "details": {
+                          "name": ["공백일 수 없습니다"],
+                          "keywords": ["비어 있을 수 없습니다"]
+                        },
+                        "exceptionType": "MethodArgumentNotValidException",
+                        "status": 400
+                      }"""),
+                  @ExampleObject(name = "duplicateKeywords", summary = "중복 키워드 (IN02)", value = """
+                      {
+                        "timestamp": "2024-01-15T10:30:00.000Z",
+                        "code": "IN02",
+                        "message": "키워드는 중복될 수 없습니다.",
+                        "details": {
+                          "duplicatedKeyword": "AI"
+                        },
+                        "exceptionType": "InterestException",
+                        "status": 400
+                      }""")
+              }
+          )
       ),
       @ApiResponse(
           responseCode = "409",
-          description = "유사한 이름의 관심사가 이미 존재합니다 (IN01)",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          description = "유사한 이름의 관심사가 이미 존재 (IN01)",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "IN01",
+                    "message": "유사한 이름의 관심사가 이미 존재합니다.",
+                    "details": {
+                      "inputName": "인공 지능",
+                      "existingName": "인공지능"
+                    },
+                    "exceptionType": "InterestException",
+                    "status": 409
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "415",
           description = "지원하지 않는 Content-Type (application/json 필요)",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "UNSUPPORTED_MEDIA_TYPE",
+                    "message": "Content-Type 'text/plain' is not supported",
+                    "details": {},
+                    "exceptionType": "HttpMediaTypeNotSupportedException",
+                    "status": 415
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "500",
           description = "서버 내부 오류",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "INTERNAL_SERVER_ERROR",
+                    "message": "서버 내부 오류가 발생했습니다.",
+                    "details": {},
+                    "exceptionType": "Exception",
+                    "status": 500
+                  }""")
+          )
       )
   })
   ResponseEntity<InterestDto> create(
@@ -111,42 +294,121 @@ public interface InterestApiDocs {
       description = """
           `PATCH /api/interests/{interestId}`
 
-          관심사의 키워드 목록을 수정합니다. 유사한 이름의 관심사가 이미 존재하면 수정할 수 없습니다.""",
+          관심사의 키워드 목록을 수정합니다.""",
       operationId = "update_2"
   )
   @ApiResponses({
       @ApiResponse(
           responseCode = "200",
           description = "관심사 수정 성공",
-          content = @Content(schema = @Schema(implementation = InterestDto.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = InterestDto.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "id": "550e8400-e29b-41d4-a716-446655440000",
+                    "name": "인공지능",
+                    "keywords": ["AI", "ChatGPT", "LLM"],
+                    "subscriberCount": 1024,
+                    "subscribedByMe": true,
+                    "createdAt": "2024-01-15T10:30:00.000Z"
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "400",
           description = """
               잘못된 요청
               - keywords가 null이거나 비어 있음
-              - keywords 목록에 중복된 키워드가 존재 (IN02)""",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+              - keywords에 중복된 값 존재 (IN02)""",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "IN02",
+                    "message": "키워드는 중복될 수 없습니다.",
+                    "details": {
+                      "duplicatedKeyword": "AI"
+                    },
+                    "exceptionType": "InterestException",
+                    "status": 400
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "404",
           description = "관심사를 찾을 수 없음 (IN03)",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "IN03",
+                    "message": "관심사를 찾을 수 없습니다.",
+                    "details": {
+                      "interestId": "550e8400-e29b-41d4-a716-446655440000"
+                    },
+                    "exceptionType": "InterestException",
+                    "status": 404
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "409",
-          description = "유사한 이름의 관심사가 이미 존재합니다 (IN01)",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          description = "유사한 이름의 관심사가 이미 존재 (IN01)",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "IN01",
+                    "message": "유사한 이름의 관심사가 이미 존재합니다.",
+                    "details": {
+                      "inputName": "인공 지능",
+                      "existingName": "인공지능"
+                    },
+                    "exceptionType": "InterestException",
+                    "status": 409
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "415",
           description = "지원하지 않는 Content-Type (application/json 필요)",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "UNSUPPORTED_MEDIA_TYPE",
+                    "message": "Content-Type 'text/plain' is not supported",
+                    "details": {},
+                    "exceptionType": "HttpMediaTypeNotSupportedException",
+                    "status": 415
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "500",
           description = "서버 내부 오류",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "INTERNAL_SERVER_ERROR",
+                    "message": "서버 내부 오류가 발생했습니다.",
+                    "details": {},
+                    "exceptionType": "Exception",
+                    "status": 500
+                  }""")
+          )
       )
   })
   ResponseEntity<InterestDto> update(
@@ -163,19 +425,42 @@ public interface InterestApiDocs {
       operationId = "delete_1"
   )
   @ApiResponses({
-      @ApiResponse(
-          responseCode = "204",
-          description = "관심사 삭제 성공"
-      ),
+      @ApiResponse(responseCode = "204", description = "관심사 삭제 성공"),
       @ApiResponse(
           responseCode = "404",
           description = "관심사를 찾을 수 없음 (IN03)",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "IN03",
+                    "message": "관심사를 찾을 수 없습니다.",
+                    "details": {
+                      "interestId": "550e8400-e29b-41d4-a716-446655440000"
+                    },
+                    "exceptionType": "InterestException",
+                    "status": 404
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "500",
           description = "서버 내부 오류",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "INTERNAL_SERVER_ERROR",
+                    "message": "서버 내부 오류가 발생했습니다.",
+                    "details": {},
+                    "exceptionType": "Exception",
+                    "status": 500
+                  }""")
+          )
       )
   })
   ResponseEntity<Void> delete(
@@ -194,12 +479,35 @@ public interface InterestApiDocs {
       @ApiResponse(
           responseCode = "200",
           description = "관심사 구독 성공",
-          content = @Content(schema = @Schema(implementation = SubscriptionDto.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = SubscriptionDto.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "id": "bb0e8400-e29b-41d4-a716-446655440000",
+                    "interestId": "550e8400-e29b-41d4-a716-446655440000",
+                    "interestName": "인공지능",
+                    "interestKeywords": ["AI", "머신러닝", "딥러닝"],
+                    "createdAt": "2024-01-15T10:30:00.000Z"
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "401",
           description = "Monew-Request-User-ID 헤더 누락",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "UNAUTHORIZED",
+                    "message": "Required request header 'Monew-Request-User-ID' for method parameter type UUID is not present",
+                    "details": {},
+                    "exceptionType": "MissingRequestHeaderException",
+                    "status": 401
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "404",
@@ -207,17 +515,58 @@ public interface InterestApiDocs {
               리소스 없음
               - 관심사를 찾을 수 없음 (IN03)
               - 사용자를 찾을 수 없음 (UR03)""",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "IN03",
+                    "message": "관심사를 찾을 수 없습니다.",
+                    "details": {
+                      "interestId": "550e8400-e29b-41d4-a716-446655440000"
+                    },
+                    "exceptionType": "InterestException",
+                    "status": 404
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "409",
-          description = "이미 구독 중인 관심사입니다 (IN04)",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          description = "이미 구독 중인 관심사 (IN04)",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "IN04",
+                    "message": "이미 구독한 관심사입니다.",
+                    "details": {
+                      "interestId": "550e8400-e29b-41d4-a716-446655440000",
+                      "userId": "770e8400-e29b-41d4-a716-446655440002"
+                    },
+                    "exceptionType": "InterestException",
+                    "status": 409
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "500",
           description = "서버 내부 오류",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "INTERNAL_SERVER_ERROR",
+                    "message": "서버 내부 오류가 발생했습니다.",
+                    "details": {},
+                    "exceptionType": "Exception",
+                    "status": 500
+                  }""")
+          )
       )
   })
   ResponseEntity<SubscriptionDto> subscribe(
@@ -234,27 +583,76 @@ public interface InterestApiDocs {
       operationId = "unsubscribe"
   )
   @ApiResponses({
-      @ApiResponse(
-          responseCode = "204",
-          description = "관심사 구독 취소 성공"
-      ),
+      @ApiResponse(responseCode = "204", description = "관심사 구독 취소 성공"),
       @ApiResponse(
           responseCode = "401",
           description = "Monew-Request-User-ID 헤더 누락",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "UNAUTHORIZED",
+                    "message": "Required request header 'Monew-Request-User-ID' for method parameter type UUID is not present",
+                    "details": {},
+                    "exceptionType": "MissingRequestHeaderException",
+                    "status": 401
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "404",
           description = """
               리소스 없음
               - 관심사를 찾을 수 없음 (IN03)
-              - 구독 중인 관심사가 아닙니다 (IN05)""",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+              - 구독 중인 관심사가 아님 (IN05)""",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = {
+                  @ExampleObject(name = "interestNotFound", summary = "관심사 없음 (IN03)", value = """
+                      {
+                        "timestamp": "2024-01-15T10:30:00.000Z",
+                        "code": "IN03",
+                        "message": "관심사를 찾을 수 없습니다.",
+                        "details": {
+                          "interestId": "550e8400-e29b-41d4-a716-446655440000"
+                        },
+                        "exceptionType": "InterestException",
+                        "status": 404
+                      }"""),
+                  @ExampleObject(name = "subscriptionNotFound", summary = "미구독 관심사 (IN05)", value = """
+                      {
+                        "timestamp": "2024-01-15T10:30:00.000Z",
+                        "code": "IN05",
+                        "message": "구독 중인 관심사가 아닙니다.",
+                        "details": {
+                          "interestId": "550e8400-e29b-41d4-a716-446655440000",
+                          "userId": "770e8400-e29b-41d4-a716-446655440002"
+                        },
+                        "exceptionType": "InterestException",
+                        "status": 404
+                      }""")
+              }
+          )
       ),
       @ApiResponse(
           responseCode = "500",
           description = "서버 내부 오류",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "INTERNAL_SERVER_ERROR",
+                    "message": "서버 내부 오류가 발생했습니다.",
+                    "details": {},
+                    "exceptionType": "Exception",
+                    "status": 500
+                  }""")
+          )
       )
   })
   ResponseEntity<Void> unsubscribe(

--- a/src/main/java/com/springboot/monew/interest/controller/InterestApiDocs.java
+++ b/src/main/java/com/springboot/monew/interest/controller/InterestApiDocs.java
@@ -1,5 +1,264 @@
 package com.springboot.monew.interest.controller;
 
+import com.springboot.monew.common.exception.ErrorResponse;
+import com.springboot.monew.interest.dto.request.InterestPageRequest;
+import com.springboot.monew.interest.dto.request.InterestRegisterRequest;
+import com.springboot.monew.interest.dto.request.InterestUpdateRequest;
+import com.springboot.monew.interest.dto.response.CursorPageResponseInterestDto;
+import com.springboot.monew.interest.dto.response.InterestDto;
+import com.springboot.monew.interest.dto.response.SubscriptionDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
 public interface InterestApiDocs {
 
+  @Operation(
+      summary = "관심사 목록 조회",
+      description = """
+          `GET /api/interests`
+
+          커서 기반 페이지네이션으로 관심사 목록을 조회합니다.""",
+      operationId = "list_2"
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "관심사 목록 조회 성공",
+          content = @Content(schema = @Schema(implementation = CursorPageResponseInterestDto.class))
+      ),
+      @ApiResponse(
+          responseCode = "400",
+          description = """
+              잘못된 요청
+              - 필수 쿼리 파라미터 누락 또는 형식 오류
+              - limit이 1 미만이거나 허용 범위 초과
+              - orderBy 값이 허용된 값이 아님 (name, subscriberCount)
+              - after 커서 형식 불일치""",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "401",
+          description = "Monew-Request-User-ID 헤더 누락",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "500",
+          description = "서버 내부 오류",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      )
+  })
+  CursorPageResponseInterestDto list(
+      @Valid InterestPageRequest request,
+      @Parameter(description = "요청자 ID") @RequestHeader("Monew-Request-User-ID") UUID userId
+  );
+
+  @Operation(
+      summary = "관심사 등록",
+      description = """
+          `POST /api/interests`
+
+          새로운 관심사를 등록합니다. 유사한 이름의 관심사가 이미 존재하면 등록할 수 없습니다.""",
+      operationId = "create_3"
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "201",
+          description = "관심사 등록 성공",
+          content = @Content(schema = @Schema(implementation = InterestDto.class))
+      ),
+      @ApiResponse(
+          responseCode = "400",
+          description = """
+              잘못된 요청
+              - name이 null이거나 빈 문자열
+              - name 길이 초과
+              - keywords가 null이거나 비어 있음
+              - keywords 목록에 중복된 키워드가 존재 (IN02)""",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "409",
+          description = "유사한 이름의 관심사가 이미 존재합니다 (IN01)",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "415",
+          description = "지원하지 않는 Content-Type (application/json 필요)",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "500",
+          description = "서버 내부 오류",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      )
+  })
+  ResponseEntity<InterestDto> create(
+      @Valid @RequestBody InterestRegisterRequest request
+  );
+
+  @Operation(
+      summary = "관심사 수정",
+      description = """
+          `PATCH /api/interests/{interestId}`
+
+          관심사의 키워드 목록을 수정합니다. 유사한 이름의 관심사가 이미 존재하면 수정할 수 없습니다.""",
+      operationId = "update_2"
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "관심사 수정 성공",
+          content = @Content(schema = @Schema(implementation = InterestDto.class))
+      ),
+      @ApiResponse(
+          responseCode = "400",
+          description = """
+              잘못된 요청
+              - keywords가 null이거나 비어 있음
+              - keywords 목록에 중복된 키워드가 존재 (IN02)""",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "404",
+          description = "관심사를 찾을 수 없음 (IN03)",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "409",
+          description = "유사한 이름의 관심사가 이미 존재합니다 (IN01)",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "415",
+          description = "지원하지 않는 Content-Type (application/json 필요)",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "500",
+          description = "서버 내부 오류",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      )
+  })
+  ResponseEntity<InterestDto> update(
+      @Parameter(description = "관심사 ID") @PathVariable UUID interestId,
+      @Valid @RequestBody InterestUpdateRequest request
+  );
+
+  @Operation(
+      summary = "관심사 물리 삭제",
+      description = """
+          `DELETE /api/interests/{interestId}`
+
+          관심사를 물리적으로 삭제합니다. 연관된 구독 정보도 함께 삭제됩니다.""",
+      operationId = "delete_1"
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "204",
+          description = "관심사 삭제 성공"
+      ),
+      @ApiResponse(
+          responseCode = "404",
+          description = "관심사를 찾을 수 없음 (IN03)",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "500",
+          description = "서버 내부 오류",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      )
+  })
+  ResponseEntity<Void> delete(
+      @Parameter(description = "관심사 ID") @PathVariable UUID interestId
+  );
+
+  @Operation(
+      summary = "관심사 구독",
+      description = """
+          `POST /api/interests/{interestId}/subscriptions`
+
+          관심사를 구독합니다. 이미 구독 중인 관심사는 중복 구독할 수 없습니다.""",
+      operationId = "subscribe"
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "관심사 구독 성공",
+          content = @Content(schema = @Schema(implementation = SubscriptionDto.class))
+      ),
+      @ApiResponse(
+          responseCode = "401",
+          description = "Monew-Request-User-ID 헤더 누락",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "404",
+          description = """
+              리소스 없음
+              - 관심사를 찾을 수 없음 (IN03)
+              - 사용자를 찾을 수 없음 (UR03)""",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "409",
+          description = "이미 구독 중인 관심사입니다 (IN04)",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "500",
+          description = "서버 내부 오류",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      )
+  })
+  ResponseEntity<SubscriptionDto> subscribe(
+      @Parameter(description = "관심사 ID") @PathVariable UUID interestId,
+      @Parameter(description = "요청자 ID") @RequestHeader("Monew-Request-User-ID") UUID userId
+  );
+
+  @Operation(
+      summary = "관심사 구독 취소",
+      description = """
+          `DELETE /api/interests/{interestId}/subscriptions`
+
+          관심사 구독을 취소합니다. 구독 중이지 않은 관심사는 취소할 수 없습니다.""",
+      operationId = "unsubscribe"
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "204",
+          description = "관심사 구독 취소 성공"
+      ),
+      @ApiResponse(
+          responseCode = "401",
+          description = "Monew-Request-User-ID 헤더 누락",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "404",
+          description = """
+              리소스 없음
+              - 관심사를 찾을 수 없음 (IN03)
+              - 구독 중인 관심사가 아닙니다 (IN05)""",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "500",
+          description = "서버 내부 오류",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      )
+  })
+  ResponseEntity<Void> unsubscribe(
+      @Parameter(description = "관심사 ID") @PathVariable UUID interestId,
+      @Parameter(description = "요청자 ID") @RequestHeader("Monew-Request-User-ID") UUID userId
+  );
 }

--- a/src/main/java/com/springboot/monew/interest/controller/InterestController.java
+++ b/src/main/java/com/springboot/monew/interest/controller/InterestController.java
@@ -11,6 +11,7 @@ import com.springboot.monew.interest.service.SubscriptionService;
 import jakarta.validation.Valid;
 import java.net.URI;
 import java.util.UUID;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -23,6 +24,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "관심사 관리", description = "관심사 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/interests")

--- a/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleApiDocs.java
+++ b/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleApiDocs.java
@@ -1,0 +1,245 @@
+package com.springboot.monew.newsarticles.controller;
+
+import com.springboot.monew.common.exception.ErrorResponse;
+import com.springboot.monew.newsarticles.dto.request.NewsArticlePageRequest;
+import com.springboot.monew.newsarticles.dto.response.CursorPageResponseNewsArticleDto;
+import com.springboot.monew.newsarticles.dto.response.NewsArticleDto;
+import com.springboot.monew.newsarticles.dto.response.NewsArticleViewDto;
+import com.springboot.monew.newsarticles.enums.ArticleSource;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+public interface NewsArticleApiDocs {
+
+  @Operation(
+      summary = "뉴스 기사 수집",
+      description = """
+          `POST /api/articles`
+
+          외부 출처(네이버, RSS 등)에서 관심사 키워드 기반으로 뉴스 기사를 수집합니다.""",
+      operationId = "collectNews"
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "뉴스 수집 완료"
+      ),
+      @ApiResponse(
+          responseCode = "500",
+          description = "서버 내부 오류 (외부 API 호출 실패 또는 저장 실패)",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      )
+  })
+  ResponseEntity<String> collectNews();
+
+  @Operation(
+      summary = "뉴스 기사 조회 이력 등록",
+      description = """
+          `POST /api/articles/{articleId}/article-views`
+
+          사용자가 뉴스 기사를 조회했음을 기록합니다. 동일한 기사를 이미 조회한 경우 중복 등록할 수 없습니다.""",
+      operationId = "createView"
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "201",
+          description = "뉴스 기사 조회 이력 등록 성공",
+          content = @Content(schema = @Schema(implementation = NewsArticleViewDto.class))
+      ),
+      @ApiResponse(
+          responseCode = "400",
+          description = "이미 조회한 뉴스 기사입니다 (NA03)",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "401",
+          description = "Monew-Request-User-ID 헤더 누락",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "404",
+          description = """
+              리소스 없음
+              - 뉴스 기사를 찾을 수 없음 (NA01)
+              - 사용자를 찾을 수 없음 (UR03)""",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "500",
+          description = "서버 내부 오류",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      )
+  })
+  ResponseEntity<NewsArticleViewDto> createView(
+      @Parameter(description = "뉴스 기사 ID") @PathVariable("articleId") UUID articleId,
+      @Parameter(description = "요청자 ID") @RequestHeader("Monew-Request-User-ID") UUID userId
+  );
+
+  @Operation(
+      summary = "뉴스 기사 목록 조회",
+      description = """
+          `GET /api/articles`
+
+          커서 기반 페이지네이션으로 뉴스 기사 목록을 조회합니다.""",
+      operationId = "list_3"
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "뉴스 기사 목록 조회 성공",
+          content = @Content(schema = @Schema(implementation = CursorPageResponseNewsArticleDto.class))
+      ),
+      @ApiResponse(
+          responseCode = "400",
+          description = """
+              잘못된 요청
+              - 필수 쿼리 파라미터 누락 또는 형식 오류
+              - limit이 1 미만이거나 허용 범위 초과
+              - orderBy 값이 허용된 값이 아님 (publishedAt, commentCount)
+              - after 커서 형식 불일치
+              - source 값이 허용된 출처가 아님""",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "401",
+          description = "Monew-Request-User-ID 헤더 누락",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "500",
+          description = "서버 내부 오류",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      )
+  })
+  CursorPageResponseNewsArticleDto list(
+      @Valid NewsArticlePageRequest request,
+      @Parameter(description = "요청자 ID") @RequestHeader("Monew-Request-User-ID") UUID userId
+  );
+
+  @Operation(
+      summary = "뉴스 기사 단건 조회",
+      description = """
+          `GET /api/articles/{articleId}`
+
+          뉴스 기사 ID로 특정 뉴스 기사를 조회합니다.""",
+      operationId = "find_1"
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "뉴스 기사 단건 조회 성공",
+          content = @Content(schema = @Schema(implementation = NewsArticleDto.class))
+      ),
+      @ApiResponse(
+          responseCode = "401",
+          description = "Monew-Request-User-ID 헤더 누락",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "404",
+          description = "뉴스 기사를 찾을 수 없음 (NA01)",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "500",
+          description = "서버 내부 오류",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      )
+  })
+  ResponseEntity<NewsArticleDto> find(
+      @Parameter(description = "뉴스 기사 ID") @PathVariable("articleId") UUID articleId,
+      @Parameter(description = "요청자 ID") @RequestHeader("Monew-Request-User-ID") UUID userId
+  );
+
+  @Operation(
+      summary = "뉴스 기사 출처 목록 조회",
+      description = """
+          `GET /api/articles/sources`
+
+          사용 가능한 뉴스 기사 출처 목록을 조회합니다.""",
+      operationId = "findSource"
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "출처 목록 조회 성공"
+      ),
+      @ApiResponse(
+          responseCode = "500",
+          description = "서버 내부 오류",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      )
+  })
+  ResponseEntity<List<ArticleSource>> findSource();
+
+  @Operation(
+      summary = "뉴스 기사 논리 삭제",
+      description = """
+          `DELETE /api/articles/{articleId}`
+
+          뉴스 기사를 논리적으로 삭제합니다. 이미 삭제된 기사는 삭제할 수 없습니다.""",
+      operationId = "softDelete_2"
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "204",
+          description = "뉴스 기사 논리 삭제 성공"
+      ),
+      @ApiResponse(
+          responseCode = "400",
+          description = "이미 삭제된 뉴스 기사입니다 (NA02)",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "404",
+          description = "뉴스 기사를 찾을 수 없음 (NA01)",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "500",
+          description = "서버 내부 오류",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      )
+  })
+  ResponseEntity<Void> softDelete(
+      @Parameter(description = "뉴스 기사 ID") @PathVariable UUID articleId
+  );
+
+  @Operation(
+      summary = "뉴스 기사 물리 삭제",
+      description = """
+          `DELETE /api/articles/{articleId}/hard`
+
+          뉴스 기사를 물리적으로 삭제합니다. 데이터베이스에서 완전히 제거됩니다.""",
+      operationId = "hardDelete_3"
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "204",
+          description = "뉴스 기사 물리 삭제 성공"
+      ),
+      @ApiResponse(
+          responseCode = "404",
+          description = "뉴스 기사를 찾을 수 없음 (NA01)",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "500",
+          description = "서버 내부 오류",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      )
+  })
+  ResponseEntity<Void> hardDelete(
+      @Parameter(description = "뉴스 기사 ID") @PathVariable("articleId") UUID articleId
+  );
+}

--- a/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleApiDocs.java
+++ b/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleApiDocs.java
@@ -8,7 +8,9 @@ import com.springboot.monew.newsarticles.dto.response.NewsArticleViewDto;
 import com.springboot.monew.newsarticles.enums.ArticleSource;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -30,14 +32,23 @@ public interface NewsArticleApiDocs {
       operationId = "collectNews"
   )
   @ApiResponses({
-      @ApiResponse(
-          responseCode = "200",
-          description = "뉴스 수집 완료"
-      ),
+      @ApiResponse(responseCode = "200", description = "뉴스 수집 완료"),
       @ApiResponse(
           responseCode = "500",
           description = "서버 내부 오류 (외부 API 호출 실패 또는 저장 실패)",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "INTERNAL_SERVER_ERROR",
+                    "message": "서버 내부 오류가 발생했습니다.",
+                    "details": {},
+                    "exceptionType": "Exception",
+                    "status": 500
+                  }""")
+          )
       )
   })
   ResponseEntity<String> collectNews();
@@ -54,17 +65,54 @@ public interface NewsArticleApiDocs {
       @ApiResponse(
           responseCode = "201",
           description = "뉴스 기사 조회 이력 등록 성공",
-          content = @Content(schema = @Schema(implementation = NewsArticleViewDto.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = NewsArticleViewDto.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "id": "cc0e8400-e29b-41d4-a716-446655440000",
+                    "articleId": "660e8400-e29b-41d4-a716-446655440001",
+                    "userId": "770e8400-e29b-41d4-a716-446655440002",
+                    "createdAt": "2024-01-15T10:30:00.000Z"
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "400",
-          description = "이미 조회한 뉴스 기사입니다 (NA03)",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          description = "이미 조회한 뉴스 기사 (NA03)",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "NA03",
+                    "message": "이미 조회된 뉴스기사입니다.",
+                    "details": {
+                      "articleId": "660e8400-e29b-41d4-a716-446655440001",
+                      "userId": "770e8400-e29b-41d4-a716-446655440002"
+                    },
+                    "exceptionType": "ArticleException",
+                    "status": 400
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "401",
           description = "Monew-Request-User-ID 헤더 누락",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "UNAUTHORIZED",
+                    "message": "Required request header 'Monew-Request-User-ID' for method parameter type UUID is not present",
+                    "details": {},
+                    "exceptionType": "MissingRequestHeaderException",
+                    "status": 401
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "404",
@@ -72,12 +120,38 @@ public interface NewsArticleApiDocs {
               리소스 없음
               - 뉴스 기사를 찾을 수 없음 (NA01)
               - 사용자를 찾을 수 없음 (UR03)""",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "NA01",
+                    "message": "뉴스기사를 찾을 수 없습니다.",
+                    "details": {
+                      "articleId": "660e8400-e29b-41d4-a716-446655440001"
+                    },
+                    "exceptionType": "ArticleException",
+                    "status": 404
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "500",
           description = "서버 내부 오류",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "INTERNAL_SERVER_ERROR",
+                    "message": "서버 내부 오류가 발생했습니다.",
+                    "details": {},
+                    "exceptionType": "Exception",
+                    "status": 500
+                  }""")
+          )
       )
   })
   ResponseEntity<NewsArticleViewDto> createView(
@@ -93,32 +167,166 @@ public interface NewsArticleApiDocs {
           커서 기반 페이지네이션으로 뉴스 기사 목록을 조회합니다.""",
       operationId = "list_3"
   )
+  @Parameters({
+      @Parameter(
+          name = "keyword",
+          description = "기사 제목/요약 검색 키워드 (선택, 부분 일치)",
+          example = "인공지능"
+      ),
+      @Parameter(
+          name = "interestId",
+          description = "특정 관심사에 연관된 기사만 조회 (선택)",
+          example = "550e8400-e29b-41d4-a716-446655440000",
+          schema = @Schema(type = "string", format = "uuid")
+      ),
+      @Parameter(
+          name = "sourceIn",
+          description = """
+              출처 필터 (선택, 복수 선택 가능)
+              - `NAVER` : 네이버
+              - `HANKYUNG` : 한국경제
+              - `CHOSUN` : 조선일보
+              - `YONHAP` : 연합뉴스""",
+          schema = @Schema(type = "array", allowableValues = {"NAVER", "HANKYUNG", "CHOSUN", "YONHAP"})
+      ),
+      @Parameter(
+          name = "publishDateFrom",
+          description = "발행일 범위 시작 (선택, ISO 8601 형식)",
+          example = "2024-01-01T00:00:00.000Z"
+      ),
+      @Parameter(
+          name = "publishDateTo",
+          description = "발행일 범위 종료 (선택, ISO 8601 형식)",
+          example = "2024-01-31T23:59:59.000Z"
+      ),
+      @Parameter(
+          name = "orderBy",
+          description = """
+              정렬 기준 (필수)
+              - `publishDate` : 발행일 순
+              - `commentCount` : 댓글 수 순
+              - `viewCount` : 조회 수 순""",
+          required = true,
+          schema = @Schema(type = "string", allowableValues = {"publishDate", "commentCount", "viewCount"})
+      ),
+      @Parameter(
+          name = "direction",
+          description = """
+              정렬 방향 (필수)
+              - `ASC` : 오름차순
+              - `DESC` : 내림차순""",
+          required = true,
+          schema = @Schema(type = "string", allowableValues = {"ASC", "DESC"})
+      ),
+      @Parameter(
+          name = "cursor",
+          description = """
+              이전 페이지의 마지막 커서 값 (첫 페이지 조회 시 생략)
+              - orderBy=`publishDate` 형식: `2024-01-15T10:30:00.000000000Z`
+              - orderBy=`commentCount` / `viewCount` 형식: `100|2024-01-15T10:30:00.000000000Z`""",
+          example = "2024-01-15T10:30:00.000000000Z"
+      ),
+      @Parameter(
+          name = "after",
+          description = "이전 페이지의 마지막 항목 publishDate (cursor와 함께 사용)",
+          example = "2024-01-15T10:30:00.000Z"
+      ),
+      @Parameter(
+          name = "limit",
+          description = "페이지당 조회 개수 (필수, 최소: 1, 최대: 100)",
+          required = true,
+          schema = @Schema(type = "integer", minimum = "1", maximum = "100")
+      )
+  })
   @ApiResponses({
       @ApiResponse(
           responseCode = "200",
           description = "뉴스 기사 목록 조회 성공",
-          content = @Content(schema = @Schema(implementation = CursorPageResponseNewsArticleDto.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = CursorPageResponseNewsArticleDto.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "content": [
+                      {
+                        "id": "660e8400-e29b-41d4-a716-446655440001",
+                        "source": "NAVER",
+                        "sourceUrl": "https://news.naver.com/article/001/0001234567",
+                        "title": "AI 기술 혁신, 산업 전반 변화 이끈다",
+                        "summary": "인공지능 기술의 급격한 발전으로 제조·금융·의료 등 산업 전반에 걸쳐 대규모 변화가 예고되고 있다.",
+                        "imageUrl": "https://imgnews.pstatic.net/image/001/2024/01/15/sample.jpg",
+                        "publishedAt": "2024-01-15T10:30:00.000Z",
+                        "commentCount": 42,
+                        "viewCount": 1500,
+                        "viewedByMe": false
+                      }
+                    ],
+                    "nextCursor": "2024-01-15T10:30:00.000000000Z",
+                    "nextAfter": "2024-01-15T10:30:00.000Z",
+                    "size": 1,
+                    "totalElements": 320,
+                    "hasNext": true
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "400",
           description = """
               잘못된 요청
-              - 필수 쿼리 파라미터 누락 또는 형식 오류
-              - limit이 1 미만이거나 허용 범위 초과
-              - orderBy 값이 허용된 값이 아님 (publishedAt, commentCount)
-              - after 커서 형식 불일치
-              - source 값이 허용된 출처가 아님""",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+              - 필수 파라미터 누락 또는 형식 오류
+              - limit 범위 초과 (1~100)
+              - orderBy 값이 허용된 값이 아님 (publishDate, commentCount, viewCount)
+              - sourceIn에 허용되지 않는 출처 값 포함""",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "BAD_REQUEST",
+                    "message": "입력값 검증에 실패하였습니다.",
+                    "details": {
+                      "orderBy": ["널이어서는 안됩니다"],
+                      "limit": ["1에서 100 사이여야 합니다"]
+                    },
+                    "exceptionType": "MethodArgumentNotValidException",
+                    "status": 400
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "401",
           description = "Monew-Request-User-ID 헤더 누락",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "UNAUTHORIZED",
+                    "message": "Required request header 'Monew-Request-User-ID' for method parameter type UUID is not present",
+                    "details": {},
+                    "exceptionType": "MissingRequestHeaderException",
+                    "status": 401
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "500",
           description = "서버 내부 오류",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "INTERNAL_SERVER_ERROR",
+                    "message": "서버 내부 오류가 발생했습니다.",
+                    "details": {},
+                    "exceptionType": "Exception",
+                    "status": 500
+                  }""")
+          )
       )
   })
   CursorPageResponseNewsArticleDto list(
@@ -138,22 +346,76 @@ public interface NewsArticleApiDocs {
       @ApiResponse(
           responseCode = "200",
           description = "뉴스 기사 단건 조회 성공",
-          content = @Content(schema = @Schema(implementation = NewsArticleDto.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = NewsArticleDto.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "id": "660e8400-e29b-41d4-a716-446655440001",
+                    "source": "NAVER",
+                    "sourceUrl": "https://news.naver.com/article/001/0001234567",
+                    "title": "AI 기술 혁신, 산업 전반 변화 이끈다",
+                    "summary": "인공지능 기술의 급격한 발전으로 산업 전반에 걸쳐 대규모 변화가 예고되고 있다.",
+                    "imageUrl": "https://imgnews.pstatic.net/image/001/2024/01/15/sample.jpg",
+                    "publishedAt": "2024-01-15T10:30:00.000Z",
+                    "commentCount": 42,
+                    "viewCount": 1500,
+                    "viewedByMe": true
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "401",
           description = "Monew-Request-User-ID 헤더 누락",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "UNAUTHORIZED",
+                    "message": "Required request header 'Monew-Request-User-ID' for method parameter type UUID is not present",
+                    "details": {},
+                    "exceptionType": "MissingRequestHeaderException",
+                    "status": 401
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "404",
           description = "뉴스 기사를 찾을 수 없음 (NA01)",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "NA01",
+                    "message": "뉴스기사를 찾을 수 없습니다.",
+                    "details": {
+                      "articleId": "660e8400-e29b-41d4-a716-446655440001"
+                    },
+                    "exceptionType": "ArticleException",
+                    "status": 404
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "500",
           description = "서버 내부 오류",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "INTERNAL_SERVER_ERROR",
+                    "message": "서버 내부 오류가 발생했습니다.",
+                    "details": {},
+                    "exceptionType": "Exception",
+                    "status": 500
+                  }""")
+          )
       )
   })
   ResponseEntity<NewsArticleDto> find(
@@ -170,14 +432,23 @@ public interface NewsArticleApiDocs {
       operationId = "findSource"
   )
   @ApiResponses({
-      @ApiResponse(
-          responseCode = "200",
-          description = "출처 목록 조회 성공"
-      ),
+      @ApiResponse(responseCode = "200", description = "출처 목록 조회 성공"),
       @ApiResponse(
           responseCode = "500",
           description = "서버 내부 오류",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "INTERNAL_SERVER_ERROR",
+                    "message": "서버 내부 오류가 발생했습니다.",
+                    "details": {},
+                    "exceptionType": "Exception",
+                    "status": 500
+                  }""")
+          )
       )
   })
   ResponseEntity<List<ArticleSource>> findSource();
@@ -191,24 +462,61 @@ public interface NewsArticleApiDocs {
       operationId = "softDelete_2"
   )
   @ApiResponses({
-      @ApiResponse(
-          responseCode = "204",
-          description = "뉴스 기사 논리 삭제 성공"
-      ),
+      @ApiResponse(responseCode = "204", description = "뉴스 기사 논리 삭제 성공"),
       @ApiResponse(
           responseCode = "400",
-          description = "이미 삭제된 뉴스 기사입니다 (NA02)",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          description = "이미 삭제된 뉴스 기사 (NA02)",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "NA02",
+                    "message": "이미 삭제된 뉴스기사입니다.",
+                    "details": {
+                      "articleId": "660e8400-e29b-41d4-a716-446655440001"
+                    },
+                    "exceptionType": "ArticleException",
+                    "status": 400
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "404",
           description = "뉴스 기사를 찾을 수 없음 (NA01)",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "NA01",
+                    "message": "뉴스기사를 찾을 수 없습니다.",
+                    "details": {
+                      "articleId": "660e8400-e29b-41d4-a716-446655440001"
+                    },
+                    "exceptionType": "ArticleException",
+                    "status": 404
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "500",
           description = "서버 내부 오류",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "INTERNAL_SERVER_ERROR",
+                    "message": "서버 내부 오류가 발생했습니다.",
+                    "details": {},
+                    "exceptionType": "Exception",
+                    "status": 500
+                  }""")
+          )
       )
   })
   ResponseEntity<Void> softDelete(
@@ -224,19 +532,42 @@ public interface NewsArticleApiDocs {
       operationId = "hardDelete_3"
   )
   @ApiResponses({
-      @ApiResponse(
-          responseCode = "204",
-          description = "뉴스 기사 물리 삭제 성공"
-      ),
+      @ApiResponse(responseCode = "204", description = "뉴스 기사 물리 삭제 성공"),
       @ApiResponse(
           responseCode = "404",
           description = "뉴스 기사를 찾을 수 없음 (NA01)",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "NA01",
+                    "message": "뉴스기사를 찾을 수 없습니다.",
+                    "details": {
+                      "articleId": "660e8400-e29b-41d4-a716-446655440001"
+                    },
+                    "exceptionType": "ArticleException",
+                    "status": 404
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "500",
           description = "서버 내부 오류",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "INTERNAL_SERVER_ERROR",
+                    "message": "서버 내부 오류가 발생했습니다.",
+                    "details": {},
+                    "exceptionType": "Exception",
+                    "status": 500
+                  }""")
+          )
       )
   })
   ResponseEntity<Void> hardDelete(

--- a/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleApiDocs.java
+++ b/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleApiDocs.java
@@ -9,6 +9,7 @@ import com.springboot.monew.newsarticles.enums.ArticleSource;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -432,7 +433,14 @@ public interface NewsArticleApiDocs {
       operationId = "findSource"
   )
   @ApiResponses({
-      @ApiResponse(responseCode = "200", description = "출처 목록 조회 성공"),
+      @ApiResponse(
+          responseCode = "200",
+          description = "출처 목록 조회 성공",
+          content = @Content(
+              mediaType = "application/json",
+              array = @ArraySchema(schema = @Schema(implementation = ArticleSource.class))
+          )
+      ),
       @ApiResponse(
           responseCode = "500",
           description = "서버 내부 오류",

--- a/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleController.java
+++ b/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleController.java
@@ -11,6 +11,7 @@ import jakarta.validation.Valid;
 import java.net.URI;
 import java.util.List;
 import java.util.UUID;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -23,11 +24,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "뉴스 관리", description = "뉴스 기사 관련 API")
 @Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/articles")
-public class NewsArticleController {
+public class NewsArticleController implements NewsArticleApiDocs {
 
   private final NewsArticleCollectService newsArticleCollectService;
   private final NewsArticleService newsArticleService;

--- a/src/main/java/com/springboot/monew/notification/controller/NotificationApiDocs.java
+++ b/src/main/java/com/springboot/monew/notification/controller/NotificationApiDocs.java
@@ -63,7 +63,7 @@ public interface NotificationApiDocs {
                         "userId": "770e8400-e29b-41d4-a716-446655440002",
                         "resourceType": "COMMENT",
                         "resourceId": "660e8400-e29b-41d4-a716-446655440001",
-                        "message": "홍길동님이 회원님의 댓글에 좋아요를 눌렀습니다.",
+                        "content": "홍길동님이 회원님의 댓글에 좋아요를 눌렀습니다.",
                         "confirmed": false,
                         "createdAt": "2024-01-15T10:30:00.000Z",
                         "updatedAt": "2024-01-15T10:30:00.000Z"

--- a/src/main/java/com/springboot/monew/notification/controller/NotificationApiDocs.java
+++ b/src/main/java/com/springboot/monew/notification/controller/NotificationApiDocs.java
@@ -6,7 +6,9 @@ import com.springboot.monew.notification.dto.NotificationDto;
 import com.springboot.monew.notification.dto.NotificationFindRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -27,34 +29,114 @@ public interface NotificationApiDocs {
           커서 기반 페이지네이션으로 알림 목록을 조회합니다.""",
       operationId = "find"
   )
+  @Parameters({
+      @Parameter(
+          name = "cursor",
+          description = "이전 페이지의 마지막 알림 ID (첫 페이지 조회 시 생략)",
+          example = "550e8400-e29b-41d4-a716-446655440000",
+          schema = @Schema(type = "string", format = "uuid")
+      ),
+      @Parameter(
+          name = "after",
+          description = "이전 페이지의 마지막 알림 createdAt (cursor와 함께 사용)",
+          example = "2024-01-15T10:30:00.000Z"
+      ),
+      @Parameter(
+          name = "limit",
+          description = "페이지당 조회 개수 (필수, 최소: 1)",
+          required = true,
+          schema = @Schema(type = "integer", minimum = "1")
+      )
+  })
   @ApiResponses({
       @ApiResponse(
           responseCode = "200",
           description = "알림 목록 조회 성공",
-          content = @Content(schema = @Schema(implementation = CursorPageResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = CursorPageResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "content": [
+                      {
+                        "id": "550e8400-e29b-41d4-a716-446655440000",
+                        "userId": "770e8400-e29b-41d4-a716-446655440002",
+                        "resourceType": "COMMENT",
+                        "resourceId": "660e8400-e29b-41d4-a716-446655440001",
+                        "message": "홍길동님이 회원님의 댓글에 좋아요를 눌렀습니다.",
+                        "confirmed": false,
+                        "createdAt": "2024-01-15T10:30:00.000Z",
+                        "updatedAt": "2024-01-15T10:30:00.000Z"
+                      }
+                    ],
+                    "nextCursor": "550e8400-e29b-41d4-a716-446655440000",
+                    "nextAfter": "2024-01-15T10:30:00.000Z",
+                    "size": 1,
+                    "totalElements": 5,
+                    "hasNext": false
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "400",
           description = """
               잘못된 요청
-              - 필수 쿼리 파라미터 누락 또는 형식 오류
-              - limit이 1 미만이거나 허용 범위 초과
-              - after 커서 형식 불일치""",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+              - limit 누락 또는 1 미만""",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "BAD_REQUEST",
+                    "message": "입력값 검증에 실패하였습니다.",
+                    "details": {
+                      "limit": ["1 이상이어야 합니다"]
+                    },
+                    "exceptionType": "MethodArgumentNotValidException",
+                    "status": 400
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "401",
           description = "Monew-Request-User-ID 헤더 누락",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "UNAUTHORIZED",
+                    "message": "Required request header 'Monew-Request-User-ID' for method parameter type UUID is not present",
+                    "details": {},
+                    "exceptionType": "MissingRequestHeaderException",
+                    "status": 401
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "500",
           description = """
               서버 내부 오류
-              - DB에 저장된 알림 데이터가 손상되었거나 유효하지 않음 (NT01)
-              - 알림 타입과 연결된 객체가 일치하지 않음 (NT02)
-              - 알림 생성에 필요한 필수 객체가 누락됨 (NT03)""",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+              - DB 알림 데이터 손상 (NT01)
+              - 알림 타입과 연결 객체 불일치 (NT02)
+              - 알림 생성 필수 객체 누락 (NT03)""",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "NT01",
+                    "message": "DB에 저장된 알림 데이터가 손상되었거나 유효하지 않습니다.",
+                    "details": {
+                      "notificationId": "550e8400-e29b-41d4-a716-446655440000"
+                    },
+                    "exceptionType": "NotificationException",
+                    "status": 500
+                  }""")
+          )
       )
   })
   ResponseEntity<CursorPageResponse<NotificationDto>> find(
@@ -71,19 +153,40 @@ public interface NotificationApiDocs {
       operationId = "bulkUpdate"
   )
   @ApiResponses({
-      @ApiResponse(
-          responseCode = "204",
-          description = "알림 전체 확인 처리 성공"
-      ),
+      @ApiResponse(responseCode = "204", description = "알림 전체 확인 처리 성공"),
       @ApiResponse(
           responseCode = "401",
           description = "Monew-Request-User-ID 헤더 누락",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "UNAUTHORIZED",
+                    "message": "Required request header 'Monew-Request-User-ID' for method parameter type UUID is not present",
+                    "details": {},
+                    "exceptionType": "MissingRequestHeaderException",
+                    "status": 401
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "500",
           description = "서버 내부 오류",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "INTERNAL_SERVER_ERROR",
+                    "message": "서버 내부 오류가 발생했습니다.",
+                    "details": {},
+                    "exceptionType": "Exception",
+                    "status": 500
+                  }""")
+          )
       )
   })
   ResponseEntity<?> bulkUpdate(
@@ -99,27 +202,65 @@ public interface NotificationApiDocs {
       operationId = "update_3"
   )
   @ApiResponses({
-      @ApiResponse(
-          responseCode = "204",
-          description = "알림 확인 처리 성공"
-      ),
+      @ApiResponse(responseCode = "204", description = "알림 확인 처리 성공"),
       @ApiResponse(
           responseCode = "400",
-          description = "이미 확인 처리된 알림입니다 (NT04)",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          description = "이미 확인 처리된 알림 (NT04)",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "NT04",
+                    "message": "이미 읽음 처리된 알림입니다.",
+                    "details": {
+                      "notificationId": "550e8400-e29b-41d4-a716-446655440000"
+                    },
+                    "exceptionType": "NotificationException",
+                    "status": 400
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "401",
           description = "Monew-Request-User-ID 헤더 누락",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "UNAUTHORIZED",
+                    "message": "Required request header 'Monew-Request-User-ID' for method parameter type UUID is not present",
+                    "details": {},
+                    "exceptionType": "MissingRequestHeaderException",
+                    "status": 401
+                  }""")
+          )
       ),
       @ApiResponse(
           responseCode = "500",
           description = """
               서버 내부 오류
               - 알림을 찾을 수 없음 (NT05)
-              - DB에 저장된 알림 데이터가 손상되었거나 유효하지 않음 (NT01)""",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+              - DB 알림 데이터 손상 (NT01)""",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "timestamp": "2024-01-15T10:30:00.000Z",
+                    "code": "NT05",
+                    "message": "알림을 찾을 수 없습니다.",
+                    "details": {
+                      "notificationId": "550e8400-e29b-41d4-a716-446655440000",
+                      "userId": "770e8400-e29b-41d4-a716-446655440002"
+                    },
+                    "exceptionType": "NotificationException",
+                    "status": 500
+                  }""")
+          )
       )
   })
   ResponseEntity<?> update(

--- a/src/main/java/com/springboot/monew/notification/controller/NotificationApiDocs.java
+++ b/src/main/java/com/springboot/monew/notification/controller/NotificationApiDocs.java
@@ -1,0 +1,129 @@
+package com.springboot.monew.notification.controller;
+
+import com.springboot.monew.common.dto.CursorPageResponse;
+import com.springboot.monew.common.exception.ErrorResponse;
+import com.springboot.monew.notification.dto.NotificationDto;
+import com.springboot.monew.notification.dto.NotificationFindRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+public interface NotificationApiDocs {
+
+  @Operation(
+      summary = "알림 목록 조회",
+      description = """
+          `GET /api/notifications`
+
+          커서 기반 페이지네이션으로 알림 목록을 조회합니다.""",
+      operationId = "find"
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "알림 목록 조회 성공",
+          content = @Content(schema = @Schema(implementation = CursorPageResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "400",
+          description = """
+              잘못된 요청
+              - 필수 쿼리 파라미터 누락 또는 형식 오류
+              - limit이 1 미만이거나 허용 범위 초과
+              - after 커서 형식 불일치""",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "401",
+          description = "Monew-Request-User-ID 헤더 누락",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "500",
+          description = """
+              서버 내부 오류
+              - DB에 저장된 알림 데이터가 손상되었거나 유효하지 않음 (NT01)
+              - 알림 타입과 연결된 객체가 일치하지 않음 (NT02)
+              - 알림 생성에 필요한 필수 객체가 누락됨 (NT03)""",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      )
+  })
+  ResponseEntity<CursorPageResponse<NotificationDto>> find(
+      @Valid NotificationFindRequest request,
+      @Parameter(description = "요청자 ID") @RequestHeader("Monew-Request-User-ID") @NotNull UUID userId
+  );
+
+  @Operation(
+      summary = "알림 전체 확인 처리",
+      description = """
+          `PATCH /api/notifications`
+
+          사용자의 모든 미확인 알림을 일괄 확인 처리합니다.""",
+      operationId = "bulkUpdate"
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "204",
+          description = "알림 전체 확인 처리 성공"
+      ),
+      @ApiResponse(
+          responseCode = "401",
+          description = "Monew-Request-User-ID 헤더 누락",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "500",
+          description = "서버 내부 오류",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      )
+  })
+  ResponseEntity<?> bulkUpdate(
+      @Parameter(description = "요청자 ID") @RequestHeader("Monew-Request-User-ID") @NotNull UUID userId
+  );
+
+  @Operation(
+      summary = "알림 단건 확인 처리",
+      description = """
+          `PATCH /api/notifications/{notificationId}`
+
+          특정 알림을 확인 처리합니다. 이미 확인된 알림은 다시 확인 처리할 수 없습니다.""",
+      operationId = "update_3"
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "204",
+          description = "알림 확인 처리 성공"
+      ),
+      @ApiResponse(
+          responseCode = "400",
+          description = "이미 확인 처리된 알림입니다 (NT04)",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "401",
+          description = "Monew-Request-User-ID 헤더 누락",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "500",
+          description = """
+              서버 내부 오류
+              - 알림을 찾을 수 없음 (NT05)
+              - DB에 저장된 알림 데이터가 손상되었거나 유효하지 않음 (NT01)""",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      )
+  })
+  ResponseEntity<?> update(
+      @Parameter(description = "알림 ID") @PathVariable @NotNull UUID notificationId,
+      @Parameter(description = "요청자 ID") @RequestHeader("Monew-Request-User-ID") @NotNull UUID userId
+  );
+}

--- a/src/main/java/com/springboot/monew/notification/controller/NotificationController.java
+++ b/src/main/java/com/springboot/monew/notification/controller/NotificationController.java
@@ -7,6 +7,7 @@ import com.springboot.monew.notification.service.NotificationService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -18,10 +19,11 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "알림 관리", description = "알림 관련 API")
 @RestController
 @RequestMapping("/api/notifications")
 @RequiredArgsConstructor
-public class NotificationController {
+public class NotificationController implements NotificationApiDocs {
 
   private final NotificationService notificationService;
 

--- a/src/main/java/com/springboot/monew/users/controller/UserActivityDocs.java
+++ b/src/main/java/com/springboot/monew/users/controller/UserActivityDocs.java
@@ -8,18 +8,19 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.UUID;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 
-@Tag(name = "사용자 활동 내역 관리", description = "사용자 활동 내역 관련 API")
 public interface UserActivityDocs {
 
   @Operation(
-      summary = "사용자 활동 내역 관리",
-      description = "사용자 ID로 활동 내역을 조회합니다.",
-      operationId = "find"
+      summary = "사용자 활동 내역 조회",
+      description = """
+          `GET /api/user-activities/{userId}`
+
+          사용자 ID로 활동 내역(구독, 댓글, 좋아요, 기사 조회 이력)을 조회합니다.""",
+      operationId = "getUserActivity"
   )
   @ApiResponses({
       @ApiResponse(
@@ -29,7 +30,7 @@ public interface UserActivityDocs {
       ),
       @ApiResponse(
           responseCode = "404",
-          description = "사용자 정보 없음",
+          description = "사용자를 찾을 수 없음 (UR03)",
           content = @Content(schema = @Schema(implementation = ErrorResponse.class))
       ),
       @ApiResponse(
@@ -39,7 +40,6 @@ public interface UserActivityDocs {
       )
   })
   ResponseEntity<UserActivityDto> getUserActivity(
-      @Parameter(description = "사용자 ID")
-      @PathVariable UUID userId
+      @Parameter(description = "사용자 ID") @PathVariable UUID userId
   );
 }

--- a/src/main/java/com/springboot/monew/users/controller/UserApiDocs.java
+++ b/src/main/java/com/springboot/monew/users/controller/UserApiDocs.java
@@ -12,18 +12,19 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 
-@Tag(name = "사용자 관리", description = "사용자 관련 API")
 public interface UserApiDocs {
 
   @Operation(
       summary = "회원가입",
-      description = "새로운 사용자를 등록합니다.",
+      description = """
+          `POST /api/users`
+
+          새로운 사용자를 등록합니다.""",
       operationId = "register"
   )
   @ApiResponses({
@@ -34,12 +35,24 @@ public interface UserApiDocs {
       ),
       @ApiResponse(
           responseCode = "400",
-          description = "잘못된 요청 (입력값 검증 실패)",
+          description = """
+              잘못된 요청
+              - email이 null이거나 이메일 형식 아님
+              - password가 null이거나 최소 길이 미달
+              - nickname이 null이거나 빈 문자열""",
           content = @Content(schema = @Schema(implementation = ErrorResponse.class))
       ),
       @ApiResponse(
           responseCode = "409",
-          description = "이메일 중복 또는 닉네임 중복",
+          description = """
+              중복 충돌
+              - 이미 사용 중인 이메일입니다 (UR01)
+              - 이미 사용 중인 닉네임입니다 (UR02)""",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "415",
+          description = "지원하지 않는 Content-Type (application/json 필요)",
           content = @Content(schema = @Schema(implementation = ErrorResponse.class))
       ),
       @ApiResponse(
@@ -49,14 +62,15 @@ public interface UserApiDocs {
       )
   })
   ResponseEntity<UserDto> register(
-      @Valid
-      @RequestBody
-      UserRegisterRequest request
+      @Valid @RequestBody UserRegisterRequest request
   );
 
   @Operation(
       summary = "로그인",
-      description = "사용자 로그인을 처리합니다.",
+      description = """
+          `POST /api/users/login`
+
+          사용자 로그인을 처리합니다.""",
       operationId = "login"
   )
   @ApiResponses({
@@ -67,12 +81,20 @@ public interface UserApiDocs {
       ),
       @ApiResponse(
           responseCode = "400",
-          description = "잘못된 요청 (입력값 검증 실패)",
+          description = """
+              잘못된 요청
+              - email이 null이거나 이메일 형식 아님
+              - password가 null이거나 빈 문자열""",
           content = @Content(schema = @Schema(implementation = ErrorResponse.class))
       ),
       @ApiResponse(
           responseCode = "401",
-          description = "로그인 실패 (이메일 또는 비밀번호 불일치)",
+          description = "이메일 또는 비밀번호가 올바르지 않습니다 (UR04)",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "415",
+          description = "지원하지 않는 Content-Type (application/json 필요)",
           content = @Content(schema = @Schema(implementation = ErrorResponse.class))
       ),
       @ApiResponse(
@@ -82,14 +104,15 @@ public interface UserApiDocs {
       )
   })
   ResponseEntity<UserDto> login(
-      @Valid
-      @RequestBody
-      UserLoginRequest request
+      @Valid @RequestBody UserLoginRequest request
   );
 
   @Operation(
       summary = "사용자 정보 수정",
-      description = "사용자의 닉네임을 수정합니다.",
+      description = """
+          `PATCH /api/users/{userId}`
+
+          사용자의 닉네임을 수정합니다. 본인의 계정만 수정할 수 있습니다.""",
       operationId = "update"
   )
   @ApiResponses({
@@ -100,22 +123,30 @@ public interface UserApiDocs {
       ),
       @ApiResponse(
           responseCode = "400",
-          description = "잘못된 요청 (입력값 검증 실패)",
+          description = """
+              잘못된 요청
+              - nickname이 null이거나 빈 문자열
+              - nickname 길이 초과""",
           content = @Content(schema = @Schema(implementation = ErrorResponse.class))
       ),
       @ApiResponse(
           responseCode = "403",
-          description = "사용자 정보 수정 권한 없음",
+          description = "본인의 사용자 정보만 수정할 수 있습니다 (UR05)",
           content = @Content(schema = @Schema(implementation = ErrorResponse.class))
       ),
       @ApiResponse(
           responseCode = "404",
-          description = "사용자 정보 없음",
+          description = "사용자를 찾을 수 없음 (UR03)",
           content = @Content(schema = @Schema(implementation = ErrorResponse.class))
       ),
       @ApiResponse(
           responseCode = "409",
-          description = "닉네임 중복",
+          description = "이미 사용 중인 닉네임입니다 (UR02)",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "415",
+          description = "지원하지 않는 Content-Type (application/json 필요)",
           content = @Content(schema = @Schema(implementation = ErrorResponse.class))
       ),
       @ApiResponse(
@@ -125,61 +156,63 @@ public interface UserApiDocs {
       )
   })
   ResponseEntity<UserDto> update(
-      @Parameter(description = "사용자 ID")
-      @PathVariable UUID userId,
-
-      @Parameter(description = "요청자 ID")
-
-      @Valid
-      @RequestBody
-      UserUpdateRequest request
+      @Parameter(description = "사용자 ID") @PathVariable UUID userId,
+      @Valid @RequestBody UserUpdateRequest request
   );
 
   @Operation(
       summary = "사용자 논리 삭제",
-      description = "사용자를 논리적으로 삭제합니다.",
+      description = """
+          `DELETE /api/users/{userId}`
+
+          사용자를 논리적으로 삭제합니다.""",
       operationId = "delete"
   )
   @ApiResponses({
       @ApiResponse(
           responseCode = "204",
-          description = "사용자 삭제 성공"
+          description = "사용자 논리 삭제 성공"
       ),
       @ApiResponse(
           responseCode = "404",
-          description = "사용자 정보 없음"
+          description = "사용자를 찾을 수 없음 (UR03)",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
       ),
       @ApiResponse(
           responseCode = "500",
-          description = "서버 내부 오류"
+          description = "서버 내부 오류",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
       )
   })
   ResponseEntity<Void> delete(
-      @Parameter(description = "사용자 ID")
-      @PathVariable UUID userId
+      @Parameter(description = "사용자 ID") @PathVariable UUID userId
   );
 
   @Operation(
       summary = "사용자 물리 삭제",
-      description = "사용자를 물리적으로 삭제합니다.",
+      description = """
+          `DELETE /api/users/{userId}/hard`
+
+          사용자를 물리적으로 삭제합니다. 데이터베이스에서 완전히 제거됩니다.""",
       operationId = "hardDelete_1"
   )
   @ApiResponses({
       @ApiResponse(
           responseCode = "204",
-          description = "사용자 삭제 성공"
+          description = "사용자 물리 삭제 성공"
       ),
       @ApiResponse(
           responseCode = "404",
-          description = "사용자 정보 없음"
+          description = "사용자를 찾을 수 없음 (UR03)",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
       ),
       @ApiResponse(
           responseCode = "500",
-          description = "서버 내부 오류"
+          description = "서버 내부 오류",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
       )
   })
   ResponseEntity<Void> hardDelete(
-      @Parameter(description = "사용자 ID")
-      @PathVariable UUID userId
+      @Parameter(description = "사용자 ID") @PathVariable UUID userId
   );
 }

--- a/src/test/java/com/springboot/monew/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/springboot/monew/comment/controller/CommentControllerTest.java
@@ -49,7 +49,7 @@ class CommentControllerTest {
 
   @Test
   @DisplayName("댓글이 등록이 성공하면 201을 반환한다")
-  void create_성공() throws Exception {
+  void create_Returns201_WhenValidRequest() throws Exception {
     // given
     UUID userId = UUID.randomUUID();
     UUID articleId = UUID.randomUUID();
@@ -78,7 +78,7 @@ class CommentControllerTest {
 
   @Test
   @DisplayName("댓글 내용이 없다면 등록에 실패한다")
-  void create_실패() throws Exception {
+  void create_Returns400_WhenContentIsBlank() throws Exception {
     // given
     UUID userId = UUID.randomUUID();
     UUID articleId = UUID.randomUUID();
@@ -97,7 +97,7 @@ class CommentControllerTest {
 
   @Test
   @DisplayName("댓글 논리 삭제 시 204를 반환한다.")
-  void softDelete_성공() throws Exception {
+  void softDelete_Returns204_WhenCommentExists() throws Exception {
     // given
     UUID commentId = UUID.randomUUID();
 
@@ -110,7 +110,7 @@ class CommentControllerTest {
 
   @Test
   @DisplayName("이미 논리 삭제가 된 댓글은 실패한다")
-  void softDelete_실패() throws Exception {
+  void softDelete_Returns400_WhenAlreadyDeleted() throws Exception {
     // given
     UUID commentId = UUID.randomUUID();
 
@@ -125,7 +125,7 @@ class CommentControllerTest {
 
   @Test
   @DisplayName("댓글 수정 성공 시 200을 반환한다.")
-  void update_성공() throws Exception {
+  void update_Returns200_WhenValidRequest() throws Exception {
     // given
     UUID commentId = UUID.randomUUID();
     UUID userId = UUID.randomUUID();
@@ -156,7 +156,7 @@ class CommentControllerTest {
 
   @Test
   @DisplayName("댓글 수정 실패 시 400을 반환한다.")
-  void update_실패() throws Exception {
+  void update_Returns400_WhenContentIsBlank() throws Exception {
     // given
     UUID commentId = UUID.randomUUID();
     UUID userId = UUID.randomUUID();
@@ -177,7 +177,7 @@ class CommentControllerTest {
 
   @Test
   @DisplayName("Monew-Request-User-ID 헤더 누락 시 401을 반환한다")
-  void update_실패_헤더누락() throws Exception {
+  void update_Returns401_WhenHeaderMissing() throws Exception {
     // given
     UUID commentId = UUID.randomUUID();
     CommentUpdateRequest request = new CommentUpdateRequest("수정한 댓글");
@@ -193,7 +193,7 @@ class CommentControllerTest {
 
   @Test
   @DisplayName("본인 댓글이 아닌 것들 수정하려고 하면 수정에 실패한다.")
-  void update_실패_본인댓글아님() throws Exception {
+  void update_Returns403_WhenNotOwnedByUser() throws Exception {
     // given
     UUID commentId = UUID.randomUUID();
     UUID userId = UUID.randomUUID();
@@ -212,7 +212,7 @@ class CommentControllerTest {
 
   @Test
   @DisplayName("댓글 물리 삭제 시 204를 반환한다.")
-  void hardDelete_성공() throws Exception {
+  void hardDelete_Returns204_WhenCommentExists() throws Exception {
     // given
     UUID commentId = UUID.randomUUID();
 
@@ -227,7 +227,7 @@ class CommentControllerTest {
 
   @Test
   @DisplayName("댓글 목록 조회 성공")
-  void list_성공() throws Exception {
+  void list_Returns200_WhenValidRequest() throws Exception {
     // given
     UUID articleId = UUID.randomUUID();
     UUID userId = UUID.randomUUID();
@@ -237,7 +237,7 @@ class CommentControllerTest {
         "댓글2", 1L, true, Instant.now());
 
     CursorPageResponseCommentDto<CommentDto> response = new CursorPageResponseCommentDto<>(
-        List.of(comment1, comment2), null, null, 2, 2, false
+        List.of(comment1, comment2), null, null, 2, 2L, false
     );
 
     given(commentService.list(any(CommentPageRequest.class), any(UUID.class))).willReturn(response);
@@ -259,7 +259,7 @@ class CommentControllerTest {
 
   @Test
   @DisplayName("댓글 목록 조회 실패 - 잘못된 정렬 속성")
-  void list_실패() throws Exception {
+  void list_Returns400_WhenInvalidOrderBy() throws Exception {
     // given
     UUID articleId = UUID.randomUUID();
     UUID userId = UUID.randomUUID();

--- a/src/test/java/com/springboot/monew/comment/controller/CommentLikeControllerTest.java
+++ b/src/test/java/com/springboot/monew/comment/controller/CommentLikeControllerTest.java
@@ -39,7 +39,7 @@ class CommentLikeControllerTest {
 
   @Test
   @DisplayName("댓글 좋아요 성공 시 201을 반환한다.")
-  void like_성공() throws Exception {
+  void like_Returns201_WhenValidRequest() throws Exception {
     // given
     UUID commentId = UUID.randomUUID();
     UUID userId = UUID.randomUUID();
@@ -70,7 +70,7 @@ class CommentLikeControllerTest {
 
   @Test
   @DisplayName("존재하지 않는 댓글에 좋아요 시 404를 반환한다.")
-  void like_실패_댓글없음() throws Exception {
+  void like_Returns404_WhenCommentNotFound() throws Exception {
     // given
     UUID commentId = UUID.randomUUID();
     UUID userId = UUID.randomUUID();
@@ -88,7 +88,7 @@ class CommentLikeControllerTest {
 
   @Test
   @DisplayName("존재하지 않는 유저가 좋아요 시 404를 반환한다.")
-  void like_실패_유저없음() throws Exception {
+  void like_Returns404_WhenUserNotFound() throws Exception {
     // given
     UUID commentId = UUID.randomUUID();
     UUID userId = UUID.randomUUID();
@@ -106,7 +106,7 @@ class CommentLikeControllerTest {
 
   @Test
   @DisplayName("중복 좋아요 시 409를 반환한다.")
-  void like_실패_중복좋아요() throws Exception {
+  void like_Returns409_WhenAlreadyLiked() throws Exception {
     // given
     UUID commentId = UUID.randomUUID();
     UUID userId = UUID.randomUUID();
@@ -125,7 +125,7 @@ class CommentLikeControllerTest {
 
   @Test
   @DisplayName("Monew-Request-User-ID 헤더 누락 시 401을 반환한다.")
-  void like_실패_헤더누락() throws Exception {
+  void like_Returns401_WhenHeaderMissing() throws Exception {
     // given
     UUID commentId = UUID.randomUUID();
     UUID userId = UUID.randomUUID();
@@ -140,7 +140,7 @@ class CommentLikeControllerTest {
 
   @Test
   @DisplayName("댓글 좋아요 취소 성공 시 200을 반환한다.")
-  void unlike_성공() throws Exception {
+  void unlike_Returns200_WhenValidRequest() throws Exception {
     // given
     UUID commentId = UUID.randomUUID();
     UUID userId = UUID.randomUUID();
@@ -155,7 +155,7 @@ class CommentLikeControllerTest {
 
   @Test
   @DisplayName("존재하지 않는 댓글에 좋아요 취소 시 404를 반환한다.")
-  void unlike_실패_댓글없음() throws Exception {
+  void unlike_Returns404_WhenCommentNotFound() throws Exception {
     // given
     UUID commentId = UUID.randomUUID();
     UUID userId = UUID.randomUUID();
@@ -173,7 +173,7 @@ class CommentLikeControllerTest {
 
   @Test
   @DisplayName("좋아요를 누르지 않은 댓글에 좋아요 취소 시 404를 반환한다.")
-  void unlike_실패_좋아요없음() throws Exception {
+  void unlike_Returns404_WhenLikeNotFound() throws Exception {
     // given
     UUID commentId = UUID.randomUUID();
     UUID userId = UUID.randomUUID();
@@ -191,7 +191,7 @@ class CommentLikeControllerTest {
 
   @Test
   @DisplayName("Monew-Request-User-ID 헤더 누락 시 401을 반환한다.")
-  void unlike_실패_헤더누락() throws Exception {
+  void unlike_Returns401_WhenHeaderMissing() throws Exception {
     // given
     UUID commentId = UUID.randomUUID();
     UUID userId = UUID.randomUUID();

--- a/src/test/java/com/springboot/monew/comment/repository/CommentLikeRepositoryTest.java
+++ b/src/test/java/com/springboot/monew/comment/repository/CommentLikeRepositoryTest.java
@@ -26,7 +26,7 @@ class CommentLikeRepositoryTest extends BaseRepositoryTest {
 
   @Test
   @DisplayName("유저가 좋아요한 댓글 Id 목록 반환에 성공한다!")
-  void findCommentIdsByUserIdAndCommentIdIn_성공() {
+  void findCommentIdsByUserIdAndCommentIdIn_ReturnsLikedCommentIds_WhenUserLikedSomeComments() {
     // given
     NewsArticle article = testEntityManager.generateNewsArticle();
     List<Comment> comments = testEntityManager.generateComments(5, article);

--- a/src/test/java/com/springboot/monew/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/springboot/monew/comment/repository/CommentRepositoryTest.java
@@ -31,7 +31,7 @@ class CommentRepositoryTest extends BaseRepositoryTest {
 
   @Test
   @DisplayName("삭제되지 않은 댓글 조회 성공 - user JOIN FETCH로 쿼리 1번")
-  void findByIdAndIsDeletedFalse_성공() {
+  void findByIdAndIsDeletedFalse_ReturnsComment_WhenCommentExists() {
     // given
     User user = testEntityManager.generateUser();
     Comment comment = new Comment(user, article, "테스트 댓글");
@@ -52,7 +52,7 @@ class CommentRepositoryTest extends BaseRepositoryTest {
 
   @Test
   @DisplayName("논리 삭제된 댓글은 조회되지 않는다")
-  void findByIdAndIsDeletedFalse_삭제된댓글_empty() {
+  void findByIdAndIsDeletedFalse_ReturnsEmpty_WhenCommentDeleted() {
     // given
     User user = testEntityManager.generateUser();
     Comment comment = new Comment(user, article, "테스트 댓글");
@@ -71,7 +71,7 @@ class CommentRepositoryTest extends BaseRepositoryTest {
 
   @Test
   @DisplayName("좋아요 수 1 증가 성공")
-  void incrementLikeCount_성공() {
+  void incrementLikeCount_IncreasesLikeCountByOne_WhenCommentExists() {
     // given
     NewsArticle article = testEntityManager.generateNewsArticle();
     User user = testEntityManager.generateUser();
@@ -92,7 +92,7 @@ class CommentRepositoryTest extends BaseRepositoryTest {
 
   @Test
   @DisplayName("좋아요 수 1 감소 성공")
-  void decrementLikeCount_성공() {
+  void decrementLikeCount_DecreasesLikeCountByOne_WhenLikeCountIsPositive() {
     // given
     NewsArticle article = testEntityManager.generateNewsArticle();
     User user = testEntityManager.generateUser();
@@ -116,7 +116,7 @@ class CommentRepositoryTest extends BaseRepositoryTest {
 
   @Test
   @DisplayName("좋아요 수가 0일 때 감소 시도 → 0 유지")
-  void decrementLikeCount_0이하_음수안됨() {
+  void decrementLikeCount_MaintainsZero_WhenLikeCountIsZero() {
     // given
     NewsArticle article = testEntityManager.generateNewsArticle();
     User user = testEntityManager.generateUser();
@@ -139,7 +139,7 @@ class CommentRepositoryTest extends BaseRepositoryTest {
 
   @Test
   @DisplayName("cursor null이면 첫 페이지 반환")
-  void findComments_커서없음_첫페이지() {
+  void findComments_ReturnsFirstPage_WhenCursorIsNull() {
     // given
     testEntityManager.generateComments(3, article);
     flushAndClear();
@@ -155,14 +155,14 @@ class CommentRepositoryTest extends BaseRepositoryTest {
 
   @Test
   @DisplayName("createdAt DESC 정렬 - 최신순으로 반환")
-  void findComments_createdAt_DESC() {
+  void findComments_ReturnsDescOrder_WhenOrderByCreatedAtDesc() {
     // given
     List<Comment> comments = testEntityManager.generateComments(3, article);
     Instant base = Instant.now();
     setCreatedAt(comments.get(0).getId(), base.minusSeconds(20));
     setCreatedAt(comments.get(1).getId(), base.minusSeconds(10));
     setCreatedAt(comments.get(2).getId(), base);
-    flushAndClear(); //DB INSERT && 영속성 컨텍스트 초기화
+    flushAndClear();
 
     // when
     List<Comment> result = commentRepository.findComments(
@@ -170,7 +170,6 @@ class CommentRepositoryTest extends BaseRepositoryTest {
         null, null, 10);
 
     // then
-    // 역순과 동일해야 함
     Assertions.assertThat(result)
         .extracting(Comment::getCreatedAt)
         .isSortedAccordingTo(Comparator.reverseOrder());
@@ -178,14 +177,14 @@ class CommentRepositoryTest extends BaseRepositoryTest {
 
   @Test
   @DisplayName("createdAt ASC 정렬 - 오래된순으로 반환")
-  void findComments_createdAt_ASC() {
+  void findComments_ReturnsAscOrder_WhenOrderByCreatedAtAsc() {
     // given
     List<Comment> comments = testEntityManager.generateComments(3, article);
     Instant base = Instant.now();
     setCreatedAt(comments.get(0).getId(), base.minusSeconds(20));
     setCreatedAt(comments.get(1).getId(), base.minusSeconds(10));
     setCreatedAt(comments.get(2).getId(), base);
-    flushAndClear(); // DB INSERT && 영속성 컨텍스트 초기화
+    flushAndClear();
 
     // when
     List<Comment> result = commentRepository.findComments(
@@ -193,7 +192,6 @@ class CommentRepositoryTest extends BaseRepositoryTest {
         null, null, 10);
 
     // then
-    // ASC면 원래 순서랑 동일해야 함.
     Assertions.assertThat(result)
         .extracting(Comment::getCreatedAt)
         .isSortedAccordingTo(Comparator.naturalOrder());
@@ -201,10 +199,9 @@ class CommentRepositoryTest extends BaseRepositoryTest {
 
   @Test
   @DisplayName("likeCount DESC 정렬 - 좋아요 많은순으로 반환")
-  void findComments_likeCount_DESC() {
+  void findComments_ReturnsDescOrder_WhenOrderByLikeCountDesc() {
     // given
     List<Comment> comments = testEntityManager.generateComments(3, article);
-    // comments.get(0) → likeCount 1, get(1) → 2, get(2) → 3
     commentRepository.incrementLikeCount(comments.get(0).getId());
     commentRepository.incrementLikeCount(comments.get(1).getId());
     commentRepository.incrementLikeCount(comments.get(1).getId());
@@ -219,7 +216,6 @@ class CommentRepositoryTest extends BaseRepositoryTest {
         null, null, 10);
 
     // then
-    // 좋아요 순이면 역순으로!
     Assertions.assertThat(result)
         .extracting(Comment::getLikeCount)
         .isSortedAccordingTo(Comparator.reverseOrder());
@@ -227,7 +223,7 @@ class CommentRepositoryTest extends BaseRepositoryTest {
 
   @Test
   @DisplayName("likeCount ASC 정렬 - 좋아요 적은순으로 반환")
-  void findComments_likeCount_ASC() {
+  void findComments_ReturnsAscOrder_WhenOrderByLikeCountAsc() {
     // given
     List<Comment> comments = testEntityManager.generateComments(3, article);
     commentRepository.incrementLikeCount(comments.get(0).getId());
@@ -251,7 +247,7 @@ class CommentRepositoryTest extends BaseRepositoryTest {
 
   @Test
   @DisplayName("cursor 있을 때 해당 커서 이후 데이터만 반환 - 1·2페이지 중복 없음")
-  void findComments_커서있음_이후데이터만() {
+  void findComments_ReturnsNextPageOnly_WhenCursorProvided() {
     // given
     List<Comment> comments = testEntityManager.generateComments(5, article);
     Instant base = Instant.now();
@@ -263,7 +259,6 @@ class CommentRepositoryTest extends BaseRepositoryTest {
     List<Comment> firstPage = commentRepository.findComments(
         article.getId(), CommentOrderBy.createdAt, CommentDirection.DESC,
         null, null, 3);
-    // 커서 가져옴
     Comment last = firstPage.get(firstPage.size() - 1);
 
     // when
@@ -272,7 +267,6 @@ class CommentRepositoryTest extends BaseRepositoryTest {
         CommentOrderBy.createdAt.getCursor(last), last.getCreatedAt(), 3);
 
     // then
-    // 두번 째 Page에 첫번 째 Page가 들어있으면 안됨 !
     List<UUID> firstPageIds = firstPage.stream().map(Comment::getId).toList();
     Assertions.assertThat(secondPage)
         .extracting(Comment::getId)
@@ -281,7 +275,7 @@ class CommentRepositoryTest extends BaseRepositoryTest {
 
   @Test
   @DisplayName("논리 삭제된 댓글은 목록에서 제외")
-  void findComments_삭제된댓글_제외() {
+  void findComments_ExcludesDeletedComments_WhenCommentDeleted() {
     // given
     List<Comment> comments = testEntityManager.generateComments(3, article);
     comments.get(0).delete();
@@ -301,7 +295,7 @@ class CommentRepositoryTest extends BaseRepositoryTest {
 
   @Test
   @DisplayName("limit 적용 - 지정한 개수만큼만 반환")
-  void findComments_limit_적용() {
+  void findComments_ReturnsLimitedCount_WhenLimitProvided() {
     // given
     int limit = 3;
     testEntityManager.generateComments(5, article);
@@ -318,19 +312,18 @@ class CommentRepositoryTest extends BaseRepositoryTest {
 
   @Test
   @DisplayName("다른 article의 댓글은 제외")
-  void findComments_다른article_제외() {
+  void findComments_ReturnsEmpty_WhenDifferentArticle() {
     // given
     NewsArticle otherArticle = testEntityManager.generateNewsArticle();
     testEntityManager.generateComments(3, otherArticle);
     flushAndClear();
 
-    // when (원래 기사 댓글 조회)
+    // when
     List<Comment> result = commentRepository.findComments(
         article.getId(), CommentOrderBy.createdAt, CommentDirection.DESC,
         null, null, 10);
 
     // then
-    // 기사 댓글은 비어 있어야 함
     Assertions.assertThat(result).isEmpty();
   }
 


### PR DESCRIPTION
## 관련 이슈 번호
- Closes #54 

## 📌 작업 내용           
  - 전체 Controller Swagger 문서화
                                                                                                 
## 🔧 변경 사항
  - `CommentApiDocs`, `CommentLikeApiDocs` — 댓글/좋아요 전 엔드포인트 문서화 (목록 조회, 등록,  
  수정, 논리/물리 삭제, 좋아요/취소)                                                             
  - `InterestApiDocs` — 관심사 전 엔드포인트 문서화 (목록 조회, 등록, 수정, 삭제, 구독/취소)     
  - `NotificationApiDocs` 신규 생성 — 알림 전 엔드포인트 문서화 (목록 조회, 전체/단건 확인 처리) 
  - `NewsArticleApiDocs` 신규 생성 — 뉴스 기사 전 엔드포인트 문서화 (수집, 조회 이력 등록,       
  목록/단건/출처 조회, 논리/물리 삭제)                                                           
  - `UserApiDocs`, `UserActivityDocs` — 기존 문서 에러 케이스 상세화                             
  - 컨트롤러 클래스(`CommentController`, `CommentLikeController`, `InterestController`,          
  `NotificationController`, `NewsArticleController`)에 `@Tag` 직접 추가 — Swagger UI 섹션명      
  한글화 (댓글 관리, 관심사 관리, 뉴스 관리, 알림 관리)                                          
  - `CommentLikeController` → `CommentLikeApiDocs` implements 추가, `NotificationController` /   
  `NewsArticleController` → 각 ApiDocs implements 추가                                           
  - 각 엔드포인트 description에 API URL 명시 (`` `GET /api/comments` `` 형식)                    
  - 목록 조회 쿼리 파라미터 `@Parameters` 상세 설명 추가 (허용값, 형식, 필수 여부, 예시)         
  - `@ExampleObject`로 ErrorResponse 구체적인 예시 추가 — `details` 필드에 실제 에러 원인 포함,  
  에러코드별 분리 (CM01~CM05, IN01~IN05, NT01~NT05, NA01~NA03)                                   
  - 성공 응답 예시의 `size` 값을 실제 `content` 배열 개수와 일치하도록 수정                      
                                                                                                 
  ## 반영 브랜치                                                                                 
  `feature/#54/swagger-document` -> `dev`                                                        

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * API 문서 대폭 확장 — 댓글/좋아요/관심사/뉴스/알림/사용자 관련 엔드포인트에 대한 상세한 OpenAPI 명세, 응답 스키마·오류 예제·헤더·파라미터 설명 추가
  * 컨트롤러별 그룹화 태그(카테고리) 추가

* **Refactor**
  * 페이지네이션 응답의 일부 필드가 nullable로 변경되어 미확인 값 처리 지원

* **Tests**
  * 단위/통합 테스트의 테스트명 및 서술을 영어/행동 중심으로 정비
<!-- end of auto-generated comment: release notes by coderabbit.ai -->