### PR TITLE
[Refactor] UserActivityService와 UserActivityUpdateService 로그 보강

### DIFF
--- a/src/main/java/com/springboot/monew/users/service/UserActivityService.java
+++ b/src/main/java/com/springboot/monew/users/service/UserActivityService.java
@@ -26,12 +26,16 @@ public class UserActivityService {
 
   public UserActivityDto findUserActivity(UUID userId) {
     User user = userRepository.findById(userId)
-        .orElseThrow(() -> new UserException(
-            UserErrorCode.USER_NOT_FOUND,
-            Map.of("userId", userId)
-        ));
+        .orElseThrow(() -> {
+          log.warn("사용자 활동 조회 실패: 사용자를 찾을 수 없음 - userId={}", userId);
+          return new UserException(
+              UserErrorCode.USER_NOT_FOUND,
+              Map.of("userId", userId)
+          );
+        });
 
     if (user.isDeleted()) {
+      log.warn("사용자 활동 조회 실패: 삭제된 사용자 - userId={}", userId);
       throw new UserException(
           UserErrorCode.USER_NOT_FOUND,
           Map.of("userId", userId)
@@ -41,6 +45,9 @@ public class UserActivityService {
     // MongoDB에 활동 내역 문서가 없으면 빈 배열이 들어간 응답 Dto를 반환하도록 설정
     return userActivityRepository.findById(userId)
         .map(userActivityMapper::toDto)
-        .orElseGet(() -> userActivityMapper.toEmptyDto(user));
+        .orElseGet(() -> {
+          log.info("사용자 활동 문서 없음: 빈 활동 응답 반환 - userId={}", userId);
+          return userActivityMapper.toEmptyDto(user);
+        });
   }
 }

--- a/src/main/java/com/springboot/monew/users/service/UserActivityUpdateService.java
+++ b/src/main/java/com/springboot/monew/users/service/UserActivityUpdateService.java
@@ -43,7 +43,7 @@ public class UserActivityUpdateService {
     UserActivityDocument document = getDocument(userId);
     document.updateNickname(nickname);
     userActivityRepository.save(document);
-    log.info("사용자 활동 닉네임 갱신 완료 - userId={}, nickname={}", userId, nickname);
+    log.info("사용자 활동 닉네임 갱신 완료 - userId={}", userId);
   }
 
   // 관심사 키워드가 변경되면 해당 관심사를 구독 중인 사용자들의 활동 내역 구독 정보를 갱신한다.

--- a/src/main/java/com/springboot/monew/users/service/UserActivityUpdateService.java
+++ b/src/main/java/com/springboot/monew/users/service/UserActivityUpdateService.java
@@ -13,10 +13,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 @Transactional
 public class UserActivityUpdateService {
@@ -33,6 +35,7 @@ public class UserActivityUpdateService {
     );
 
     userActivityRepository.save(document);
+    log.info("사용자 활동 문서 생성 완료 - userId={}", user.getId());
   }
 
   // 사용자 닉네임이 변경되면 활동 내역 문서의 사용자 기본 정보도 갱신한다.
@@ -40,6 +43,7 @@ public class UserActivityUpdateService {
     UserActivityDocument document = getDocument(userId);
     document.updateNickname(nickname);
     userActivityRepository.save(document);
+    log.info("사용자 활동 닉네임 갱신 완료 - userId={}, nickname={}", userId, nickname);
   }
 
   // 관심사 키워드가 변경되면 해당 관심사를 구독 중인 사용자들의 활동 내역 구독 정보를 갱신한다.
@@ -53,6 +57,7 @@ public class UserActivityUpdateService {
     );
 
     userActivityRepository.saveAll(documents);
+    log.info("사용자 활동 관심사 키워드 일괄 갱신 완료 - interestId={}, documentCount={}", interestId, documents.size());
   }
 
 
@@ -61,6 +66,7 @@ public class UserActivityUpdateService {
     UserActivityDocument document = getDocument(userId);
     document.addSubscription(item);
     userActivityRepository.save(document);
+    log.info("사용자 활동 구독 추가 완료 - userId={}, interestId={}", userId, item.interestId());
   }
 
   // 관심사 구독 취소 시 사용자 활동 문서에서 구독 내역을 제거한다.
@@ -68,6 +74,7 @@ public class UserActivityUpdateService {
     UserActivityDocument document = getDocument(userId);
     document.removeSubscription(interestId);
     userActivityRepository.save(document);
+    log.info("사용자 활동 구독 제거 완료 - userId={}, interestId={}", userId, interestId);
   }
 
   // 댓글 작성 시 사용자 활동 문서에 댓글 내역을 추가한다.
@@ -75,6 +82,7 @@ public class UserActivityUpdateService {
     UserActivityDocument document = getDocument(userId);
     document.addComment(item);
     userActivityRepository.save(document);
+    log.info("사용자 활동 댓글 추가 완료 - userId={}, commentId={}", userId, item.id());
   }
 
   // 댓글 수정 시 사용자 활동 문서의 댓글 내역을 갱신한다.
@@ -82,6 +90,7 @@ public class UserActivityUpdateService {
     UserActivityDocument document = getDocument(userId);
     document.updateComment(item);
     userActivityRepository.save(document);
+    log.info("사용자 활동 댓글 수정 완료 - userId={}, commentId={}", userId, item.id());
   }
 
   // 댓글 삭제 시 사용자 활동 문서에서 댓글 내역을 제거한다.
@@ -89,6 +98,7 @@ public class UserActivityUpdateService {
     UserActivityDocument document = getDocument(userId);
     document.removeComment(commentId);
     userActivityRepository.save(document);
+    log.info("사용자 활동 댓글 제거 완료 - userId={}, commentId={}", userId, commentId);
   }
 
   // 댓글 좋아요 시 사용자 활동 문서에 좋아요 내역을 추가한다.
@@ -96,6 +106,7 @@ public class UserActivityUpdateService {
     UserActivityDocument document = getDocument(userId);
     document.addCommentLike(item);
     userActivityRepository.save(document);
+    log.info("사용자 활동 댓글 좋아요 추가 완료 - userId={}, commentId={}", userId, item.commentId());
   }
 
   // 댓글 좋아요 취소 시 사용자 활동 문서에서 좋아요 내역을 제거한다.
@@ -103,6 +114,7 @@ public class UserActivityUpdateService {
     UserActivityDocument document = getDocument(userId);
     document.removeCommentLike(commentId);
     userActivityRepository.save(document);
+    log.info("사용자 활동 댓글 좋아요 제거 완료 - userId={}, commentId={}", userId, commentId);
   }
 
   // 댓글 좋아요 수 변경 시 사용자 활동 문서의 댓글 좋아요 수를 갱신한다.
@@ -110,6 +122,7 @@ public class UserActivityUpdateService {
     UserActivityDocument document = getDocument(userId);
     document.updateCommentLikeCount(commentId, likeCount);
     userActivityRepository.save(document);
+    log.info("사용자 활동 댓글 좋아요 수 갱신 완료 - userId={}, commentId={}, likeCount={}", userId, commentId, likeCount);
   }
 
   // 기사 조회 시 사용자 활동 문서에 기사 조회 내역을 추가한다.
@@ -117,15 +130,19 @@ public class UserActivityUpdateService {
     UserActivityDocument document = getDocument(userId);
     document.addArticleView(item);
     userActivityRepository.save(document);
+    log.info("사용자 활동 기사 조회 추가 완료 - userId={}, articleId={}", userId, item.articleId());
   }
 
   // 사용자 활동 내역 문서를 조회한다. 없으면 회원가입 시 문서 생성이 누락된 상태로 보고 예외를 던진다.
   private UserActivityDocument getDocument(UUID userId) {
     return userActivityRepository.findById(userId)
-        .orElseThrow(() -> new UserException(
-            UserErrorCode.USER_NOT_FOUND,
-            Map.of("userId", userId)
-        ));
+        .orElseThrow(() -> {
+          log.warn("사용자 활동 문서 조회 실패: 문서를 찾을 수 없음 - userId={}", userId);
+          return new UserException(
+              UserErrorCode.USER_NOT_FOUND,
+              Map.of("userId", userId)
+          );
+        });
   }
 
 }

--- a/src/main/java/com/springboot/monew/users/service/UserService.java
+++ b/src/main/java/com/springboot/monew/users/service/UserService.java
@@ -115,7 +115,7 @@ public class UserService {
     applicationEventPublisher.publishEvent(
         new UserNicknameUpdatedEvent(user.getId(), user.getNickname())
     );
-    log.info("닉네임 수정 완료 - userId={}, nickname={}", user.getId(), user.getNickname());
+    log.info("닉네임 수정 완료 - userId={}", user.getId());
     return userMapper.toDto(user);
   }
 


### PR DESCRIPTION
## 📌 해당 이슈카드

 Closes #289

## 📌 작업 내용

- 사용자 활동 조회 서비스와 활동 문서 갱신 서비스에 로그를 추가했습니다.
- 기존 `UserService`의 로그 스타일을 기준으로 로그 레벨과 메시지 형식을 맞췄습니다.
- 사용자 활동 조회 실패, 활동 문서 미존재 fallback, 활동 문서 갱신 완료 흐름을 추적할 수 있도록 보강했습니다.

## 🔧 변경 사항

- `UserActivityService`
  - 사용자 미존재 시 `warn` 로그를 추가했습니다.
  - 삭제된 사용자 조회 시 `warn` 로그를 추가했습니다.
  - 활동 문서가 없어 빈 DTO를 반환하는 fallback 구간에 `info` 로그를 추가했습니다.

- `UserActivityUpdateService`
  - 활동 문서 조회 실패 시 `warn` 로그를 추가했습니다.
  - 활동 문서 생성, 닉네임 갱신, 관심사 키워드 일괄 갱신, 구독 추가/제거, 댓글 추가/수정/삭제, 댓글 좋아요 추가/제거, 댓글 좋아요 수 갱신, 기사 조회 내역 추가 완료 시 `info` 로그를 추가했습니다.
  - 서비스 성공/실패 흐름에서 `userId`, `interestId`, `commentId`, `articleId`, `likeCount`, `documentCount` 등 추적에 필요한 식별자가 로그에 남도록 정리했습니다.

## 반영 브랜치
`feature/#289/user-activity-log` -> `dev`

## 💬 기타 참고 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 사용자 활동 조회 및 업데이트 프로세스에 대한 내부 로깅 기능을 강화했습니다.
  * 시스템 모니터링 및 문제 진단을 위한 상세한 로그 기록이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->