### PR TITLE
[Feat]뉴스기사 백업/복구기능 구현

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,13 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
+      - name: Check S3 env
+        run: |
+          echo "AWS_S3_REGION=${AWS_S3_REGION:-MISSING}"
+          test -n "$AWS_S3_ACCESS_KEY" && echo "AWS_S3_ACCESS_KEY exists" || echo "AWS_S3_ACCESS_KEY missing"
+          test -n "$AWS_S3_SECRET_KEY" && echo "AWS_S3_SECRET_KEY exists" || echo "AWS_S3_SECRET_KEY missing"
+          test -n "$AWS_S3_BUCKET" && echo "AWS_S3_BUCKET exists" || echo "AWS_S3_BUCKET missing"
+
       - name: Run tests with coverage
         run: ./gradlew test jacocoTestReport
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     env:
-      SPRING_PROFILES_ACTIVE: dev
-      CLOUD_AWS_S3_ACCESS_KEY: ${{ secrets.AWS_S3_ACCESS_KEY }}
-      CLOUD_AWS_S3_SECRET_KEY: ${{ secrets.AWS_S3_SECRET_KEY }}
-      CLOUD_AWS_S3_REGION: ${{ secrets.AWS_S3_REGION }}
-      CLOUD_AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
-      CLOUD_AWS_S3_PRESIGNED_URL_EXPIRATION: 600
       NAVER_API_KEY: ${{ secrets.NAVER_API_KEY }}
       NAVER_API_SECRET: ${{ secrets.NAVER_API_SECRET }}
 
@@ -28,13 +22,6 @@ jobs:
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
-
-      - name: Check S3 env
-        run: |
-          echo "AWS_S3_REGION=${AWS_S3_REGION:-MISSING}"
-          test -n "$AWS_S3_ACCESS_KEY" && echo "AWS_S3_ACCESS_KEY exists" || echo "AWS_S3_ACCESS_KEY missing"
-          test -n "$AWS_S3_SECRET_KEY" && echo "AWS_S3_SECRET_KEY exists" || echo "AWS_S3_SECRET_KEY missing"
-          test -n "$AWS_S3_BUCKET" && echo "AWS_S3_BUCKET exists" || echo "AWS_S3_BUCKET missing"
 
       - name: Run tests with coverage
         run: ./gradlew test jacocoTestReport

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,13 +8,14 @@ jobs:
   test:
     runs-on: ubuntu-latest
     env:
+      SPRING_PROFILES_ACTIVE: dev
+      CLOUD_AWS_S3_ACCESS_KEY: ${{ secrets.AWS_S3_ACCESS_KEY }}
+      CLOUD_AWS_S3_SECRET_KEY: ${{ secrets.AWS_S3_SECRET_KEY }}
+      CLOUD_AWS_S3_REGION: ${{ secrets.AWS_S3_REGION }}
+      CLOUD_AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+      CLOUD_AWS_S3_PRESIGNED_URL_EXPIRATION: 600
       NAVER_API_KEY: ${{ secrets.NAVER_API_KEY }}
       NAVER_API_SECRET: ${{ secrets.NAVER_API_SECRET }}
-      AWS_S3_ACCESS_KEY: ${{ secrets.AWS_S3_ACCESS_KEY }}
-      AWS_S3_SECRET_KEY: ${{ secrets.AWS_S3_SECRET_KEY }}
-      AWS_S3_REGION: ${{ secrets.AWS_S3_REGION }}
-      AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
-      AWS_S3_PRESIGNED_URL_EXPIRATION: 600
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,11 @@ jobs:
     env:
       NAVER_API_KEY: ${{ secrets.NAVER_API_KEY }}
       NAVER_API_SECRET: ${{ secrets.NAVER_API_SECRET }}
+      AWS_S3_ACCESS_KEY: ${{ secrets.AWS_S3_ACCESS_KEY }}
+      AWS_S3_SECRET_KEY: ${{ secrets.AWS_S3_SECRET_KEY }}
+      AWS_S3_REGION: ${{ secrets.AWS_S3_REGION }}
+      AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+      AWS_S3_PRESIGNED_URL_EXPIRATION: 600
 
     steps:
       - uses: actions/checkout@v4

--- a/src/main/java/com/springboot/monew/MoNewApplication.java
+++ b/src/main/java/com/springboot/monew/MoNewApplication.java
@@ -5,7 +5,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
-@ConfigurationPropertiesScan
 public class MoNewApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/com/springboot/monew/MoNewApplication.java
+++ b/src/main/java/com/springboot/monew/MoNewApplication.java
@@ -2,8 +2,10 @@ package com.springboot.monew;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class MoNewApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/com/springboot/monew/config/S3Config.java
+++ b/src/main/java/com/springboot/monew/config/S3Config.java
@@ -22,13 +22,6 @@ public class S3Config {
   @Bean
   public S3Client s3Client() {//S3Client: S3 API 호출용 클라이언트(S3에 요청 보내는 객체)
 
-    log.info("==== S3 CONFIG DEBUG ====");
-    log.info("accessKey: {}", props.getAccessKey());
-    log.info("secretKey: {}", props.getSecretKey());
-    log.info("region: {}", props.getRegion());
-    log.info("bucket: {}", props.getBucket());
-    log.info("=========================");
-
     String region = props.getRegion();
 
     if (region == null || region.isBlank()) {

--- a/src/main/java/com/springboot/monew/config/S3Config.java
+++ b/src/main/java/com/springboot/monew/config/S3Config.java
@@ -1,0 +1,43 @@
+package com.springboot.monew.config;
+
+import com.springboot.monew.newsarticles.s3.AwsProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+  private final AwsProperties props;
+
+  public S3Config(AwsProperties props) {this.props = props;}
+
+  @Bean
+  public S3Client s3Client() {//S3Client: S3 API 호출용 클라이언트(S3에 요청 보내는 객체)
+
+    // 키가 있는경우
+    if (props.getAccessKey() != null && !props.getAccessKey().isBlank()) {
+      return S3Client.builder()
+          .region(Region.of(props.getRegion()))
+          .credentialsProvider(
+              StaticCredentialsProvider.create(
+                  AwsBasicCredentials.create(
+                      props.getAccessKey(),
+                      props.getSecretKey()
+                  )
+              )
+          )
+          .build();
+    }
+    // 그렇지 않으면: 기본 체인(환경변수, 프로파일, IAM Role)을 자동 탐색
+    // 키가 없는경우
+    return S3Client.builder()
+        .region(Region.of(props.getRegion()))
+        .credentialsProvider(DefaultCredentialsProvider.create())
+        .build();
+  }
+
+}

--- a/src/main/java/com/springboot/monew/config/S3Config.java
+++ b/src/main/java/com/springboot/monew/config/S3Config.java
@@ -19,7 +19,7 @@ public class S3Config {
   public S3Client s3Client() {//S3Client: S3 API 호출용 클라이언트(S3에 요청 보내는 객체)
 
     // 키가 있는경우
-    Boolean hasAccessKey = props.getAccessKey().equals(props.getSecretKey());
+    Boolean hasAccessKey = props.getAccessKey().equals(props.getAccessKey());
     Boolean hasSecretKey = props.getSecretKey().equals(props.getSecretKey());
     if (hasAccessKey || hasSecretKey) {
       if(!(hasAccessKey && hasSecretKey)) {

--- a/src/main/java/com/springboot/monew/config/S3Config.java
+++ b/src/main/java/com/springboot/monew/config/S3Config.java
@@ -19,8 +19,8 @@ public class S3Config {
   public S3Client s3Client() {//S3Client: S3 API 호출용 클라이언트(S3에 요청 보내는 객체)
 
     // 키가 있는경우
-    Boolean hasAccessKey = props.getAccessKey().equals(props.getAccessKey());
-    Boolean hasSecretKey = props.getSecretKey().equals(props.getSecretKey());
+    boolean hasAccessKey = props.getAccessKey() != null && !props.getAccessKey().isBlank();
+    boolean hasSecretKey = props.getSecretKey() != null && !props.getSecretKey().isBlank();
     if (hasAccessKey || hasSecretKey) {
       if(!(hasAccessKey && hasSecretKey)) {
         throw new IllegalArgumentException("S3 access key와 secret key는 함께 설정되어야 합니다.");

--- a/src/main/java/com/springboot/monew/config/S3Config.java
+++ b/src/main/java/com/springboot/monew/config/S3Config.java
@@ -18,6 +18,12 @@ public class S3Config {
   @Bean
   public S3Client s3Client() {//S3Client: S3 API 호출용 클라이언트(S3에 요청 보내는 객체)
 
+    String region = props.getRegion();
+
+    if (region == null || region.isBlank()) {
+      throw new IllegalStateException("AWS_S3_REGION 설정이 누락되었습니다.");
+    }
+
     // 키가 있는경우
     boolean hasAccessKey = props.getAccessKey() != null && !props.getAccessKey().isBlank();
     boolean hasSecretKey = props.getSecretKey() != null && !props.getSecretKey().isBlank();

--- a/src/main/java/com/springboot/monew/config/S3Config.java
+++ b/src/main/java/com/springboot/monew/config/S3Config.java
@@ -2,6 +2,7 @@ package com.springboot.monew.config;
 
 import com.springboot.monew.newsarticles.s3.AwsProperties;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
@@ -12,6 +13,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 
 @Slf4j
 @Configuration
+@EnableConfigurationProperties(AwsProperties.class)   //AwsProperties라는 클래스를 설정 바인딩 대상으로 등록해
 public class S3Config {
   private final AwsProperties props;
 

--- a/src/main/java/com/springboot/monew/config/S3Config.java
+++ b/src/main/java/com/springboot/monew/config/S3Config.java
@@ -1,6 +1,7 @@
 package com.springboot.monew.config;
 
 import com.springboot.monew.newsarticles.s3.AwsProperties;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
@@ -9,6 +10,7 @@ import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 
+@Slf4j
 @Configuration
 public class S3Config {
   private final AwsProperties props;
@@ -17,6 +19,13 @@ public class S3Config {
 
   @Bean
   public S3Client s3Client() {//S3Client: S3 API 호출용 클라이언트(S3에 요청 보내는 객체)
+
+    log.info("==== S3 CONFIG DEBUG ====");
+    log.info("accessKey: {}", props.getAccessKey());
+    log.info("secretKey: {}", props.getSecretKey());
+    log.info("region: {}", props.getRegion());
+    log.info("bucket: {}", props.getBucket());
+    log.info("=========================");
 
     String region = props.getRegion();
 

--- a/src/main/java/com/springboot/monew/config/S3Config.java
+++ b/src/main/java/com/springboot/monew/config/S3Config.java
@@ -19,7 +19,12 @@ public class S3Config {
   public S3Client s3Client() {//S3Client: S3 API 호출용 클라이언트(S3에 요청 보내는 객체)
 
     // 키가 있는경우
-    if (props.getAccessKey() != null && !props.getAccessKey().isBlank()) {
+    Boolean hasAccessKey = props.getAccessKey().equals(props.getSecretKey());
+    Boolean hasSecretKey = props.getSecretKey().equals(props.getSecretKey());
+    if (hasAccessKey || hasSecretKey) {
+      if(!(hasAccessKey && hasSecretKey)) {
+        throw new IllegalArgumentException("S3 access key와 secret key는 함께 설정되어야 합니다.");
+      }
       return S3Client.builder()
           .region(Region.of(props.getRegion()))
           .credentialsProvider(
@@ -32,6 +37,7 @@ public class S3Config {
           )
           .build();
     }
+
     // 그렇지 않으면: 기본 체인(환경변수, 프로파일, IAM Role)을 자동 탐색
     // 키가 없는경우
     return S3Client.builder()

--- a/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleController.java
+++ b/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleController.java
@@ -4,11 +4,15 @@ import com.springboot.monew.newsarticles.dto.request.NewsArticlePageRequest;
 import com.springboot.monew.newsarticles.dto.response.CursorPageResponseNewsArticleDto;
 import com.springboot.monew.newsarticles.dto.response.NewsArticleDto;
 import com.springboot.monew.newsarticles.dto.response.NewsArticleViewDto;
+import com.springboot.monew.newsarticles.dto.response.RestoreResultDto;
 import com.springboot.monew.newsarticles.enums.ArticleSource;
 import com.springboot.monew.newsarticles.service.NewsArticleCollectService;
+import com.springboot.monew.newsarticles.s3.NewsArticleRestoreService;
 import com.springboot.monew.newsarticles.service.NewsArticleService;
 import jakarta.validation.Valid;
 import java.net.URI;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -33,6 +37,7 @@ public class NewsArticleController implements NewsArticleApiDocs {
 
   private final NewsArticleCollectService newsArticleCollectService;
   private final NewsArticleService newsArticleService;
+  private final NewsArticleRestoreService  newsArticleRestoreService;
 
   @PostMapping
   public ResponseEntity<String> collectNews() {
@@ -74,6 +79,17 @@ public class NewsArticleController implements NewsArticleApiDocs {
   @GetMapping("/sources")
   public ResponseEntity<List<ArticleSource>> findSource(){
     return ResponseEntity.ok(newsArticleService.findAllSources());
+  }
+
+  @GetMapping("/restore")
+  public ResponseEntity<List<RestoreResultDto>> restore(@RequestParam(value = "from", required = true) String from,
+                                                        @RequestParam(value = "to", required = true) String to){
+
+    LocalDate fromDate = LocalDate.parse(from.substring(0, 10));
+    LocalDate toDate = LocalDate.parse(to.substring(0, 10));
+    List<RestoreResultDto> result = newsArticleRestoreService.restore(fromDate, toDate);
+
+    return ResponseEntity.ok(result);
   }
 
   //뉴스기사 논리삭제

--- a/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleController.java
+++ b/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleController.java
@@ -18,6 +18,7 @@ import java.util.UUID;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -27,6 +28,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 @Tag(name = "뉴스 관리", description = "뉴스 기사 관련 API")
 @Slf4j
@@ -85,11 +87,16 @@ public class NewsArticleController implements NewsArticleApiDocs {
   public ResponseEntity<List<RestoreResultDto>> restore(@RequestParam(value = "from", required = true) String from,
                                                         @RequestParam(value = "to", required = true) String to){
 
-    LocalDate fromDate = LocalDate.parse(from.substring(0, 10));
-    LocalDate toDate = LocalDate.parse(to.substring(0, 10));
-    List<RestoreResultDto> result = newsArticleRestoreService.restore(fromDate, toDate);
+    LocalDate fromDate;
+    LocalDate toDate;
+    try {
+      fromDate = LocalDate.parse(from.substring(0, 10));
+      toDate = LocalDate.parse(to.substring(0, 10));
+    } catch (Exception e) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "날짜 형식이 올바르지 않습니다. (예: 2024-01-15)");
+    }
 
-    return ResponseEntity.ok(result);
+    return ResponseEntity.ok(newsArticleRestoreService.restore(fromDate, toDate));
   }
 
   //뉴스기사 논리삭제

--- a/src/main/java/com/springboot/monew/newsarticles/dto/NewsArticleBackupDto.java
+++ b/src/main/java/com/springboot/monew/newsarticles/dto/NewsArticleBackupDto.java
@@ -1,0 +1,20 @@
+package com.springboot.monew.newsarticles.dto;
+
+import com.springboot.monew.newsarticles.enums.ArticleSource;
+import java.time.Instant;
+import java.util.UUID;
+
+//S3에 백업할때 올릴 뉴스기사DTO
+public record NewsArticleBackupDto(
+    UUID id,
+    ArticleSource source,
+    String originalLink,
+    String title,
+    Instant publishedAt,
+    String summary,
+    Boolean isDeleted,
+    Instant createdAt
+
+) {
+
+}

--- a/src/main/java/com/springboot/monew/newsarticles/dto/response/CursorPageResponseNewsArticleDto.java
+++ b/src/main/java/com/springboot/monew/newsarticles/dto/response/CursorPageResponseNewsArticleDto.java
@@ -9,9 +9,9 @@ public record CursorPageResponseNewsArticleDto(
     List<NewsArticleDto> content,
     String nextCursor,
     String nextAfter,
-    int size,
-    long totalElements,
-    boolean hasNext
+    Integer size,
+    Long totalElements,
+    Boolean hasNext
 ) {
 
 

--- a/src/main/java/com/springboot/monew/newsarticles/dto/response/NewsArticleViewDto.java
+++ b/src/main/java/com/springboot/monew/newsarticles/dto/response/NewsArticleViewDto.java
@@ -14,7 +14,7 @@ public record NewsArticleViewDto (
     String articleTitle,
     Instant articlePublishedDate,
     String articleSummary,
-    long articleCommentCount,
-    long articleViewCount
+    Long articleCommentCount,
+    Long articleViewCount
 
 ) {}

--- a/src/main/java/com/springboot/monew/newsarticles/dto/response/RestoreResultDto.java
+++ b/src/main/java/com/springboot/monew/newsarticles/dto/response/RestoreResultDto.java
@@ -1,0 +1,13 @@
+package com.springboot.monew.newsarticles.dto.response;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+public record RestoreResultDto(
+    Instant restoreDate,
+    List<UUID> restoredArticleIds,
+    Long restoredArticleCount
+) {
+
+}

--- a/src/main/java/com/springboot/monew/newsarticles/repository/NewsArticleRepository.java
+++ b/src/main/java/com/springboot/monew/newsarticles/repository/NewsArticleRepository.java
@@ -3,6 +3,7 @@ package com.springboot.monew.newsarticles.repository;
 import com.springboot.monew.newsarticles.dto.request.NewsArticlePageRequest;
 import com.springboot.monew.newsarticles.entity.NewsArticle;
 import com.springboot.monew.newsarticles.repository.qdsl.NewsArticleQDSLRepository;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
@@ -21,5 +22,8 @@ public interface NewsArticleRepository extends JpaRepository<NewsArticle, UUID>,
   @Query("UPDATE NewsArticle n SET n.viewCount = n.viewCount + 1 WHERE n.id = :articleId")
   void incrementViewCount(@Param("articleId") UUID articleId);
 
+  //백업용 날짜 조회
+  //start날짜와 end 날짜를 넣으면 해당기간의 NewsArticle이 List형태로 조회된다.
+  List<NewsArticle> findAllByPublishedAtGreaterThanEqualAndPublishedAtLessThan(Instant start, Instant end);
 
 }

--- a/src/main/java/com/springboot/monew/newsarticles/s3/AwsProperties.java
+++ b/src/main/java/com/springboot/monew/newsarticles/s3/AwsProperties.java
@@ -7,7 +7,6 @@ import org.springframework.context.annotation.Configuration;
 
 @Getter
 @Setter
-@Configuration
 @ConfigurationProperties(prefix = "cloud.aws.s3")  // prefix 변경
 public class AwsProperties {
 

--- a/src/main/java/com/springboot/monew/newsarticles/s3/AwsProperties.java
+++ b/src/main/java/com/springboot/monew/newsarticles/s3/AwsProperties.java
@@ -1,0 +1,20 @@
+package com.springboot.monew.newsarticles.s3;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "cloud.aws.s3")  // prefix 변경
+public class AwsProperties {
+
+  private String accessKey;
+  private String secretKey;
+  private String region;
+  private String bucket;
+  private Long presignedUrlExpiration;
+
+}

--- a/src/main/java/com/springboot/monew/newsarticles/s3/NewsArticleBackupService.java
+++ b/src/main/java/com/springboot/monew/newsarticles/s3/NewsArticleBackupService.java
@@ -1,0 +1,54 @@
+package com.springboot.monew.newsarticles.s3;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.springboot.monew.newsarticles.dto.NewsArticleBackupDto;
+import com.springboot.monew.newsarticles.entity.NewsArticle;
+import com.springboot.monew.newsarticles.repository.NewsArticleRepository;
+import com.springboot.monew.newsarticles.service.NewsArticleService;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NewsArticleBackupService {
+
+  private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
+  private final NewsArticleRepository newsArticleRepository;
+  private final S3BackupService s3BackupService;
+  private final ObjectMapper objectMapper;
+
+  public void backupByPublishedAtDate(LocalDate backupDate) {
+    try{
+      //한국날짜 기준으로 백업하기 위한 시간 설정
+      Instant start = backupDate.atStartOfDay(KOREA_ZONE).toInstant();
+      Instant end = backupDate.plusDays(1).atStartOfDay(KOREA_ZONE).toInstant();
+
+      //S3에 뉴스기사 데이터들이 배열형태로 저장
+      List<NewsArticleBackupDto> backupDtos = newsArticleRepository.findAllByPublishedAtGreaterThanEqualAndPublishedAtLessThan(start, end)
+          .stream()
+          .map(article -> new NewsArticleBackupDto(
+              article.getId(),
+              article.getSource(),
+              article.getOriginalLink(),
+              article.getTitle(),
+              article.getPublishedAt(),
+              article.getSummary(),
+              article.isDeleted(),
+              article.getCreatedAt()
+          ))
+          .toList();
+
+      String json = objectMapper.writeValueAsString(backupDtos);
+      String key = "backup/news-articles/%s/news-articles.json".formatted(backupDate);
+      s3BackupService.upload(key, json);
+
+    }catch(Exception e){
+      throw new RuntimeException("뉴스 기사 백업 실패. date=" + backupDate, e);
+    }
+  }
+
+}

--- a/src/main/java/com/springboot/monew/newsarticles/s3/NewsArticleBackupService.java
+++ b/src/main/java/com/springboot/monew/newsarticles/s3/NewsArticleBackupService.java
@@ -10,8 +10,10 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class NewsArticleBackupService {
@@ -49,6 +51,16 @@ public class NewsArticleBackupService {
     }catch(Exception e){
       throw new RuntimeException("뉴스 기사 백업 실패. date=" + backupDate, e);
     }
+  }
+
+  public void backupIfMissing(LocalDate backupDate) {
+    String key = "backup/news-articles/%s/news-articles.json".formatted(backupDate);
+
+    if (s3BackupService.exists(key)) {
+      log.info("이미 백업 파일이 존재합니다. backupDate={}, key={}", backupDate, key);
+      return;
+    }
+    backupByPublishedAtDate(backupDate);
   }
 
 }

--- a/src/main/java/com/springboot/monew/newsarticles/s3/NewsArticleRestoreService.java
+++ b/src/main/java/com/springboot/monew/newsarticles/s3/NewsArticleRestoreService.java
@@ -86,14 +86,14 @@ public class NewsArticleRestoreService {
           .toList();
 
       //5. DB에 존재하는 링크 조회
-      Set<String> exstingLinks = newsArticleRepository.findAllByOriginalLinkIn(links).stream()
+      Set<String> existingLinks = newsArticleRepository.findAllByOriginalLinkIn(links).stream()
           .map(NewsArticle::getOriginalLink)
           .collect(Collectors.toSet());
 
       //6. 유실된 데이터만 필터링
       List<NewsArticle> lostArticles = backupDtos.stream()
           .filter(dto -> Boolean.TRUE.equals(dto.isDeleted()))
-          .filter(dto -> !exstingLinks.contains(dto.originalLink()))
+          .filter(dto -> !existingLinks.contains(dto.originalLink()))
           .map(dto -> new NewsArticle(
               dto.source(),
               dto.originalLink(),

--- a/src/main/java/com/springboot/monew/newsarticles/s3/NewsArticleRestoreService.java
+++ b/src/main/java/com/springboot/monew/newsarticles/s3/NewsArticleRestoreService.java
@@ -92,6 +92,7 @@ public class NewsArticleRestoreService {
 
       //6. 유실된 데이터만 필터링
       List<NewsArticle> lostArticles = backupDtos.stream()
+          .filter(dto -> Boolean.TRUE.equals(dto.isDeleted()))
           .filter(dto -> !exstingLinks.contains(dto.originalLink()))
           .map(dto -> new NewsArticle(
               dto.source(),
@@ -101,6 +102,8 @@ public class NewsArticleRestoreService {
               dto.summary()
           ))
           .toList();
+
+      log.debug("유실된 뉴스기사 데이터={}", lostArticles);
 
       //7. 저장
       List<NewsArticle> saved = newsArticleRepository.saveAll(lostArticles);

--- a/src/main/java/com/springboot/monew/newsarticles/s3/NewsArticleRestoreService.java
+++ b/src/main/java/com/springboot/monew/newsarticles/s3/NewsArticleRestoreService.java
@@ -1,0 +1,116 @@
+package com.springboot.monew.newsarticles.s3;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.springboot.monew.newsarticles.dto.NewsArticleBackupDto;
+import com.springboot.monew.newsarticles.dto.response.RestoreResultDto;
+import com.springboot.monew.newsarticles.entity.NewsArticle;
+import com.springboot.monew.newsarticles.repository.NewsArticleRepository;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NewsArticleRestoreService {
+
+  private final S3BackupService s3BackupService;
+  private final NewsArticleRepository newsArticleRepository;
+  private final ObjectMapper objectMapper;
+
+  //기간(from ~ to) 동안의 뉴스 기사 복구
+  public List<RestoreResultDto> restore(LocalDate from, LocalDate to) {
+    log.debug("[뉴스기사 복구 시작] from={}, to={}", from, to);
+    List<RestoreResultDto> results = new ArrayList<>();
+
+    //from: 2026-04-25
+    //to: 2026-04-27
+    //2026-04-25: true
+    //2026-04-26: true
+    //2026-04-27: false
+    for(LocalDate date = from; !date.isAfter(to); date = date.plusDays(1)) {
+      RestoreResultDto result = restoreOneDate(date);
+      results.add(result);
+      log.debug("  date={}, restoredCount={}, restoredIds={}",
+          date,
+          result.restoredArticleIds().size(),
+          result.restoredArticleIds()
+      );
+    }
+
+    return results;
+  }
+
+  //특정 날짜 복구
+  private RestoreResultDto restoreOneDate(LocalDate date) {
+    log.debug("date형태={}", date);
+    try{
+      String key = "backup/news-articles/%s/news-articles.json".formatted(date);
+      log.debug("key형태={}", key);
+
+      //1. 백업 파일 존재 확인
+      if(!s3BackupService.exists(key)) {
+        return new RestoreResultDto(Instant.now(), List.of(), 0L);
+      }
+
+      //2. JSON 다운로드
+      String json = s3BackupService.downloadJson(key);
+
+      //3. JSON -> DTO 리스트 변환
+      //readValue(데이터, 타입정보)
+      //List 안에 NewsArticleBackupDto가 들어있다
+      List<NewsArticleBackupDto> backupDtos = objectMapper.readValue(json, new TypeReference<List<NewsArticleBackupDto>>() {});
+
+      if (backupDtos.isEmpty()) {
+        return new RestoreResultDto(Instant.now(), List.of(), 0L);
+      }
+
+      //4. originalLink 목록 추출
+      List<String> links = backupDtos.stream()
+          .map(NewsArticleBackupDto::originalLink)
+          .toList();
+
+      //5. DB에 존재하는 링크 조회
+      Set<String> exstingLinks = newsArticleRepository.findAllByOriginalLinkIn(links).stream()
+          .map(NewsArticle::getOriginalLink)
+          .collect(Collectors.toSet());
+
+      //6. 유실된 데이터만 필터링
+      List<NewsArticle> lostArticles = backupDtos.stream()
+          .filter(dto -> !exstingLinks.contains(dto.originalLink()))
+          .map(dto -> new NewsArticle(
+              dto.source(),
+              dto.originalLink(),
+              dto.title(),
+              dto.publishedAt(),
+              dto.summary()
+          ))
+          .toList();
+
+      //7. 저장
+      List<NewsArticle> saved = newsArticleRepository.saveAll(lostArticles);
+
+      //8. 결과생성
+      List<UUID> retoredIds = saved.stream()
+          .map(NewsArticle::getId)
+          .toList();
+
+      return new RestoreResultDto(
+          Instant.now(),
+          retoredIds,
+          (long) retoredIds.size()
+      );
+
+    }catch(Exception e) {
+      throw new RuntimeException("뉴스기사 복구 실패. date= " + date, e);
+    }
+  }
+}

--- a/src/main/java/com/springboot/monew/newsarticles/s3/NewsArticleRestoreService.java
+++ b/src/main/java/com/springboot/monew/newsarticles/s3/NewsArticleRestoreService.java
@@ -28,6 +28,13 @@ public class NewsArticleRestoreService {
 
   //기간(from ~ to) 동안의 뉴스 기사 복구
   public List<RestoreResultDto> restore(LocalDate from, LocalDate to) {
+
+    if (from == null || to == null) {
+      throw new IllegalArgumentException("from/to는 null일 수 없습니다.");
+    }
+    if (from.isAfter(to)){
+      throw new IllegalArgumentException("from은 to보다 이후일 수 없습니다.");
+    }
     log.debug("[뉴스기사 복구 시작] from={}, to={}", from, to);
     List<RestoreResultDto> results = new ArrayList<>();
 

--- a/src/main/java/com/springboot/monew/newsarticles/s3/S3BackupService.java
+++ b/src/main/java/com/springboot/monew/newsarticles/s3/S3BackupService.java
@@ -1,0 +1,83 @@
+package com.springboot.monew.newsarticles.s3;
+
+import java.nio.charset.StandardCharsets;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@Service
+@RequiredArgsConstructor
+public class S3BackupService {
+
+  private final S3Client s3Client;
+  private final AwsProperties props;
+
+  /*
+  S3에 백업 JSON 업로드
+  key: S3에 저장될 경로
+  json: 업로드할 JSON 문자열
+  */
+  public void upload(String key, String json) {
+    try {
+      PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+          .bucket(props.getBucket())
+          .key(key)
+          .contentType("application/json")
+          .build();
+
+      //실제 업로드 수행
+      s3Client.putObject(
+          putObjectRequest,
+          RequestBody.fromString(json, StandardCharsets.UTF_8)  //JSON 문자열을 바이트로 변환
+      );
+    }
+    catch (Exception e) {
+      throw new RuntimeException("S3 업로드 실패", e);
+    }
+  }
+
+  //백업 JSON 다운로드
+  //key: S3 저장된 파일 경로
+  public String downloadJson(String key) {
+
+    //다운로드 요청 생성
+    GetObjectRequest request = GetObjectRequest.builder()
+        .bucket(props.getBucket())  //대상 버킷
+        .key(key)                   //다운로드할 파일 경로
+        .build();
+
+    //S3에서 파일을 바이트 형태로 가져옴
+    ResponseBytes<GetObjectResponse> response = s3Client.getObjectAsBytes(request);
+
+    //바이트 -> 문자열(JSON)으로 변환 후 반환
+    return response.asString(StandardCharsets.UTF_8);
+  }
+
+  //S3에 해당 key에 파일이 존재하는지 확인
+  //key: 확인할 파일 경로
+  public boolean exists(String key) {
+    try {
+
+      //파일 메타데이터 조회 요청
+      HeadObjectRequest request = HeadObjectRequest.builder()
+          .bucket(props.getBucket())
+          .key(key)
+          .build();
+
+      //존재하면 정상 실행됨
+      s3Client.headObject(request);
+      return true;
+
+    } catch (NoSuchKeyException e) {
+      return false;
+    }
+  }
+}
+

--- a/src/main/java/com/springboot/monew/newsarticles/scheduler/NewsArticleBackupScheduler.java
+++ b/src/main/java/com/springboot/monew/newsarticles/scheduler/NewsArticleBackupScheduler.java
@@ -1,0 +1,27 @@
+package com.springboot.monew.newsarticles.scheduler;
+
+import com.springboot.monew.newsarticles.s3.NewsArticleBackupService;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class NewsArticleBackupScheduler {
+
+  private final NewsArticleBackupService backupService;
+
+  //한국시간으로 매일 02:00 실행
+  @Scheduled(cron = "0 0 2 * * *", zone = "Asia/Seoul")
+  public void backupYesterday() {
+
+    //어제 데이터를 백업
+    //4/28 02:00 실행 -> 4/27 기사 백업
+    LocalDate backupDate = LocalDate.now(ZoneId.of("Asia/Seoul")).minusDays(1);
+    backupService.backupByPublishedAtDate(backupDate);
+  }
+
+}

--- a/src/main/java/com/springboot/monew/newsarticles/scheduler/NewsArticleBackupScheduler.java
+++ b/src/main/java/com/springboot/monew/newsarticles/scheduler/NewsArticleBackupScheduler.java
@@ -1,17 +1,20 @@
 package com.springboot.monew.newsarticles.scheduler;
 
+
 import com.springboot.monew.newsarticles.s3.NewsArticleBackupService;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Configuration;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class NewsArticleBackupScheduler {
 
+  private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
   private final NewsArticleBackupService backupService;
 
   //한국시간으로 매일 02:00 실행
@@ -20,8 +23,18 @@ public class NewsArticleBackupScheduler {
 
     //어제 데이터를 백업
     //4/28 02:00 실행 -> 4/27 기사 백업
-    LocalDate backupDate = LocalDate.now(ZoneId.of("Asia/Seoul")).minusDays(1);
-    backupService.backupByPublishedAtDate(backupDate);
-  }
+    LocalDate yesterday = LocalDate.now(KOREA_ZONE).minusDays(1);
 
+    //최근 7일치 백업 누락 여부를 확인한다.
+    //백업 파일이 없는 날짜는 다시 백업한다.
+    for(int i = 0; i < 7; i++){
+      LocalDate backupDate = yesterday.minusDays(i);
+
+      try{
+        backupService.backupIfMissing(backupDate);
+      }catch (Exception e){
+        log.error("뉴스 기사 백업 실패. backupDate={}", backupDate, e);
+      }
+    }
+  }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -26,16 +26,6 @@ spring:
     job:
       enabled: false
 
-cloud:
-  aws:
-    s3:
-      bucket: ${AWS_S3_BUCKET}
-    region:
-      static: ${AWS_REGION:ap-northeast-2}
-    credentials:
-      access-key: ${AWS_ACCESS_KEY}
-      secret-key: ${AWS_SECRET_KEY}
-
 logging:
   level:
     com.springboot.monew: DEBUG

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -26,16 +26,6 @@ spring:
 server:
   port: ${SERVER_PORT:8080}
 
-cloud:
-  aws:
-    s3:
-      bucket: ${AWS_S3_BUCKET}
-    region:
-      static: ${AWS_REGION:ap-northeast-2}
-    credentials:
-      access-key: ${AWS_ACCESS_KEY}
-      secret-key: ${AWS_SECRET_KEY}
-
 logging:
   level:
     root: WARN

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,5 +28,14 @@ naver:
     key: ${NAVER_API_KEY}
     secret: ${NAVER_API_SECRET}
 
+cloud:
+  aws:
+    s3:
+      access-key: ${AWS_S3_ACCESS_KEY}
+      secret-key: ${AWS_S3_SECRET_KEY}
+      region: ${AWS_S3_REGION}
+      bucket: ${AWS_S3_BUCKET}
+      presigned-url-expiration: ${AWS_S3_PRESIGNED_URL_EXPIRATION:600} # (기본값: 10분)
+
 
 


### PR DESCRIPTION
## 📌 작업 내용
- NewsArticleBackupScheduler를 통해 02:00마다 전날의 뉴스기사를 s3에 백업한다.
- get api/articles/restore를 통해 s3에 있는 data와 DB에 있는 data를 originalLink기준으로 비교하고, DB에 없는 data를 저장한다.

## 🔧 변경 사항
- AwsProperties
- NewsArticleBackupService
- NewsArticleRestoreService
- S3BackupService
- NewsArticleBackupScheduler
- NewsArticleController: 복구 REST API 추가
- S3Config

## 반영 브랜치
`feature/#24/backup-newsarticle` -> `dev`

## 💬 기타 참고 사항
- scheduler.NewsArticleBackupScheduler: 백업 실행 스케줄러
- s3.AwsProperties: aws 환경변수 필드화
- s3.NewsArticleBackupService: 백업할 data와 key를 만든다.
- s3.S3BackupService: NewsArticleBackupService에서 만든 data와 key를 통해 s3에 업로드
- s3.NewsArticleRestoreService: 복구 비즈니스 로직(하루단위로 복구하는 로직을 for문 돌림)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 뉴스 기사 일별 백업 및 복원 기능 추가: S3 업로드/다운로드, 누락시 백업 생성, 기간 지정 복원 API(복원 결과 리스트 반환)
  * 일일 자동 백업 스케줄러 추가(매일 02:00, 서울시간)

* **설정 변경**
  * 애플리케이션에 AWS S3 설정 블록 추가 및 개발/운영 프로필의 S3 설정 정리

* **기타**
  * 백업/복원 응답 및 백업 데이터 포맷 정의, 일부 DTO의 널 허용 타입으로 변경
* **테스트/CI**
  * 테스트 워크플로우에 S3 관련 환경변수 주입 및 검사 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->