### PR TITLE
[Fix] ECS 배포 시 로그 디렉토리 미존재로 인한 애플리케이션 실행 실패 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,11 @@ RUN useradd --create-home --uid 10001 appuser
 #실행 작업 디렉토리
 WORKDIR /app
 
+# 로그 디렉토리 생성 + appuser에게 권한 부여
+RUN mkdir -p /app/.logs \
+    && chown -R appuser:appuser /app
+
+
 # JVM 실행 옵션 (기본값: 빈 문자열)
 ENV JAVA_TOOL_OPTIONS=""
 


### PR DESCRIPTION
## 📌 작업 내용
- ECS 배포 시 컨테이너가 즉시 종료되는 문제 해결
- Logback에서 파일 로그 생성 시 `/app/.logs` 디렉토리 미존재로 인해 애플리케이션 시작 실패 발생
- Dockerfile runtime 단계에서 로그 디렉토리 사전 생성 및 권한 설정 추가

## 🔧 변경 사항
- Dockerfile 수정
  - `/app/.logs` 디렉토리 생성
  - non-root 사용자(appuser)가 접근 가능하도록 권한 부여

```dockerfile
RUN mkdir -p /app/.logs \
    && chown -R appuser:appuser /app```

## 반영 브랜치
`feature/#313/deploy` -> `dev`

## 💬 기타 참고 사항
- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 로그 디렉토리 설정이 개선되었습니다.
  * 애플리케이션 디렉토리의 파일 권한 설정이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->