### PR TITLE
[Refactor] UserRepository 삭제 사용자 조회를 QueryDSL로 전환 및 테스트 코드 작성

### DIFF
--- a/src/main/java/com/springboot/monew/users/repository/UserRepository.java
+++ b/src/main/java/com/springboot/monew/users/repository/UserRepository.java
@@ -1,29 +1,16 @@
 package com.springboot.monew.users.repository;
 
 import com.springboot.monew.users.entity.User;
-import java.time.Instant;
-import java.util.List;
+import com.springboot.monew.users.repository.qdsl.UserQDSLRepository;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-public interface UserRepository extends JpaRepository<User, UUID> {
+public interface UserRepository extends JpaRepository<User, UUID>, UserQDSLRepository {
 
   boolean existsByEmail(String email);
 
   boolean existsByNickname(String nickname);
 
   Optional<User> findByEmail(String email);
-
-  // 논리 삭제된 user들 중에서 현재 시간에서 24시간을 뺀 시간인, cutoff보다 더 과거에 deletedAt이 찍힌 user들을 조회
-  @Query("""
-          select  u
-          from User u
-          where u.deletedAt is not null
-            and u.deletedAt <= :cutoff
-      """)
-  List<User> findUsersDeletedBefore(@Param("cutoff") Instant cutoff);
-
 }

--- a/src/main/java/com/springboot/monew/users/repository/qdsl/UserQDSLRepository.java
+++ b/src/main/java/com/springboot/monew/users/repository/qdsl/UserQDSLRepository.java
@@ -1,0 +1,10 @@
+package com.springboot.monew.users.repository.qdsl;
+
+import com.springboot.monew.users.entity.User;
+import java.time.Instant;
+import java.util.List;
+
+public interface UserQDSLRepository {
+
+  List<User> findUsersDeletedBefore(Instant cutoff);
+}

--- a/src/main/java/com/springboot/monew/users/repository/qdsl/UserQDSLRepositoryImpl.java
+++ b/src/main/java/com/springboot/monew/users/repository/qdsl/UserQDSLRepositoryImpl.java
@@ -1,0 +1,29 @@
+package com.springboot.monew.users.repository.qdsl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.springboot.monew.users.entity.QUser;
+import com.springboot.monew.users.entity.User;
+import java.time.Instant;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class UserQDSLRepositoryImpl implements UserQDSLRepository {
+
+  private final JPAQueryFactory queryFactory;
+  private final QUser qUser = QUser.user;
+
+  @Override
+  public List<User> findUsersDeletedBefore(Instant cutoff) {
+    return queryFactory
+        .selectFrom(qUser)
+        .where(
+            // 삭제 시간이 존재하는 사용자 중 cutoff 이전(또는 같은 시각)에 삭제된 사용자만 조회한다.
+            qUser.deletedAt.isNotNull(),
+            qUser.deletedAt.loe(cutoff)
+        )
+        .fetch();
+  }
+}

--- a/src/main/java/com/springboot/monew/users/repository/qdsl/UserQDSLRepositoryImpl.java
+++ b/src/main/java/com/springboot/monew/users/repository/qdsl/UserQDSLRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.springboot.monew.users.entity.QUser;
 import com.springboot.monew.users.entity.User;
 import java.time.Instant;
 import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -17,6 +18,8 @@ public class UserQDSLRepositoryImpl implements UserQDSLRepository {
 
   @Override
   public List<User> findUsersDeletedBefore(Instant cutoff) {
+    Objects.requireNonNull(cutoff, "cutoff는 null일 수 없습니다.");
+
     return queryFactory
         .selectFrom(qUser)
         .where(

--- a/src/test/java/com/springboot/monew/users/repository/UserRepositoryTest.java
+++ b/src/test/java/com/springboot/monew/users/repository/UserRepositoryTest.java
@@ -1,0 +1,76 @@
+package com.springboot.monew.users.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.springboot.monew.common.repository.BaseRepositoryTest;
+import com.springboot.monew.users.entity.User;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class UserRepositoryTest extends BaseRepositoryTest {
+
+  @Autowired
+  private UserRepository userRepository;
+
+  @Test
+  @DisplayName("cutoff 이전에 삭제된 사용자만 조회한다")
+  void findUsersDeletedBefore_ReturnsUsersDeletedBeforeCutoff() {
+    // given
+    Instant cutoff = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+
+    User target = saveUser("target@test.com", "target");
+    User excludedAfter = saveUser("after@test.com", "after");
+
+    setDeletedAt(target.getId(), cutoff.minus(1, ChronoUnit.DAYS));
+    setDeletedAt(excludedAfter.getId(), cutoff.plus(1, ChronoUnit.HOURS));
+    flushAndClear();
+
+    // when
+    List<User> result = userRepository.findUsersDeletedBefore(cutoff);
+
+    // then
+    assertThat(result).hasSize(1);
+    assertThat(result).extracting(User::getEmail)
+        .containsExactly("target@test.com");
+  }
+
+  @Test
+  @DisplayName("삭제 시각이 cutoff와 같아도 조회한다")
+  void findUsersDeletedBefore_ReturnsUsersWhenDeletedAtEqualsCutoff() {
+    // given
+    Instant cutoff = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+
+    User target = saveUser("equal@test.com", "equal");
+    setDeletedAt(target.getId(), cutoff);
+    flushAndClear();
+
+    // when
+    List<User> result = userRepository.findUsersDeletedBefore(cutoff);
+
+    // then
+    assertThat(result).extracting(User::getEmail)
+        .containsExactly("equal@test.com");
+  }
+
+  private User saveUser(String email, String nickname) {
+    // 테스트에서 사용할 사용자를 생성하고 즉시 DB에 반영한다.
+    User user = new User(email, nickname, "password");
+    em.persist(user);
+    em.flush();
+    return user;
+  }
+
+  private void setDeletedAt(UUID userId, Instant deletedAt) {
+    // 삭제 시점을 원하는 값으로 맞추기 위해 deleted_at 컬럼을 DB에서 직접 갱신한다.
+    em.createNativeQuery("UPDATE users SET deleted_at = :deletedAt WHERE id = :id")
+        .setParameter("deletedAt", deletedAt)
+        .setParameter("id", userId)
+        .executeUpdate();
+  }
+
+}


### PR DESCRIPTION
## 📌 해당 이슈카드

Closes #294

## 📌 작업 내용
- `UserRepository` 에서 사용하던 삭제 사용자 조회 JPQL을 제거했습니다.
- 삭제 사용자 조회 로직을 QueryDSL 기반 커스텀 레포지토리로 분리했습니다.
- `findUsersDeletedBefore(Instant cutoff)` 동작을 검증하는 레포지토리 테스트를 추가했습니다.

## 🔧 변경 사항
- `UserRepository` 가 `UserQDSLRepository` 를 확장하도록 변경했습니다.
- `@Query` 기반의 `findUsersDeletedBefore` 메서드를 제거했습니다.
- `UserQDSLRepository`, `UserQDSLRepositoryImpl` 를 추가해 아래 조건으로 조회하도록 구현했습니다.
  - `deletedAt` 이 `null` 이 아닌 사용자
  - `deletedAt <= cutoff` 인 사용자
- 테스트 코드 추가
  - cutoff 이전에 삭제된 사용자만 조회되는지 검증
  - 삭제 시각이 cutoff 와 동일한 경우도 포함되는지 검증

## 반영 브랜치
`feature/#294/user-activity-qdsl` -> `dev`

## 💬 기타 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 사용자 데이터 삭제 조회 기능의 내부 구현이 개선되었습니다. 이를 통해 쿼리 처리 방식이 최적화되었습니다.
  * 특정 시점 이전 삭제 사용자 조회 시 경계값 처리가 더욱 정확해졌습니다.
  * 해당 기능의 정확성을 검증하는 자동화 테스트가 추가되어 안정성이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->