### PR TITLE
[Refactor] User 관련 DTO와 item 필드의 primitive 타입을 wrapper 타입으로 변경

### DIFF
--- a/src/main/java/com/springboot/monew/newsarticles/mapper/NewsArticleViewMapper.java
+++ b/src/main/java/com/springboot/monew/newsarticles/mapper/NewsArticleViewMapper.java
@@ -30,5 +30,5 @@ public interface NewsArticleViewMapper {
   @Mapping(target = "articleSummary", source = "articleView.newsArticle.summary")
   @Mapping(target = "articleCommentCount", source = "commentCount")
   @Mapping(target = "articleViewCount", source = "articleView.newsArticle.viewCount")
-  ArticleViewItem toArticleViewItem(ArticleView articleView, long commentCount);
+  ArticleViewItem toArticleViewItem(ArticleView articleView, Long commentCount);
 }

--- a/src/main/java/com/springboot/monew/users/document/UserActivityDocument.java
+++ b/src/main/java/com/springboot/monew/users/document/UserActivityDocument.java
@@ -123,7 +123,7 @@ public class UserActivityDocument {
   }
 
   // 내 댓글이 좋아요/좋아요 취소를 받았을 때 comments 안의 likeCount를 갱신한다.
-  public void updateCommentLikeCount(UUID commentId, long likeCount) {
+  public void updateCommentLikeCount(UUID commentId, Long likeCount) {
     comments.replaceAll(comment -> {
       if (!comment.id().equals(commentId)) {
         return comment;
@@ -177,7 +177,7 @@ public class UserActivityDocument {
       UUID userId,
       String userNickname,
       String content,
-      long likeCount,
+      Long likeCount,
       Instant createdAt
   ) {
 
@@ -192,7 +192,7 @@ public class UserActivityDocument {
       UUID commentUserId,
       String commentUserNickname,
       String commentContent,
-      long commentLikeCount,
+      Long commentLikeCount,
       Instant commentCreatedAt
   ) {
 
@@ -208,8 +208,8 @@ public class UserActivityDocument {
       String articleTitle,
       Instant articlePublishedDate,
       String articleSummary,
-      long articleCommentCount,
-      long articleViewCount
+      Long articleCommentCount,
+      Long articleViewCount
   ) {
 
   }

--- a/src/main/java/com/springboot/monew/users/dto/response/CommentActivityDto.java
+++ b/src/main/java/com/springboot/monew/users/dto/response/CommentActivityDto.java
@@ -24,7 +24,7 @@ public record CommentActivityDto(
     String content,
 
     @Schema(description = "좋아요 수")
-    long likeCount,
+    Long likeCount,
 
     @Schema(description = "작성된 날짜", format = "date-time")
     Instant createdAt

--- a/src/main/java/com/springboot/monew/users/dto/response/CommentLikeActivityDto.java
+++ b/src/main/java/com/springboot/monew/users/dto/response/CommentLikeActivityDto.java
@@ -30,7 +30,7 @@ public record CommentLikeActivityDto(
     String commentContent,
 
     @Schema(description = "좋아요 수")
-    long commentLikeCount,
+    Long commentLikeCount,
 
     @Schema(description = "작성된 날짜", format = "date-time")
     Instant commentCreatedAt

--- a/src/main/java/com/springboot/monew/users/event/comment/CommentLikeCountUpdatedEvent.java
+++ b/src/main/java/com/springboot/monew/users/event/comment/CommentLikeCountUpdatedEvent.java
@@ -5,7 +5,7 @@ import java.util.UUID;
 public record CommentLikeCountUpdatedEvent(
     UUID userId,
     UUID commentId,
-    long likeCount
+    Long likeCount
 ) {
 
 }

--- a/src/main/java/com/springboot/monew/users/service/UserActivityUpdateService.java
+++ b/src/main/java/com/springboot/monew/users/service/UserActivityUpdateService.java
@@ -118,7 +118,7 @@ public class UserActivityUpdateService {
   }
 
   // 댓글 좋아요 수 변경 시 사용자 활동 문서의 댓글 좋아요 수를 갱신한다.
-  public void updateCommentLikeCount(UUID userId, UUID commentId, long likeCount) {
+  public void updateCommentLikeCount(UUID userId, UUID commentId, Long likeCount) {
     UserActivityDocument document = getDocument(userId);
     document.updateCommentLikeCount(commentId, likeCount);
     userActivityRepository.save(document);

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -39,3 +39,11 @@ naver:
   api:
     key: "test-secret-key-for-build-pass"
     secret: "test-secret-key-for-build-pass"
+
+cloud:
+  aws:
+    s3:
+      region: ap-northeast-2
+      access-key: test-access-key
+      secret-key: test-secret-key
+      bucket: test-bucket


### PR DESCRIPTION
## 해당 이슈카드

Closes #297

## 작업 내용

- User 관련 응답 DTO와 활동 문서 item 객체에서 primitive 타입 필드를 wrapper 타입으로 변경했습니다.
- wrapper 타입 변경에 맞춰 사용자 활동 갱신 서비스 및 이벤트 전달 타입을 함께 정리했습니다.
- 관련 매퍼 및 테스트 코드에서 변경된 타입을 반영하도록 수정했습니다.

## 변경 사항

- `CommentActivityDto`, `CommentLikeActivityDto`의 카운트 필드를 `long` -> `Long`으로 변경
- `UserActivityDocument` 내부 `CommentItem`, `CommentLikeItem`, `ArticleViewItem`의 카운트 필드를 wrapper 타입으로 변경
- `CommentLikeCountUpdatedEvent`, `UserActivityUpdateService.updateCommentLikeCount(...)` 시그니처를 wrapper 타입 기준으로 정리
- User Activity 관련 매핑 변경된 타입을 반영
- null 허용 가능성이 있는 응답/문서 필드에 대해 primitive 대신 wrapper 타입을 사용하도록 일관성 정리

## 반영 브랜치

`feature/#297/user-activity-wrapper` -> `dev`

## 기타 참고 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 댓글 수 및 게시글 수 필드를 null 가능한 타입으로 변경하여 데이터 처리의 유연성을 개선했습니다.

* **작업**
  * 테스트 환경의 AWS S3 설정을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->