### PR TITLE
[Test] 사용자 활동 테스트 보강 및 Mongo 트랜잭션 설정 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,5 +8,24 @@ services:
     volumes:
       - mongo-data:/data/db
 
+  mongo-init:
+    image: mongo:7
+    depends_on:
+      - mongodb
+    restart: "no"
+    entrypoint: >
+      bash -c "
+      sleep 5 &&
+      mongosh --host mongodb:27017 --eval
+      'try {
+        rs.status();
+      } catch (e) {
+        rs.initiate({
+          _id: \"rs0\",
+          members: [{ _id: 0, host: \"localhost:27017\" }]
+        });
+      }'
+      "
+
 volumes:
   mongo-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,19 +13,27 @@ services:
     depends_on:
       - mongodb
     restart: "no"
-    entrypoint: >
-      bash -c "
-      sleep 5 &&
-      mongosh --host mongodb:27017 --eval
-      'try {
-        rs.status();
-      } catch (e) {
-        rs.initiate({
-          _id: \"rs0\",
-          members: [{ _id: 0, host: \"localhost:27017\" }]
-        });
-      }'
-      "
+    entrypoint:
+      - bash
+      - -c
+      - |
+        until mongosh --host mongodb:27017 --eval "db.adminCommand('ping')" >/dev/null 2>&1; do
+          echo "Waiting for MongoDB to be ready..."
+          sleep 2
+        done
+        
+        mongosh --host mongodb:27017 --eval "
+          try {
+            rs.status();
+            print('Replica set already initialized.');
+          } catch (e) {
+            rs.initiate({
+              _id: 'rs0',
+              members: [{ _id: 0, host: 'localhost:27017' }]
+            });
+            print('Replica set initialized.');
+          }
+        "
 
 volumes:
   mongo-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,21 +7,23 @@ services:
     command: ["mongod", "--replSet", "rs0", "--bind_ip_all"]
     volumes:
       - mongo-data:/data/db
+    healthcheck:
+      test: [ "CMD", "mongosh", "--eval", "db.adminCommand('ping')" ]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 5s
 
   mongo-init:
     image: mongo:7
     depends_on:
-      - mongodb
+      mongodb:
+        condition: service_healthy
     restart: "no"
     entrypoint:
       - bash
       - -c
       - |
-        until mongosh --host mongodb:27017 --eval "db.adminCommand('ping')" >/dev/null 2>&1; do
-          echo "Waiting for MongoDB to be ready..."
-          sleep 2
-        done
-        
         mongosh --host mongodb:27017 --eval "
           try {
             rs.status();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,10 @@
 services:
   mongodb:
-    image: mongo:latest
+    image: mongo:7
     container_name: monew-mongo
     ports:
       - "27017:27017"
+    command: ["mongod", "--replSet", "rs0", "--bind_ip_all"]
     volumes:
       - mongo-data:/data/db
 

--- a/src/main/java/com/springboot/monew/config/JpaTransactionConfig.java
+++ b/src/main/java/com/springboot/monew/config/JpaTransactionConfig.java
@@ -1,0 +1,19 @@
+package com.springboot.monew.config;
+
+import jakarta.persistence.EntityManagerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+public class JpaTransactionConfig {
+  @Primary
+  @Bean(name = "transactionManager")
+  public PlatformTransactionManager transactionManager(
+      EntityManagerFactory entityManagerFactory
+  ) {
+    return new JpaTransactionManager(entityManagerFactory);
+  }
+}

--- a/src/main/java/com/springboot/monew/config/MongoConfig.java
+++ b/src/main/java/com/springboot/monew/config/MongoConfig.java
@@ -1,0 +1,17 @@
+package com.springboot.monew.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.MongoTransactionManager;
+
+@Configuration
+public class MongoConfig {
+
+  @Bean
+  public MongoTransactionManager mongoTransactionManager(
+      MongoDatabaseFactory mongoDatabaseFactory
+  ) {
+    return new MongoTransactionManager(mongoDatabaseFactory);
+  }
+}

--- a/src/main/java/com/springboot/monew/config/MongoConfig.java
+++ b/src/main/java/com/springboot/monew/config/MongoConfig.java
@@ -8,7 +8,7 @@ import org.springframework.data.mongodb.MongoTransactionManager;
 @Configuration
 public class MongoConfig {
 
-  @Bean
+  @Bean(name = "mongoTransactionManager")
   public MongoTransactionManager mongoTransactionManager(
       MongoDatabaseFactory mongoDatabaseFactory
   ) {

--- a/src/main/java/com/springboot/monew/users/service/UserActivityUpdateService.java
+++ b/src/main/java/com/springboot/monew/users/service/UserActivityUpdateService.java
@@ -43,6 +43,7 @@ public class UserActivityUpdateService {
   }
 
   // 관심사 키워드가 변경되면 해당 관심사를 구독 중인 사용자들의 활동 내역 구독 정보를 갱신한다.
+  @Transactional("mongoTransactionManager")
   public void updateSubscriptionInterest(UUID interestId, List<String> keywords) {
     List<UserActivityDocument> documents =
         userActivityRepository.findAllBySubscriptionsInterestId(interestId);

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -19,7 +19,7 @@ spring:
         dialect: org.hibernate.dialect.PostgreSQLDialect
   data:
     mongodb:
-      uri: ${MONGODB_URI:mongodb://localhost:27017/monew}
+      uri: ${MONGODB_URI:mongodb://localhost:27017/monew?replicaSet=rs0}
   batch:
     jdbc:
       initialize-schema: always

--- a/src/test/java/com/springboot/monew/comment/service/CommentLikeServiceTest.java
+++ b/src/test/java/com/springboot/monew/comment/service/CommentLikeServiceTest.java
@@ -20,7 +20,11 @@ import com.springboot.monew.comment.repository.CommentLikeRepository;
 import com.springboot.monew.comment.repository.CommentRepository;
 import com.springboot.monew.common.exception.MonewException;
 import com.springboot.monew.notification.event.CommentLikeNotificationEvent;
+import com.springboot.monew.users.document.UserActivityDocument.CommentLikeItem;
 import com.springboot.monew.users.entity.User;
+import com.springboot.monew.users.event.comment.CommentLikeCountUpdatedEvent;
+import com.springboot.monew.users.event.comment.CommentLikedEvent;
+import com.springboot.monew.users.event.comment.CommentUnlikedEvent;
 import com.springboot.monew.users.exception.UserErrorCode;
 import com.springboot.monew.users.repository.UserRepository;
 import java.time.Instant;
@@ -31,6 +35,7 @@ import org.instancio.Instancio;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -67,13 +72,26 @@ class CommentLikeServiceTest {
         .set(field(User.class, "deletedAt"), null)
         .create();
 
-
     CommentLikeDto expected = new CommentLikeDto(
         UUID.randomUUID(),
         user.getId(),
         Instant.now(),
         refreshed.getId(),
         refreshed.getArticle().getId(),
+        refreshed.getUser().getId(),
+        refreshed.getUser().getNickname(),
+        refreshed.getContent(),
+        refreshed.getLikeCount(),
+        refreshed.getCreatedAt()
+    );
+
+    // 사용자 활동 이벤트 발행 시 CommentLikedEvent 안에 담길 CommentLikeItem을 미리 준비한다.
+    CommentLikeItem commentLikeItem = new CommentLikeItem(
+        UUID.randomUUID(),
+        Instant.now(),
+        refreshed.getId(),
+        refreshed.getArticle().getId(),
+        refreshed.getArticle().getTitle(),
         refreshed.getUser().getId(),
         refreshed.getUser().getNickname(),
         refreshed.getContent(),
@@ -88,6 +106,8 @@ class CommentLikeServiceTest {
     given(commentLikeRepository.existsByCommentIdAndUserId(comment.getId(), user.getId()))
         .willReturn(false);
     given(commentLikeMapper.toCommentLikeDto(any(CommentLike.class))).willReturn(expected);
+    // like() 내부에서 CommentLikedEvent 생성 시 toCommentLikeItem()을 호출하므로 null이 반환되지 않도록 stub 처리한다.
+    given(commentLikeMapper.toCommentLikeItem(any(CommentLike.class))).willReturn(commentLikeItem);
 
     // when
     CommentLikeDto result = commentLikeService.like(comment.getId(), user.getId());
@@ -98,7 +118,45 @@ class CommentLikeServiceTest {
     verify(commentRepository, times(2)).findByIdAndIsDeletedFalse(comment.getId());
     verify(commentLikeRepository).save(any(CommentLike.class));
     verify(commentLikeMapper).toCommentLikeDto(any(CommentLike.class));
-    verify(eventPublisher).publishEvent(any(CommentLikeNotificationEvent.class));
+
+    // 좋아요 등록 시 총 3개의 이벤트가 발행되는지 검증하고, 전달된 이벤트 객체들을 모두 가져온다.
+    ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+    verify(eventPublisher, times(3)).publishEvent(captor.capture());
+
+    // 발행된 이벤트 목록에서 사용자 활동 내역 추가 이벤트를 찾는다.
+    CommentLikedEvent likedEvent = captor.getAllValues().stream()
+        .filter(CommentLikedEvent.class::isInstance)
+        .map(CommentLikedEvent.class::cast)
+        .findFirst()
+        .orElseThrow();
+
+    // 발행된 이벤트 목록에서 댓글 좋아요 수 갱신 이벤트를 찾는다.
+    CommentLikeCountUpdatedEvent likeCountUpdatedEvent = captor.getAllValues().stream()
+        .filter(CommentLikeCountUpdatedEvent.class::isInstance)
+        .map(CommentLikeCountUpdatedEvent.class::cast)
+        .findFirst()
+        .orElseThrow();
+
+    // 발행된 이벤트 목록에서 댓글 좋아요 알림 이벤트를 찾는다.
+    CommentLikeNotificationEvent notificationEvent = captor.getAllValues().stream()
+        .filter(CommentLikeNotificationEvent.class::isInstance)
+        .map(CommentLikeNotificationEvent.class::cast)
+        .findFirst()
+        .orElseThrow();
+
+    // 사용자 활동 내역에 추가할 좋아요 이벤트가 올바르게 발행되었는지 검증한다.
+    assertThat(likedEvent.userId()).isEqualTo(user.getId());
+    assertThat(likedEvent.item().commentId()).isEqualTo(refreshed.getId());
+    assertThat(likedEvent.item().articleId()).isEqualTo(refreshed.getArticle().getId());
+    assertThat(likedEvent.item().commentContent()).isEqualTo(refreshed.getContent());
+
+    // 댓글 작성자의 활동 내역에 반영할 좋아요 수 갱신 이벤트가 올바르게 발행되었는지 검증한다.
+    assertThat(likeCountUpdatedEvent.userId()).isEqualTo(refreshed.getUser().getId());
+    assertThat(likeCountUpdatedEvent.commentId()).isEqualTo(refreshed.getId());
+    assertThat(likeCountUpdatedEvent.likeCount()).isEqualTo(refreshed.getLikeCount());
+
+    // 댓글 좋아요 알림 이벤트가 함께 발행되었는지 검증한다.
+    assertThat(notificationEvent).isNotNull();
   }
 
   @Test
@@ -200,7 +258,19 @@ class CommentLikeServiceTest {
 
     CommentLike commentLike = new CommentLike(comment, user);
 
-    given(commentRepository.findByIdAndIsDeletedFalse(comment.getId())).willReturn(Optional.of(comment));
+    // 좋아요 수가 감소한 뒤 다시 조회되는 댓글 객체를 미리 준비한다.
+    Comment refreshed = Instancio.of(Comment.class)
+        .set(field(BaseEntity.class, "id"), comment.getId())
+        .set(field(BaseEntity.class, "createdAt"), comment.getCreatedAt())
+        .set(field(Comment.class, "article"), comment.getArticle())
+        .set(field(Comment.class, "user"), comment.getUser())
+        .set(field(Comment.class, "content"), comment.getContent())
+        .set(field(Comment.class, "likeCount"), comment.getLikeCount() - 1)
+        .create();
+
+    // unlike() 내부에서 좋아요 수 감소 후 댓글을 다시 조회하므로, 감소된 likeCount가 반영된 댓글을 반환하도록 설정한다.
+    given(commentRepository.findByIdAndIsDeletedFalse(comment.getId())).willReturn(Optional.of(comment))
+        .willReturn(Optional.of(refreshed));
     given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
     given(commentLikeRepository.findCommentLikeByCommentAndUser(comment, user)).willReturn(Optional.of(commentLike));
 
@@ -210,6 +280,33 @@ class CommentLikeServiceTest {
     // then
     verify(commentLikeRepository).delete(commentLike);
     verify(commentRepository).decrementLikeCount(comment.getId());
+
+    // 좋아요 취소 시 총 2개의 이벤트가 발행되는지 검증하고, 전달된 이벤트 객체들을 모두 가져온다.
+    ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+    verify(eventPublisher, times(2)).publishEvent(captor.capture());
+
+    // 발행된 이벤트 목록에서 사용자 활동 내역 제거 이벤트를 찾는다.
+    CommentUnlikedEvent unlikedEvent = captor.getAllValues().stream()
+        .filter(CommentUnlikedEvent.class::isInstance)
+        .map(CommentUnlikedEvent.class::cast)
+        .findFirst()
+        .orElseThrow();
+
+    // 발행된 이벤트 목록에서 댓글 좋아요 수 갱신 이벤트를 찾는다.
+    CommentLikeCountUpdatedEvent likeCountUpdatedEvent = captor.getAllValues().stream()
+        .filter(CommentLikeCountUpdatedEvent.class::isInstance)
+        .map(CommentLikeCountUpdatedEvent.class::cast)
+        .findFirst()
+        .orElseThrow();
+
+    // 사용자 활동 내역에서 제거할 좋아요 취소 이벤트가 올바르게 발행되었는지 검증한다.
+    assertThat(unlikedEvent.userId()).isEqualTo(user.getId());
+    assertThat(unlikedEvent.commentId()).isEqualTo(comment.getId());
+
+    // 댓글 작성자의 활동 내역에 반영할 좋아요 수 갱신 이벤트가 올바르게 발행되었는지 검증한다.
+    assertThat(likeCountUpdatedEvent.userId()).isEqualTo(refreshed.getUser().getId());
+    assertThat(likeCountUpdatedEvent.commentId()).isEqualTo(refreshed.getId());
+    assertThat(likeCountUpdatedEvent.likeCount()).isEqualTo(refreshed.getLikeCount());
   }
 
   @Test

--- a/src/test/java/com/springboot/monew/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/springboot/monew/comment/service/CommentServiceTest.java
@@ -30,7 +30,11 @@ import com.springboot.monew.newsarticles.entity.NewsArticle;
 import com.springboot.monew.newsarticles.enums.ArticleSource;
 import com.springboot.monew.newsarticles.exception.NewsArticleErrorCode;
 import com.springboot.monew.newsarticles.repository.NewsArticleRepository;
+import com.springboot.monew.users.document.UserActivityDocument.CommentItem;
 import com.springboot.monew.users.entity.User;
+import com.springboot.monew.users.event.comment.CommentCreatedEvent;
+import com.springboot.monew.users.event.comment.CommentDeletedEvent;
+import com.springboot.monew.users.event.comment.CommentUpdatedEvent;
 import com.springboot.monew.users.exception.UserErrorCode;
 import com.springboot.monew.users.repository.UserRepository;
 import java.lang.reflect.Field;
@@ -42,6 +46,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -94,9 +99,23 @@ class CommentServiceTest {
         Instant.now()
     );
 
+    // 이벤트 발행 시 CommentCreatedEvent 안에 담길 CommentItem mock 값을 미리 준비
+    CommentItem commentItem = new CommentItem(
+        UUID.randomUUID(),
+        article.getId(),
+        article.getTitle(),
+        user.getId(),
+        user.getNickname(),
+        request.content(),
+        0L,
+        Instant.now()
+    );
+
     given(articleRepository.findById(article.getId())).willReturn(Optional.of(article));
     given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
     given(commentMapper.toCommentDto(any(Comment.class), eq(false))).willReturn(expected);
+    // commentService.create() 내부에서 이벤트 생성 시 toCommentItem()을 호출하므로 null이 반환되지 않도록 stub 처리
+    given(commentMapper.toCommentItem(any(Comment.class))).willReturn(commentItem);
 
     // when
     CommentDto result = commentService.create(request);
@@ -111,6 +130,16 @@ class CommentServiceTest {
     verify(userRepository).findById(user.getId());
     verify(commentMapper).toCommentDto(any(Comment.class), eq(false));
 
+    // 발행된 CommentCreatedEvent를 가져와 댓글 생성 정보가 올바르게 담겼는지 검증
+    ArgumentCaptor<CommentCreatedEvent> captor =
+        ArgumentCaptor.forClass(CommentCreatedEvent.class);
+
+    verify(eventPublisher).publishEvent(captor.capture());
+
+    assertThat(captor.getValue().userId()).isEqualTo(user.getId());
+    assertThat(captor.getValue().item().articleId()).isEqualTo(article.getId());
+    assertThat(captor.getValue().item().userId()).isEqualTo(user.getId());
+    assertThat(captor.getValue().item().content()).isEqualTo(request.content());
   }
 
   @Test
@@ -198,11 +227,25 @@ class CommentServiceTest {
         Instant.now()
     );
 
+    // 이벤트 발행 시 CommentUpdatedEvent 안에 담길 CommentItem mock 값을 미리 준비
+    CommentItem commentItem = new CommentItem(
+        commentId,
+        UUID.randomUUID(),
+        "기사 제목",
+        user.getId(),
+        user.getNickname(),
+        request.content(),
+        0L,
+        Instant.now()
+    );
+
 
     given(commentRepository.findByIdAndIsDeletedFalse(comment.getId())).willReturn(Optional.of(comment));
     given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
     given(commentLikeRepository.existsByCommentIdAndUserId(comment.getId(), user.getId())).willReturn(false);
     given(commentMapper.toCommentDto(any(Comment.class), eq(false))).willReturn(expected);
+    // commentService.update() 내부에서 이벤트 생성 시 toCommentItem()을 호출하므로 null이 반환되지 않도록 stub 처리
+    given(commentMapper.toCommentItem(any(Comment.class))).willReturn(commentItem);
 
     // when
     CommentDto result = commentService.update(comment.getId(), user.getId(), request);
@@ -216,6 +259,17 @@ class CommentServiceTest {
     verify(commentRepository).findByIdAndIsDeletedFalse(comment.getId());
     verify(userRepository).findById(user.getId());
     verify(commentMapper).toCommentDto(any(Comment.class), eq(false));
+
+    // 발행된 CommentUpdatedEvent를 가져와 수정된 댓글 정보가 올바르게 담겼는지 검증
+    ArgumentCaptor<CommentUpdatedEvent> captor =
+        ArgumentCaptor.forClass(CommentUpdatedEvent.class);
+
+    verify(eventPublisher).publishEvent(captor.capture());
+
+    assertThat(captor.getValue().userId()).isEqualTo(user.getId());
+    assertThat(captor.getValue().item().id()).isEqualTo(commentId);
+    assertThat(captor.getValue().item().userId()).isEqualTo(user.getId());
+    assertThat(captor.getValue().item().content()).isEqualTo(request.content());
   }
 
   @Test
@@ -375,13 +429,14 @@ class CommentServiceTest {
   void hardDelete_DeletesComment_WhenCommentExists() {
     // given
     UUID commentId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
     Comment comment = mock(Comment.class);
 
     given(commentRepository.findById(commentId)).willReturn(Optional.of(comment));
     // 물리 삭제 이벤트 발행 시 댓글 작성자 ID와 댓글 ID를 사용하므로 필요한 값만 stub 처리한다.
     User user = mock(User.class);
     given(comment.getUser()).willReturn(user);
-    given(user.getId()).willReturn(UUID.randomUUID());
+    given(user.getId()).willReturn(userId);
     given(comment.getId()).willReturn(commentId);
     // when
     commentService.hardDelete(commentId);
@@ -389,6 +444,16 @@ class CommentServiceTest {
     // then
     verify(commentRepository).findById(commentId);
     verify(commentRepository).delete(comment);
+
+    // 발행된 CommentDeletedEvent를 가져와 삭제 대상 정보가 올바르게 담겼는지 검증한다.
+    ArgumentCaptor<CommentDeletedEvent> captor =
+        ArgumentCaptor.forClass(CommentDeletedEvent.class);
+
+    // eventPublisher.publishEvent()가 호출되었는지 확인하고 전달된 이벤트 객체를 가져온다.
+    verify(eventPublisher).publishEvent(captor.capture());
+
+    assertThat(captor.getValue().userId()).isEqualTo(userId);
+    assertThat(captor.getValue().commentId()).isEqualTo(commentId);
   }
 
   @Test

--- a/src/test/java/com/springboot/monew/interest/service/InterestServiceTest.java
+++ b/src/test/java/com/springboot/monew/interest/service/InterestServiceTest.java
@@ -28,6 +28,7 @@ import com.springboot.monew.interest.repository.InterestRepository;
 import com.springboot.monew.interest.repository.KeywordRepository;
 import com.springboot.monew.interest.repository.SubscriptionRepository;
 import com.springboot.monew.users.entity.User;
+import com.springboot.monew.users.event.interest.InterestUpdatedEvent;
 import com.springboot.monew.users.exception.UserErrorCode;
 import com.springboot.monew.users.exception.UserException;
 import com.springboot.monew.users.repository.UserRepository;
@@ -40,6 +41,7 @@ import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -571,6 +573,16 @@ class InterestServiceTest {
     assertThat(result).isEqualTo(expected);
     verify(interestKeywordRepository).deleteAll(List.of(oldLink));
     verify(interestKeywordRepository).save(any(InterestKeyword.class));
+
+    // 발행된 InterestUpdatedEvent를 가져와 수정된 관심사 ID와 키워드 목록이 올바르게 담겼는지 검증한다.
+    ArgumentCaptor<InterestUpdatedEvent> captor =
+        ArgumentCaptor.forClass(InterestUpdatedEvent.class);
+
+    // eventPublisher.publishEvent()가 호출되었는지 확인하고 전달된 이벤트 객체를 가져온다.
+    verify(eventPublisher).publishEvent(captor.capture());
+
+    assertThat(captor.getValue().interestId()).isEqualTo(interestId);
+    assertThat(captor.getValue().keywords()).containsExactly("채권");
   }
 
   @Test

--- a/src/test/java/com/springboot/monew/interest/service/SubscriptionServiceTest.java
+++ b/src/test/java/com/springboot/monew/interest/service/SubscriptionServiceTest.java
@@ -19,7 +19,10 @@ import com.springboot.monew.interest.mapper.SubscriptionDtoMapper;
 import com.springboot.monew.interest.repository.InterestKeywordRepository;
 import com.springboot.monew.interest.repository.InterestRepository;
 import com.springboot.monew.interest.repository.SubscriptionRepository;
+import com.springboot.monew.users.document.UserActivityDocument.SubscriptionItem;
 import com.springboot.monew.users.entity.User;
+import com.springboot.monew.users.event.interest.InterestSubscribedEvent;
+import com.springboot.monew.users.event.interest.InterestUnsubscribedEvent;
 import com.springboot.monew.users.exception.UserErrorCode;
 import com.springboot.monew.users.exception.UserException;
 import com.springboot.monew.users.repository.UserRepository;
@@ -32,6 +35,7 @@ import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -88,6 +92,15 @@ class SubscriptionServiceTest {
         subscription.getCreatedAt()
     );
 
+    // 사용자 활동 이벤트 발행 시 InterestSubscribedEvent 안에 담길 SubscriptionItem을 미리 준비한다.
+    SubscriptionItem subscriptionItem = new SubscriptionItem(
+        subscription.getId(),
+        interestId,
+        interest.getName(),
+        List.of("주식", "채권"),
+        subscription.getCreatedAt()
+    );
+
     given(userRepository.findById(userId)).willReturn(Optional.of(user));
     given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
     given(subscriptionRepository.existsByUserIdAndInterestId(userId, interestId)).willReturn(false);
@@ -97,12 +110,26 @@ class SubscriptionServiceTest {
     given(interestRepository.findSubscriberCountById(interestId)).willReturn(2L);
     given(subscriptionDtoMapper.toSubscriptionDto(subscription, List.of("주식", "채권"), 2L))
         .willReturn(expected);
+    // subscribe() 내부에서 InterestSubscribedEvent 생성 시 toSubscriptionItem()을 호출하므로 null이 반환되지 않도록 stub 처리한다.
+    given(subscriptionDtoMapper.toSubscriptionItem(subscription, List.of("주식", "채권"))).willReturn(subscriptionItem);
 
     // when
     SubscriptionDto result = subscriptionService.subscribe(interestId, userId);
 
     // then
     assertThat(result).isEqualTo(expected);
+
+    // 발행된 InterestSubscribedEvent를 가져와 구독 정보가 올바르게 담겼는지 검증한다.
+    ArgumentCaptor<InterestSubscribedEvent> captor =
+        ArgumentCaptor.forClass(InterestSubscribedEvent.class);
+
+    // eventPublisher.publishEvent()가 호출되었는지 확인하고 전달된 이벤트 객체를 가져온다.
+    verify(eventPublisher).publishEvent(captor.capture());
+
+    assertThat(captor.getValue().userId()).isEqualTo(userId);
+    assertThat(captor.getValue().item().interestId()).isEqualTo(interestId);
+    assertThat(captor.getValue().item().interestName()).isEqualTo(interest.getName());
+    assertThat(captor.getValue().item().interestKeywords()).containsExactly("주식", "채권");
   }
 
   @Test
@@ -385,6 +412,16 @@ class SubscriptionServiceTest {
     // then
     verify(subscriptionRepository).deleteByUserIdAndInterestId(userId, interestId);
     verify(interestRepository).decrementSubscriberCount(interestId);
+
+    // 발행된 InterestUnsubscribedEvent를 가져와 구독 취소 대상 정보가 올바르게 담겼는지 검증한다.
+    ArgumentCaptor<InterestUnsubscribedEvent> captor =
+        ArgumentCaptor.forClass(InterestUnsubscribedEvent.class);
+
+    // eventPublisher.publishEvent()가 호출되었는지 확인하고 전달된 이벤트 객체를 가져온다.
+    verify(eventPublisher).publishEvent(captor.capture());
+
+    assertThat(captor.getValue().userId()).isEqualTo(userId);
+    assertThat(captor.getValue().interestId()).isEqualTo(interestId);
   }
 
   @Test

--- a/src/test/java/com/springboot/monew/newsarticles/service/NewsArticleServiceTest.java
+++ b/src/test/java/com/springboot/monew/newsarticles/service/NewsArticleServiceTest.java
@@ -35,7 +35,9 @@ import com.springboot.monew.newsarticles.mapper.NewsArticleViewMapper;
 import com.springboot.monew.newsarticles.repository.ArticleInterestRepository;
 import com.springboot.monew.newsarticles.repository.ArticleViewRepository;
 import com.springboot.monew.newsarticles.repository.NewsArticleRepository;
+import com.springboot.monew.users.document.UserActivityDocument.ArticleViewItem;
 import com.springboot.monew.users.entity.User;
+import com.springboot.monew.users.event.articleView.ArticleViewedEvent;
 import com.springboot.monew.users.exception.UserErrorCode;
 import com.springboot.monew.users.exception.UserException;
 import com.springboot.monew.users.repository.UserRepository;
@@ -48,6 +50,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -357,6 +360,21 @@ class NewsArticleServiceTest {
     //반환될 DTO mock 생성
     NewsArticleViewDto responseDto = mock(NewsArticleViewDto.class);
 
+    // 기사 조회 활동 이벤트에 담길 ArticleViewItem을 미리 준비한다.
+    ArticleViewItem articleViewItem = new ArticleViewItem(
+        UUID.randomUUID(),
+        userId,
+        Instant.now(),
+        articleId,
+        ArticleSource.NAVER,
+        "https://example.com/article",
+        "기사 제목",
+        Instant.parse("2026-04-28T00:00:00Z"),
+        "기사 요약",
+        3L,
+        11L
+    );
+
     //validateActiveUser(userId)로 사용자 존재
     given(userRepository.findById(userId)).willReturn(Optional.of(user));
 
@@ -378,6 +396,10 @@ class NewsArticleServiceTest {
     //DTO 변환결과 설정
     given(newsArticleViewMapper.toDto(any(ArticleView.class), eq(3L))).willReturn(responseDto);
 
+    // 활동 이벤트 발행 시 사용할 ArticleViewItem 변환 결과를 stub 한다.
+    given(newsArticleViewMapper.toArticleViewItem(any(ArticleView.class), eq(3L)))
+        .willReturn(articleViewItem);
+
     //  when
     NewsArticleViewDto result = newsArticleService.createView(articleId, userId);
 
@@ -396,6 +418,16 @@ class NewsArticleServiceTest {
 
     //DTO 변환이 수행되었는지 검증
     verify(newsArticleViewMapper).toDto(any(ArticleView.class), eq(3L));
+
+    // 기사 조회 성공 시 사용자 활동내역 반영을 위한 ArticleViewedEvent가 발행되었는지 검증한다.
+    ArgumentCaptor<ArticleViewedEvent> captor =
+        ArgumentCaptor.forClass(ArticleViewedEvent.class);
+
+    verify(eventPublisher).publishEvent(captor.capture());
+
+    // 발행된 이벤트에 조회한 사용자 id와 기사 조회 활동 정보가 올바르게 담겼는지 검증한다.
+    assertThat(captor.getValue().userId()).isEqualTo(userId);
+    assertThat(captor.getValue().item()).isEqualTo(articleViewItem);
   }
 
   @Test

--- a/src/test/java/com/springboot/monew/users/controller/UserControllerTest.java
+++ b/src/test/java/com/springboot/monew/users/controller/UserControllerTest.java
@@ -1,5 +1,7 @@
 package com.springboot.monew.users.controller;
 
+import static org.assertj.core.api.Assertions.as;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
@@ -22,6 +24,7 @@ import java.time.Instant;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
@@ -72,8 +75,17 @@ public class UserControllerTest {
         .andExpect(jsonPath("$.nickname").value("monew123"))
         .andExpect(jsonPath("$.createdAt").value("2026-04-17T01:46:03.003Z"));
 
-    // 컨트롤러가 실제로 register을 호출했는지 검증하기 위해 추가
-    verify(userService).register(any(UserRegisterRequest.class));
+    //ArgumentCaptor로 서비스에 전달된 UserRegisterRequest 값을 잡아서 email, nickname, password가 요청값과 같은지 검증
+    ArgumentCaptor<UserRegisterRequest> captor =
+        ArgumentCaptor.forClass(UserRegisterRequest.class);
+
+    // userService.register()이 호출되었는지 확인하고, 전달된 요청 객체를 가져와 검증
+    verify(userService).register(captor.capture());
+
+    // 컨트롤러가 요청 본문을 UserRegisterRequest로 올바르게 파싱해 서비스에 전달했는지 검증
+    assertThat(captor.getValue().email()).isEqualTo(request.email());
+    assertThat(captor.getValue().nickname()).isEqualTo(request.nickname());
+    assertThat(captor.getValue().password()).isEqualTo(request.password());
   }
 
   @Test
@@ -130,7 +142,16 @@ public class UserControllerTest {
         .andExpect(jsonPath("$.nickname").value(expected.nickname()))
         .andExpect(jsonPath("$.createdAt").value("2026-04-17T01:46:03.003Z"));
 
-    verify(userService).login(any(UserLoginRequest.class));
+    // ArgumentCaptor로 서비스에 전달된 UserLoginRequest 값을 잡아서 email, password가 요청값과 같은지 검증
+    ArgumentCaptor<UserLoginRequest> captor =
+        ArgumentCaptor.forClass(UserLoginRequest.class);
+
+    // userService.login()이 호출되었는지 확인하고, 전달된 요청 객체를 가져와 검증
+    verify(userService).login(captor.capture());
+
+    // // 컨트롤러가 요청 본문을 UserRegisterRequest로 올바르게 파싱해 서비스에 전달했는지 검증
+    assertThat(captor.getValue().email()).isEqualTo(request.email());
+    assertThat(captor.getValue().password()).isEqualTo(request.password());
   }
 
   @Test
@@ -184,7 +205,15 @@ public class UserControllerTest {
         .andExpect(jsonPath("$.nickname").value(expected.nickname()))
         .andExpect(jsonPath("$.createdAt").value("2026-04-17T01:46:03.003Z"));
 
-    verify(userService).update(eq(userId), any(UserUpdateRequest.class));
+    // 서비스에 전달된 UserUpdateRequest를 가져와 nickname이 요청값과 같은지 검증
+    ArgumentCaptor<UserUpdateRequest> captor =
+        ArgumentCaptor.forClass(UserUpdateRequest.class);
+
+    // userService.update()가 호출되었는지 확인하고, 전달된 요청 객체를 가져와 검증
+    verify(userService).update(eq(userId), captor.capture());
+
+    // 컨트롤러가 요청 본문을 UserUpdateRequest로 올바르게 파싱해 서비스에 전달했는지 검증
+    assertThat(captor.getValue().nickname()).isEqualTo(request.nickname());
   }
 
   @Test

--- a/src/test/java/com/springboot/monew/users/controller/UserControllerTest.java
+++ b/src/test/java/com/springboot/monew/users/controller/UserControllerTest.java
@@ -149,7 +149,7 @@ public class UserControllerTest {
     // userService.login()이 호출되었는지 확인하고, 전달된 요청 객체를 가져와 검증
     verify(userService).login(captor.capture());
 
-    // // 컨트롤러가 요청 본문을 UserRegisterRequest로 올바르게 파싱해 서비스에 전달했는지 검증
+    // // 컨트롤러가 요청 본문을 UserLoginRequest로 올바르게 파싱해 서비스에 전달했는지 검증
     assertThat(captor.getValue().email()).isEqualTo(request.email());
     assertThat(captor.getValue().password()).isEqualTo(request.password());
   }

--- a/src/test/java/com/springboot/monew/users/controller/UserControllerTest.java
+++ b/src/test/java/com/springboot/monew/users/controller/UserControllerTest.java
@@ -149,7 +149,7 @@ public class UserControllerTest {
     // userService.login()이 호출되었는지 확인하고, 전달된 요청 객체를 가져와 검증
     verify(userService).login(captor.capture());
 
-    // // 컨트롤러가 요청 본문을 UserLoginRequest로 올바르게 파싱해 서비스에 전달했는지 검증
+    // 컨트롤러가 요청 본문을 UserLoginRequest로 올바르게 파싱해 서비스에 전달했는지 검증
     assertThat(captor.getValue().email()).isEqualTo(request.email());
     assertThat(captor.getValue().password()).isEqualTo(request.password());
   }

--- a/src/test/java/com/springboot/monew/users/document/UserActivityDocumentTest.java
+++ b/src/test/java/com/springboot/monew/users/document/UserActivityDocumentTest.java
@@ -1,0 +1,397 @@
+package com.springboot.monew.users.document;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.springboot.monew.newsarticles.enums.ArticleSource;
+import com.springboot.monew.users.document.UserActivityDocument.ArticleViewItem;
+import com.springboot.monew.users.document.UserActivityDocument.CommentItem;
+import com.springboot.monew.users.document.UserActivityDocument.CommentLikeItem;
+import com.springboot.monew.users.document.UserActivityDocument.SubscriptionItem;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class UserActivityDocumentTest {
+
+  @Test
+  @DisplayName("같은 관심사를 다시 구독하면 중복 없이 맨 앞에 재배치한다")
+  void addSubscription_MovesDuplicateToFront() {
+    // given
+    UUID interestId1 = UUID.randomUUID();
+    UUID interestId2 = UUID.randomUUID();
+
+    UserActivityDocument document = new UserActivityDocument(
+        UUID.randomUUID(),
+        "test@example.com",
+        "tester",
+        Instant.now()
+    );
+
+    SubscriptionItem first = new SubscriptionItem(
+        UUID.randomUUID(),
+        interestId1,
+        "금융",
+        List.of("주식"),
+        Instant.now()
+    );
+    SubscriptionItem second = new SubscriptionItem(
+        UUID.randomUUID(),
+        interestId2,
+        "부동산",
+        List.of("청약"),
+        Instant.now()
+    );
+    SubscriptionItem duplicated = new SubscriptionItem(
+        UUID.randomUUID(),
+        interestId1,
+        "금융",
+        List.of("주식", "채권"),
+        Instant.now()
+    );
+
+    document.addSubscription(first);
+    document.addSubscription(second);
+
+    // when
+    document.addSubscription(duplicated);
+
+    // then
+    assertThat(document.getSubscriptions()).hasSize(2);
+    assertThat(document.getSubscriptions().get(0).interestId()).isEqualTo(interestId1);
+    assertThat(document.getSubscriptions().get(0).interestKeywords()).containsExactly("주식", "채권");
+    assertThat(document.getSubscriptions().get(1).interestId()).isEqualTo(interestId2);
+  }
+
+  @Test
+  @DisplayName("댓글 수정 시 기존 댓글을 갱신하고 맨 앞에 배치한다")
+  void updateComment_UpdatesAndMovesToFront() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID commentId1 = UUID.randomUUID();
+    UUID commentId2 = UUID.randomUUID();
+
+    UserActivityDocument document = new UserActivityDocument(
+        userId,
+        "test@example.com",
+        "tester",
+        Instant.now()
+    );
+
+    CommentItem first = new CommentItem(
+        commentId1,
+        UUID.randomUUID(),
+        "기사1",
+        userId,
+        "tester",
+        "기존 댓글",
+        0L,
+        Instant.now()
+    );
+    CommentItem second = new CommentItem(
+        commentId2,
+        UUID.randomUUID(),
+        "기사2",
+        userId,
+        "tester",
+        "다른 댓글",
+        1L,
+        Instant.now()
+    );
+    CommentItem updated = new CommentItem(
+        commentId1,
+        first.articleId(),
+        first.articleTitle(),
+        userId,
+        "tester",
+        "수정된 댓글",
+        3L,
+        first.createdAt()
+    );
+
+    document.addComment(first);
+    document.addComment(second);
+
+    // when
+    document.updateComment(updated);
+
+    // then
+    assertThat(document.getComments()).hasSize(2);
+    assertThat(document.getComments().get(0).id()).isEqualTo(commentId1);
+    assertThat(document.getComments().get(0).content()).isEqualTo("수정된 댓글");
+    assertThat(document.getComments().get(0).likeCount()).isEqualTo(3L);
+    assertThat(document.getComments().get(1).id()).isEqualTo(commentId2);
+  }
+
+  @Test
+  @DisplayName("댓글 좋아요 취소는 commentLike id가 아니라 commentId 기준으로 제거한다")
+  void removeCommentLike_RemovesByCommentId() {
+    // given
+    UUID targetCommentId = UUID.randomUUID();
+    UUID otherCommentId = UUID.randomUUID();
+
+    UserActivityDocument document = new UserActivityDocument(
+        UUID.randomUUID(),
+        "test@example.com",
+        "tester",
+        Instant.now()
+    );
+
+    CommentLikeItem target = new CommentLikeItem(
+        UUID.randomUUID(),
+        Instant.now(),
+        targetCommentId,
+        UUID.randomUUID(),
+        "기사1",
+        UUID.randomUUID(),
+        "writer1",
+        "댓글1",
+        3L,
+        Instant.now()
+    );
+    CommentLikeItem other = new CommentLikeItem(
+        UUID.randomUUID(),
+        Instant.now(),
+        otherCommentId,
+        UUID.randomUUID(),
+        "기사2",
+        UUID.randomUUID(),
+        "writer2",
+        "댓글2",
+        2L,
+        Instant.now()
+    );
+
+    document.addCommentLike(target);
+    document.addCommentLike(other);
+
+    // when
+    document.removeCommentLike(targetCommentId);
+
+    // then
+    assertThat(document.getCommentLikes()).hasSize(1);
+    assertThat(document.getCommentLikes().get(0).commentId()).isEqualTo(otherCommentId);
+  }
+
+  @Test
+  @DisplayName("댓글 좋아요 수 갱신 시 대상 댓글만 변경한다")
+  void updateCommentLikeCount_UpdatesOnlyTargetComment() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID targetCommentId = UUID.randomUUID();
+    UUID otherCommentId = UUID.randomUUID();
+
+    UserActivityDocument document = new UserActivityDocument(
+        userId,
+        "test@example.com",
+        "tester",
+        Instant.now()
+    );
+
+    CommentItem target = new CommentItem(
+        targetCommentId,
+        UUID.randomUUID(),
+        "기사1",
+        userId,
+        "tester",
+        "댓글1",
+        0L,
+        Instant.now()
+    );
+    CommentItem other = new CommentItem(
+        otherCommentId,
+        UUID.randomUUID(),
+        "기사2",
+        userId,
+        "tester",
+        "댓글2",
+        4L,
+        Instant.now()
+    );
+
+    document.addComment(target);
+    document.addComment(other);
+
+    // when
+    document.updateCommentLikeCount(targetCommentId, 7L);
+
+    // then
+    // 좋아요 수를 갱신한 대상 댓글만 7로 변경되었는지 검증한다
+    assertThat(document.getComments().stream()
+        .filter(comment -> comment.id().equals(targetCommentId))
+        .findFirst()
+        .orElseThrow()
+        .likeCount()).isEqualTo(7L);
+
+    // 갱신 대상이 아닌 다른 댓글의 좋아요 수는 기존 값 4가 유지되는지 검증한다
+    assertThat(document.getComments().stream()
+        .filter(comment -> comment.id().equals(otherCommentId))
+        .findFirst()
+        .orElseThrow()
+        .likeCount()).isEqualTo(4L);
+  }
+
+  @Test
+  @DisplayName("관심사 키워드 수정 시 해당 관심사만 갱신한다")
+  void updateSubscriptionInterest_UpdatesOnlyTargetInterest() {
+    // given
+    UUID interestId1 = UUID.randomUUID();
+    UUID interestId2 = UUID.randomUUID();
+
+    UserActivityDocument document = new UserActivityDocument(
+        UUID.randomUUID(),
+        "test@example.com",
+        "tester",
+        Instant.now()
+    );
+
+    SubscriptionItem target = new SubscriptionItem(
+        UUID.randomUUID(),
+        interestId1,
+        "금융",
+        List.of("주식"),
+        Instant.now()
+    );
+    SubscriptionItem other = new SubscriptionItem(
+        UUID.randomUUID(),
+        interestId2,
+        "부동산",
+        List.of("청약"),
+        Instant.now()
+    );
+
+    document.addSubscription(target);
+    document.addSubscription(other);
+
+    // when
+    document.updateSubscriptionInterest(interestId1, List.of("주식", "채권"));
+
+    // then
+    assertThat(document.getSubscriptions().stream()
+        .filter(subscription -> subscription.interestId().equals(interestId1))
+        .findFirst()
+        .orElseThrow()
+        .interestKeywords()).containsExactly("주식", "채권");
+
+    assertThat(document.getSubscriptions().stream()
+        .filter(subscription -> subscription.interestId().equals(interestId2))
+        .findFirst()
+        .orElseThrow()
+        .interestKeywords()).containsExactly("청약");
+  }
+
+  @Test
+  @DisplayName("기사를 다시 조회하면 중복 없이 맨 앞에 재배치한다")
+  void addArticleView_MovesDuplicateToFront() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID articleId1 = UUID.randomUUID();
+    UUID articleId2 = UUID.randomUUID();
+
+    UserActivityDocument document = new UserActivityDocument(
+        userId,
+        "test@example.com",
+        "tester",
+        Instant.now()
+    );
+
+    ArticleViewItem first = new ArticleViewItem(
+        UUID.randomUUID(),
+        userId,
+        Instant.now(),
+        articleId1,
+        ArticleSource.NAVER,
+        "https://a.com",
+        "기사1",
+        Instant.now(),
+        "요약1",
+        1L,
+        10L
+    );
+    ArticleViewItem second = new ArticleViewItem(
+        UUID.randomUUID(),
+        userId,
+        Instant.now(),
+        articleId2,
+        ArticleSource.NAVER,
+        "https://b.com",
+        "기사2",
+        Instant.now(),
+        "요약2",
+        2L,
+        20L
+    );
+    ArticleViewItem duplicated = new ArticleViewItem(
+        UUID.randomUUID(),
+        userId,
+        Instant.now(),
+        articleId1,
+        ArticleSource.NAVER,
+        "https://a.com",
+        "기사1-최신",
+        Instant.now(),
+        "요약1-최신",
+        3L,
+        30L
+    );
+
+    document.addArticleView(first);
+    document.addArticleView(second);
+
+    // when
+    document.addArticleView(duplicated);
+
+    // then
+    assertThat(document.getArticleViews()).hasSize(2);
+    assertThat(document.getArticleViews().get(0).articleId()).isEqualTo(articleId1);
+    assertThat(document.getArticleViews().get(0).articleTitle()).isEqualTo("기사1-최신");
+    assertThat(document.getArticleViews().get(1).articleId()).isEqualTo(articleId2);
+  }
+
+  @Test
+  @DisplayName("최근 활동은 최대 10개까지만 유지한다")
+  void addComment_KeepsOnlyTenRecentItems() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UserActivityDocument document = new UserActivityDocument(
+        userId,
+        "test@example.com",
+        "tester",
+        Instant.now()
+    );
+
+    UUID firstCommentId = UUID.randomUUID();
+    UUID lastCommentId = UUID.randomUUID();
+
+    // when
+    for (int i = 0; i < 11; i++) {
+      // 첫 댓글과 마지막 댓글만 고정 id로 저장해 나중에 제거/유지 여부를 검증한다.
+      UUID commentId = (i == 0) ? firstCommentId : (i == 10 ? lastCommentId : UUID.randomUUID());
+      // 댓글 활동 11개를 순서대로 추가한다.
+      document.addComment(new CommentItem(
+          commentId,
+          UUID.randomUUID(),
+          "기사" + i,
+          userId,
+          "tester",
+          "댓글" + i,
+          0L,
+          Instant.now().plusSeconds(i)
+      ));
+    }
+
+    // then
+    // 최근 활동은 최대 10개까지만 유지되어야 한다.
+    assertThat(document.getComments()).hasSize(10);
+
+    // 가장 마지막에 추가한 최신 댓글은 맨 앞에 있어야 한다.
+    assertThat(document.getComments().get(0).id()).isEqualTo(lastCommentId);
+
+    // 가장 먼저 들어간 오래된 댓글은 제거되어야 한다.
+    assertThat(document.getComments().stream()
+        .map(CommentItem::id))
+        .doesNotContain(firstCommentId);
+  }
+
+}

--- a/src/test/java/com/springboot/monew/users/event/UserActivityEventListenerTest.java
+++ b/src/test/java/com/springboot/monew/users/event/UserActivityEventListenerTest.java
@@ -1,0 +1,270 @@
+package com.springboot.monew.users.event;
+
+import static org.mockito.Mockito.verify;
+
+import com.springboot.monew.newsarticles.enums.ArticleSource;
+import com.springboot.monew.users.document.UserActivityDocument.ArticleViewItem;
+import com.springboot.monew.users.document.UserActivityDocument.CommentItem;
+import com.springboot.monew.users.document.UserActivityDocument.CommentLikeItem;
+import com.springboot.monew.users.document.UserActivityDocument.SubscriptionItem;
+import com.springboot.monew.users.entity.User;
+import com.springboot.monew.users.event.articleView.ArticleViewedEvent;
+import com.springboot.monew.users.event.comment.CommentCreatedEvent;
+import com.springboot.monew.users.event.comment.CommentDeletedEvent;
+import com.springboot.monew.users.event.comment.CommentLikeCountUpdatedEvent;
+import com.springboot.monew.users.event.comment.CommentLikedEvent;
+import com.springboot.monew.users.event.comment.CommentUnlikedEvent;
+import com.springboot.monew.users.event.comment.CommentUpdatedEvent;
+import com.springboot.monew.users.event.interest.InterestSubscribedEvent;
+import com.springboot.monew.users.event.interest.InterestUnsubscribedEvent;
+import com.springboot.monew.users.event.interest.InterestUpdatedEvent;
+import com.springboot.monew.users.event.user.UserNicknameUpdatedEvent;
+import com.springboot.monew.users.event.user.UserRegisteredEvent;
+import com.springboot.monew.users.service.UserActivityUpdateService;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class UserActivityEventListenerTest {
+
+  @Mock
+  private UserActivityUpdateService userActivityUpdateService;
+
+  @InjectMocks
+  private UserActivityEventListener userActivityEventListener;
+
+  @Test
+  @DisplayName("회원가입 이벤트를 수신하면 사용자 활동 문서를 생성한다")
+  void handle_UserRegisteredEvent() {
+    // given
+    User user = new User("test@example.com", "tester", "password");
+
+    UserRegisteredEvent event = new UserRegisteredEvent(user);
+
+    // when
+    userActivityEventListener.handle(event);
+
+    // then
+    verify(userActivityUpdateService).createUserActivity(user);
+  }
+
+  @Test
+  @DisplayName("닉네임 수정 이벤트를 수신하면 사용자 활동 문서의 닉네임을 갱신한다")
+  void handle_UserNicknameUpdatedEvent() {
+    // given
+    UUID userId = UUID.randomUUID();
+    String nickname = "newNickname";
+    UserNicknameUpdatedEvent event = new UserNicknameUpdatedEvent(userId, nickname);
+
+    // when
+    userActivityEventListener.handle(event);
+
+    // then
+    verify(userActivityUpdateService).updateUserNickname(userId, nickname);
+  }
+
+  @Test
+  @DisplayName("관심사 수정 이벤트를 수신하면 구독 중인 활동 문서의 키워드를 갱신한다")
+  void handle_InterestUpdatedEvent() {
+    // given
+    UUID interestId = UUID.randomUUID();
+    List<String> keywords = List.of("주식", "채권");
+    InterestUpdatedEvent event = new InterestUpdatedEvent(interestId, keywords);
+
+    // when
+    userActivityEventListener.handle(event);
+
+    // then
+    verify(userActivityUpdateService).updateSubscriptionInterest(interestId, keywords);
+  }
+
+  @Test
+  @DisplayName("관심사 구독 이벤트를 수신하면 활동 문서에 구독 내역을 추가한다")
+  void handle_InterestSubscribedEvent() {
+    // given
+    UUID userId = UUID.randomUUID();
+    SubscriptionItem item = new SubscriptionItem(
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        "금융",
+        List.of("주식", "채권"),
+        Instant.now()
+    );
+    InterestSubscribedEvent event = new InterestSubscribedEvent(userId, item);
+
+    // when
+    userActivityEventListener.handle(event);
+
+    // then
+    verify(userActivityUpdateService).addSubscription(userId, item);
+  }
+
+  @Test
+  @DisplayName("관심사 구독 취소 이벤트를 수신하면 활동 문서에서 구독 내역을 제거한다")
+  void handle_InterestUnsubscribedEvent() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID interestId = UUID.randomUUID();
+    InterestUnsubscribedEvent event = new InterestUnsubscribedEvent(userId, interestId);
+
+    // when
+    userActivityEventListener.handle(event);
+
+    // then
+    verify(userActivityUpdateService).removeSubscription(userId, interestId);
+  }
+
+  @Test
+  @DisplayName("댓글 생성 이벤트를 수신하면 활동 문서에 댓글 내역을 추가한다")
+  void handle_CommentCreatedEvent() {
+    // given
+    UUID userId = UUID.randomUUID();
+    CommentItem item = new CommentItem(
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        "기사 제목",
+        userId,
+        "tester",
+        "댓글 내용",
+        0L,
+        Instant.now()
+    );
+    CommentCreatedEvent event = new CommentCreatedEvent(userId, item);
+
+    // when
+    userActivityEventListener.handle(event);
+
+    // then
+    verify(userActivityUpdateService).addComment(userId, item);
+  }
+
+  @Test
+  @DisplayName("댓글 수정 이벤트를 수신하면 활동 문서의 댓글 내역을 갱신한다")
+  void handle_CommentUpdatedEvent() {
+    // given
+    UUID userId = UUID.randomUUID();
+    CommentItem item = new CommentItem(
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        "기사 제목",
+        userId,
+        "tester",
+        "수정된 댓글",
+        1L,
+        Instant.now()
+    );
+    CommentUpdatedEvent event = new CommentUpdatedEvent(userId, item);
+
+    // when
+    userActivityEventListener.handle(event);
+
+    // then
+    verify(userActivityUpdateService).updateComment(userId, item);
+  }
+
+  @Test
+  @DisplayName("댓글 삭제 이벤트를 수신하면 활동 문서에서 댓글 내역을 제거한다")
+  void handle_CommentDeletedEvent() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID commentId = UUID.randomUUID();
+    CommentDeletedEvent event = new CommentDeletedEvent(userId, commentId);
+
+    // when
+    userActivityEventListener.handle(event);
+
+    // then
+    verify(userActivityUpdateService).removeComment(userId, commentId);
+  }
+
+  @Test
+  @DisplayName("댓글 좋아요 이벤트를 수신하면 활동 문서에 좋아요 내역을 추가한다")
+  void handle_CommentLikedEvent() {
+    // given
+    UUID userId = UUID.randomUUID();
+    CommentLikeItem item = new CommentLikeItem(
+        UUID.randomUUID(),
+        Instant.now(),
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        "기사 제목",
+        UUID.randomUUID(),
+        "commentWriter",
+        "댓글 내용",
+        3L,
+        Instant.now()
+    );
+    CommentLikedEvent event = new CommentLikedEvent(userId, item);
+
+    // when
+    userActivityEventListener.handle(event);
+
+    // then
+    verify(userActivityUpdateService).addCommentLike(userId, item);
+  }
+
+  @Test
+  @DisplayName("댓글 좋아요 취소 이벤트를 수신하면 활동 문서에서 좋아요 내역을 제거한다")
+  void handle_CommentUnlikedEvent() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID commentId = UUID.randomUUID();
+    CommentUnlikedEvent event = new CommentUnlikedEvent(userId, commentId);
+
+    // when
+    userActivityEventListener.handle(event);
+
+    // then
+    verify(userActivityUpdateService).removeCommentLike(userId, commentId);
+  }
+
+  @Test
+  @DisplayName("댓글 좋아요 수 갱신 이벤트를 수신하면 활동 문서의 좋아요 수를 갱신한다")
+  void handle_CommentLikeCountUpdatedEvent() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID commentId = UUID.randomUUID();
+    long likeCount = 5L;
+    CommentLikeCountUpdatedEvent event = new CommentLikeCountUpdatedEvent(userId, commentId, likeCount);
+
+    // when
+    userActivityEventListener.handle(event);
+
+    // then
+    verify(userActivityUpdateService).updateCommentLikeCount(userId, commentId, likeCount);
+  }
+
+  @Test
+  @DisplayName("기사 조회 이벤트를 수신하면 활동 문서에 기사 조회 내역을 추가한다")
+  void handle_ArticleViewedEvent() {
+    // given
+    UUID userId = UUID.randomUUID();
+    ArticleViewItem item = new ArticleViewItem(
+        UUID.randomUUID(),
+        userId,
+        Instant.now(),
+        UUID.randomUUID(),
+        ArticleSource.NAVER,
+        "https://example.com",
+        "기사 제목",
+        Instant.now(),
+        "기사 요약",
+        2L,
+        10L
+    );
+    ArticleViewedEvent event = new ArticleViewedEvent(userId, item);
+
+    // when
+    userActivityEventListener.handle(event);
+
+    // then
+    verify(userActivityUpdateService).addArticleView(userId, item);
+  }
+}

--- a/src/test/java/com/springboot/monew/users/service/UserActivityUpdateServiceTest.java
+++ b/src/test/java/com/springboot/monew/users/service/UserActivityUpdateServiceTest.java
@@ -1,0 +1,538 @@
+package com.springboot.monew.users.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.springboot.monew.users.document.UserActivityDocument;
+import com.springboot.monew.users.document.UserActivityDocument.ArticleViewItem;
+import com.springboot.monew.users.document.UserActivityDocument.CommentItem;
+import com.springboot.monew.users.document.UserActivityDocument.CommentLikeItem;
+import com.springboot.monew.users.document.UserActivityDocument.SubscriptionItem;
+import com.springboot.monew.users.entity.User;
+import com.springboot.monew.users.exception.UserErrorCode;
+import com.springboot.monew.users.exception.UserException;
+import com.springboot.monew.users.repository.UserActivityRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class UserActivityUpdateServiceTest {
+
+  @Mock
+  private UserActivityRepository userActivityRepository;
+
+  @InjectMocks
+  private UserActivityUpdateService userActivityUpdateService;
+
+  @Test
+  @DisplayName("회원가입 시 사용자 활동 문서를 생성한다")
+  void createdUserActivity_SavesNewDocument() {
+    // given
+    UUID userId = UUID.randomUUID();
+    User user = new User("test@example.com", "tester", "password");
+
+    // when
+    userActivityUpdateService.createUserActivity(user);
+
+    // then
+    // 저장된 UserActivityDocument를 가져와 회원가입한 사용자의 기본 정보로 생성되었는지 검증한다.
+    ArgumentCaptor<UserActivityDocument> captor =
+        ArgumentCaptor.forClass(UserActivityDocument.class);
+
+    verify(userActivityRepository).save(captor.capture());
+
+    assertThat(captor.getValue().getId()).isEqualTo(user.getId());
+    assertThat(captor.getValue().getEmail()).isEqualTo(user.getEmail());
+    assertThat(captor.getValue().getNickname()).isEqualTo(user.getNickname());
+    assertThat(captor.getValue().getCreatedAt()).isEqualTo(user.getCreatedAt());
+  }
+
+  @Test
+  @DisplayName("닉네임 수정 시 사용자 활동 문서의 닉네임을 갱신한다")
+  void updateUserNickname_UpdatesNicknameAndSavesDocument() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UserActivityDocument document = new UserActivityDocument(
+        userId,
+        "test@example.com",
+        "oldNickname",
+        Instant.now()
+    );
+
+    given(userActivityRepository.findById(userId)).willReturn(Optional.of(document));
+
+    // when
+    userActivityUpdateService.updateUserNickname(userId, "newNickname");
+
+    // then
+    // 활동 문서의 닉네임이 새 값으로 실제 변경되었는지 검증한다.
+    assertThat(document.getNickname()).isEqualTo("newNickname");
+    verify(userActivityRepository).save(document);
+  }
+
+  @Test
+  @DisplayName("관심사 수정 시 해당 관심사를 구독 중인 활동 문서들의 키워드를 갱신한다")
+  void updateSubscriptionInterest_UpdatesKeywordsAndSavesAllDocuments() {
+    // given
+    UUID interestId = UUID.randomUUID();
+    UUID anotherInterestId = UUID.randomUUID();
+
+    UserActivityDocument document1 = new UserActivityDocument(
+        UUID.randomUUID(),
+        "user1@example.com",
+        "tester1",
+        Instant.now()
+    );
+    UserActivityDocument document2 = new UserActivityDocument(
+        UUID.randomUUID(),
+        "user2@example.com",
+        "tester2",
+        Instant.now()
+    );
+
+    // 두 활동 문서 모두 수정 대상 관심사를 구독하고 있는 상황을 준비한다.
+    SubscriptionItem targetItem1 = new SubscriptionItem(
+        UUID.randomUUID(),
+        interestId,
+        "금융",
+        List.of("주식"),
+        Instant.now()
+    );
+    SubscriptionItem targetItem2 = new SubscriptionItem(
+        UUID.randomUUID(),
+        interestId,
+        "금융",
+        List.of("주식"),
+        Instant.now()
+    );
+
+    // 수정 대상이 아닌 다른 관심사 구독 내역은 변경되지 않아야 하므로 함께 추가해 둔다.
+    SubscriptionItem otherItem1 = new SubscriptionItem(
+        UUID.randomUUID(),
+        anotherInterestId,
+        "부동산",
+        List.of("청약"),
+        Instant.now()
+    );
+    SubscriptionItem otherItem2 = new SubscriptionItem(
+        UUID.randomUUID(),
+        anotherInterestId,
+        "부동산",
+        List.of("청약"),
+        Instant.now()
+    );
+    document1.addSubscription(targetItem1);
+    document1.addSubscription(otherItem1);
+
+    document2.addSubscription(targetItem2);
+    document2.addSubscription(otherItem2);
+
+    given(userActivityRepository.findAllBySubscriptionsInterestId(interestId))
+        .willReturn(List.of(document1, document2));
+
+    // when
+    userActivityUpdateService.updateSubscriptionInterest(interestId, List.of("주식", "채권"));
+
+    // then
+    // 두 활동 문서 모두에서 수정 대상 관심사의 키워드가 최신 값으로 갱신되었는지 검증한다.
+    assertThat(document1.getSubscriptions().stream()
+        .filter(subscription -> subscription.interestId().equals(interestId))
+        .findFirst()
+        .orElseThrow()
+        .interestKeywords()).containsExactly("주식", "채권");
+
+    assertThat(document2.getSubscriptions().stream()
+        .filter(subscription -> subscription.interestId().equals(interestId))
+        .findFirst()
+        .orElseThrow()
+        .interestKeywords()).containsExactly("주식", "채권");
+
+    // 수정 대상이 아닌 다른 관심사 구독 내역은 그대로 유지되는지 검증한다.
+    assertThat(document1.getSubscriptions().stream()
+        .filter(subscription -> subscription.interestId().equals(anotherInterestId))
+        .findFirst()
+        .orElseThrow()
+        .interestKeywords()).containsExactly("청약");
+
+    assertThat(document2.getSubscriptions().stream()
+        .filter(subscription -> subscription.interestId().equals(anotherInterestId))
+        .findFirst()
+        .orElseThrow()
+        .interestKeywords()).containsExactly("청약");
+
+    verify(userActivityRepository).saveAll(List.of(document1, document2));
+  }
+
+  @Test
+  @DisplayName("관심사 구독 시 활동 문서에 구독 내역을 추가한다")
+  void addSubscription_AddsItemAndSavesDocument() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID interestId = UUID.randomUUID();
+    UserActivityDocument document = new UserActivityDocument(
+        userId,
+        "test@example.com",
+        "tester",
+        Instant.now()
+    );
+
+    SubscriptionItem item = new SubscriptionItem(
+        UUID.randomUUID(),
+        interestId,
+        "금융",
+        List.of("주식", "채권"),
+        Instant.now()
+    );
+
+    given(userActivityRepository.findById(userId)).willReturn(Optional.of(document));
+
+    // when
+    userActivityUpdateService.addSubscription(userId, item);
+
+    // then
+    verify(userActivityRepository).save(document);
+  }
+
+  @Test
+  @DisplayName("관심사 구독 취소 시 활동 문서에서 구독 내역을 제거한다")
+  void removeSubscription_RemovesItemAndSavesDocument() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID interestId = UUID.randomUUID();
+    UserActivityDocument document = new UserActivityDocument(
+        userId,
+        "test@example.com",
+        "tester",
+        Instant.now()
+    );
+
+    // 제거 대상 구독 내역을 미리 활동 문서에 추가해 둔다.
+    SubscriptionItem item = new SubscriptionItem(
+        UUID.randomUUID(),
+        interestId,
+        "금융",
+        List.of("주식", "채권"),
+        Instant.now()
+    );
+    document.addSubscription(item);
+
+    given(userActivityRepository.findById(userId)).willReturn(Optional.of(document));
+
+    // when
+    userActivityUpdateService.removeSubscription(userId, interestId);
+
+    // then
+    // 해당 관심사 구독 내역이 활동 문서에서 실제로 제거되었는지 검증한다.
+    assertThat(document.getSubscriptions()).isEmpty();
+    verify(userActivityRepository).save(document);
+  }
+
+  @Test
+  @DisplayName("댓글 생성 시 활동 문서에 댓글 내역을 추가한다")
+  void addComment_AddsItemAndSavesDocument() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UserActivityDocument document = new UserActivityDocument(
+        userId,
+        "test@example.com",
+        "tester",
+        Instant.now()
+    );
+
+    CommentItem item = new CommentItem(
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        "기사 제목",
+        userId,
+        "tester",
+        "댓글 내용",
+        0L,
+        Instant.now()
+    );
+
+    given(userActivityRepository.findById(userId)).willReturn(Optional.of(document));
+
+    // when
+    userActivityUpdateService.addComment(userId, item);
+
+    // then
+    verify(userActivityRepository).save(document);
+  }
+
+  @Test
+  @DisplayName("댓글 수정 시 활동 문서의 댓글 내역을 갱신한다")
+  void updateComment_UpdatesItemAndSavesDocument() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UserActivityDocument document = new UserActivityDocument(
+        userId,
+        "test@example.com",
+        "tester",
+        Instant.now()
+    );
+
+    CommentItem item = new CommentItem(
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        "기사 제목",
+        userId,
+        "tester",
+        "수정된 댓글",
+        1L,
+        Instant.now()
+    );
+
+    given(userActivityRepository.findById(userId)).willReturn(Optional.of(document));
+
+    // when
+    userActivityUpdateService.updateComment(userId, item);
+
+    // then
+    verify(userActivityRepository).save(document);
+  }
+
+  @Test
+  @DisplayName("댓글 삭제 시 활동 문서에서 댓글 내역을 제거한다")
+  void removeComment_RemovesItemAndSavesDocument() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID commentId = UUID.randomUUID();
+    UserActivityDocument document = new UserActivityDocument(
+        userId,
+        "test@example.com",
+        "tester",
+        Instant.now()
+    );
+
+    // 제거 대상 댓글 내역을 미리 활동 문서에 추가해 둔다.
+    CommentItem item = new CommentItem(
+        commentId,
+        UUID.randomUUID(),
+        "기사 제목",
+        userId,
+        "tester",
+        "댓글 내용",
+        0L,
+        Instant.now()
+    );
+    document.addComment(item);
+
+    given(userActivityRepository.findById(userId)).willReturn(Optional.of(document));
+
+    // when
+    userActivityUpdateService.removeComment(userId, commentId);
+
+    // then
+    // 해당 댓글 내역이 활동 문서에서 실제로 제거되었는지 검증한다.
+    assertThat(document.getComments()).isEmpty();
+    verify(userActivityRepository).save(document);
+  }
+
+  @Test
+  @DisplayName("댓글 좋아요 시 활동 문서에 좋아요 내역을 추가한다")
+  void addCommentLike_AddsItemAndSavesDocument() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UserActivityDocument document = new UserActivityDocument(
+        userId,
+        "test@example.com",
+        "tester",
+        Instant.now()
+    );
+
+    CommentLikeItem item = new CommentLikeItem(
+        UUID.randomUUID(),
+        Instant.now(),
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        "기사 제목",
+        UUID.randomUUID(),
+        "commentWriter",
+        "댓글 내용",
+        3L,
+        Instant.now()
+    );
+
+    given(userActivityRepository.findById(userId)).willReturn(Optional.of(document));
+
+    // when
+    userActivityUpdateService.addCommentLike(userId, item);
+
+    // then
+    verify(userActivityRepository).save(document);
+  }
+
+  @Test
+  @DisplayName("댓글 좋아요 취소 시 활동 문서에서 좋아요 내역을 제거한다")
+  void removeCommentLike_RemovesItemAndSavesDocument() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID targetCommentId = UUID.randomUUID();
+    UUID otherCommentId = UUID.randomUUID();
+
+    UserActivityDocument document = new UserActivityDocument(
+        userId,
+        "test@example.com",
+        "tester",
+        Instant.now()
+    );
+
+    // 좋아요 내역의 id와 commentId는 다른 값이므로, commentId 기준으로 삭제되는지 확인할 수 있게 준비한다.
+    CommentLikeItem targetItem = new CommentLikeItem(
+        UUID.randomUUID(),
+        Instant.now(),
+        targetCommentId,
+        UUID.randomUUID(),
+        "기사 제목1",
+        UUID.randomUUID(),
+        "commentWriter1",
+        "댓글 내용1",
+        3L,
+        Instant.now()
+    );
+
+    // 삭제 대상이 아닌 다른 좋아요 내역도 함께 추가해 두고 유지되는지 확인한다.
+    CommentLikeItem otherItem = new CommentLikeItem(
+        UUID.randomUUID(),
+        Instant.now(),
+        otherCommentId,
+        UUID.randomUUID(),
+        "기사 제목2",
+        UUID.randomUUID(),
+        "commentWriter2",
+        "댓글 내용2",
+        2L,
+        Instant.now()
+    );
+    // 삭제 대상 좋아요 내역과 비교 대상 좋아요 내역을 활동 문서에 미리 추가해 둔다.
+    document.addCommentLike(targetItem);
+    document.addCommentLike(otherItem);
+
+    given(userActivityRepository.findById(userId)).willReturn(Optional.of(document));
+
+    // when
+    userActivityUpdateService.removeCommentLike(userId, targetCommentId);
+
+    // then
+    // 좋아요 내역이 commentLike id가 아니라 commentId 기준으로 실제 제거되었는지 검증한다.
+    assertThat(document.getCommentLikes()).hasSize(1);
+    assertThat(document.getCommentLikes().get(0).commentId()).isEqualTo(otherCommentId);
+
+    verify(userActivityRepository).save(document);
+  }
+
+  @Test
+  @DisplayName("댓글 좋아요 수 갱신 시 활동 문서의 댓글 좋아요 수를 갱신한다")
+  void updateCommentLikeCount_UpdatesLikeCountAndSavesDocument() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID commentId = UUID.randomUUID();
+    UserActivityDocument document = new UserActivityDocument(
+        userId,
+        "test@example.com",
+        "tester",
+        Instant.now()
+    );
+
+    // 좋아요 수 변경 대상 댓글을 미리 활동 문서에 추가해 둔다.
+    CommentItem item = new CommentItem(
+        commentId,
+        UUID.randomUUID(),
+        "기사 제목",
+        userId,
+        "tester",
+        "댓글 내용",
+        0L,
+        Instant.now()
+    );
+    document.addComment(item);
+
+    given(userActivityRepository.findById(userId)).willReturn(Optional.of(document));
+
+    // when
+    userActivityUpdateService.updateCommentLikeCount(userId, commentId, 5L);
+
+    // then
+    // 해당 댓글의 좋아요 수가 새 값으로 실제 갱신되었는지 검증한다.
+    assertThat(document.getComments()).hasSize(1);
+    assertThat(document.getComments().get(0).likeCount()).isEqualTo(5L);
+    verify(userActivityRepository).save(document);
+  }
+
+  @Test
+  @DisplayName("기사 조회 시 활동 문서에 기사 조회 내역을 추가한다")
+  void addArticleView_AddsItemAndSavesDocument() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UserActivityDocument document = new UserActivityDocument(
+        userId,
+        "test@example.com",
+        "tester",
+        Instant.now()
+    );
+
+    ArticleViewItem item = new ArticleViewItem(
+        UUID.randomUUID(),
+        userId,
+        Instant.now(),
+        UUID.randomUUID(),
+        null,
+        "https://example.com",
+        "기사 제목",
+        Instant.now(),
+        "기사 요약",
+        2L,
+        10L
+    );
+
+    given(userActivityRepository.findById(userId)).willReturn(Optional.of(document));
+
+    // when
+    userActivityUpdateService.addArticleView(userId, item);
+
+    // then
+    verify(userActivityRepository).save(document);
+  }
+
+  @Test
+  @DisplayName("활동 문서가 존재하지 않으면 USER_NOT_FOUND 예외가 발생한다")
+  void getDocument_ThrowsException_WhenDocumentNotFound() {
+    // given
+    UUID userId = UUID.randomUUID();
+    CommentItem item = new CommentItem(
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        "기사 제목",
+        userId,
+        "tester",
+        "댓글 내용",
+        0L,
+        Instant.now()
+    );
+
+    given(userActivityRepository.findById(userId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> userActivityUpdateService.addComment(userId, item))
+        .isInstanceOf(UserException.class)
+        .satisfies(throwable -> {
+          UserException exception = (UserException) throwable;
+          assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
+          assertThat(exception.getDetails()).isEqualTo(Map.of("userId", userId));
+        });
+
+    verify(userActivityRepository).findById(userId);
+  }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -22,7 +22,7 @@ spring:
     open-in-view: false
   data:
     mongodb:
-      uri: mongodb://localhost:27017/monew-test
+      uri: mongodb://localhost:27017/monew-test?replicaSet=rs0
   batch:
     jdbc:
       initialize-schema: always


### PR DESCRIPTION
## 해당 이슈카드

Closes #95 #116 #118

## 작업 내용

- 사용자 활동 기능 관련 단위 테스트를 보강했습니다.
- 관심사 수정 시 활동 이벤트 발행 테스트를 추가했습니다.
- 기사 조회 시 활동 이벤트 발행 테스트를 추가했습니다.
- 사용자 활동 이벤트 리스너 테스트를 추가했습니다.
- 사용자 활동 문서 갱신 서비스 테스트를 추가했습니다.
- 사용자 활동 문서 규칙 테스트를 추가했습니다.
- MongoDB 다건 갱신 원자성 보완을 위해 `MongoTransactionManager`를 적용했습니다.
- JPA 기본 트랜잭션 매니저와 Mongo 트랜잭션 매니저가 함께 동작하도록 설정을 분리했습니다.

## 변경 사항

- `InterestServiceTest`에 `InterestUpdatedEvent` 발행 검증을 추가했습니다.
- `NewsArticleServiceTest`에 `ArticleViewedEvent` 발행 검증을 추가했습니다.
- `UserActivityEventListenerTest`를 추가하여 이벤트 위임 동작을 검증했습니다.
- `UserActivityUpdateServiceTest`를 추가하여 활동 문서 조회, 갱신, 저장 동작을 검증했습니다.
- `UserActivityDocumentTest`를 추가하여 최근 10개 유지, 중복 이동, 대상만 갱신/삭제되는 규칙을 검증했습니다.
- Mongo replica set 환경에서 트랜잭션을 사용할 수 있도록 설정을 추가했습니다.
- JPA 기본 `transactionManager`를 명시적으로 등록하고 `@Primary`를 지정하여 기존 JPA 서비스와 Mongo 트랜잭션 매니저가 공존하도록 조정했습니다.
- Mongo 다건 갱신 메서드에만 `@Transactional("mongoTransactionManager")`를 적용했습니다.

## 반영 브랜치
`feature/#95/user-activity-test` -> `dev`

## 기타 참고 사항

### 로컬 Mongo replica set 실행 방법

로컬 MongoDB는 `docker-compose up -d` 실행 시 replica set 모드로 함께 초기화되도록 구성했습니다.

최초 실행 또는 기존 볼륨을 초기화해야 하는 경우에는 아래 순서로 진행하면 됩니다.

1. `docker-compose down -v`
2. `docker-compose up -d`

위 과정을 거치면 Mongo 컨테이너가 replica set 멤버 1개짜리 로컬 환경으로 자동 초기화됩니다.

정상 초기화 여부는 아래 명령으로 확인할 수 있습니다.

`docker exec -it monew-mongo mongosh --eval "rs.status()"`

출력 결과에 `set: 'rs0'`, `stateStr: 'PRIMARY'`, `ok: 1`이 보이면 정상입니다.

참고로 `docker-compose down`만 실행한 경우에는 기존 볼륨이 유지되므로 보통 별도 초기화 없이 다시 `docker-composeup -d`만 실행하면 됩니다.
반면 `docker-compose down -v`를 실행했거나 볼륨이 초기화된 경우에는 replica set도 새로 구성되므로 초기화 과정을 다시 거쳐야 합니다.

### 후속 작업

- 사용자 활동 전체 이벤트 흐름에 대한 통합 테스트 작성이 남아 있습니다.
- 서비스 레벨 로그 추가 작업이 남아 있습니다.
- Atlas 배포 작업이 남아 있습니다.
- AWS 배포 전에 MongoDB부터 빨리 해놔야 될 것 같아서 통합 테스트보다 Atlas 배포를 먼저 진행할 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * MongoDB 데이터베이스 버전 업그레이드 및 레플리카 세트 구성 개선

* **Refactor**
  * 트랜잭션 관리 강화로 데이터 무결성 및 일관성 개선
  * 설정 파일 업데이트

* **Tests**
  * 이벤트 발행 및 사용자 활동 추적 검증 테스트 대폭 추가
  * 각 서비스 계층의 동작 검증 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->