### PR TITLE
[Test] 댓글 통합 테스트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,11 @@ dependencies {
     testImplementation('org.instancio:instancio-core')
     testImplementation('org.instancio:instancio-junit')
     testImplementation 'net.datafaker:datafaker:2.5.4'
+    // 통합 테스트: 운영 환경과 유사한 환경 구축을 위해 컨테이너를 사용
+    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'org.testcontainers:postgresql'
+    testImplementation 'org.testcontainers:mongodb'
 
     //aws
     implementation 'software.amazon.awssdk:s3:2.31.7'

--- a/src/test/java/com/springboot/monew/comment/integration/CommentIntegrationTest.java
+++ b/src/test/java/com/springboot/monew/comment/integration/CommentIntegrationTest.java
@@ -1,0 +1,200 @@
+package com.springboot.monew.comment.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.springboot.monew.comment.dto.CommentDto;
+import com.springboot.monew.comment.dto.CommentRegisterRequest;
+import com.springboot.monew.comment.dto.CommentUpdateRequest;
+import com.springboot.monew.comment.entity.Comment;
+import com.springboot.monew.comment.repository.CommentRepository;
+import com.springboot.monew.common.exception.ErrorResponse;
+import com.springboot.monew.common.integration.BaseIntegrationsTest;
+import com.springboot.monew.newsarticles.entity.NewsArticle;
+import com.springboot.monew.newsarticles.enums.ArticleSource;
+import com.springboot.monew.newsarticles.repository.NewsArticleRepository;
+import com.springboot.monew.user.document.UserActivityDocument;
+import com.springboot.monew.user.entity.User;
+import com.springboot.monew.user.repository.UserActivityRepository;
+import com.springboot.monew.user.repository.UserRepository;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+public class CommentIntegrationTest extends BaseIntegrationsTest {
+
+  @Autowired
+  private TestRestTemplate restTemplate;
+
+  @Autowired
+  private CommentRepository commentRepository;
+
+  @Autowired
+  private UserRepository userRepository;
+
+  @Autowired
+  private NewsArticleRepository newsArticleRepository;
+
+  @Autowired
+  private UserActivityRepository userActivityRepository;
+
+  private User user;
+  private NewsArticle article;
+
+  @BeforeEach
+  void setUp() {
+    commentRepository.deleteAll();
+    newsArticleRepository.deleteAll();
+    userActivityRepository.deleteAll();
+    userRepository.deleteAll();
+
+    // 테스트용 유저 및 뉴스기사 생성
+    user = userRepository.save(new User("test@test.com", "tester", "password1234!"));
+    // 사용자 활동내역 문서도 미리 생성
+    userActivityRepository.save(
+        new UserActivityDocument(user.getId(), user.getEmail(), user.getNickname(), Instant.now()));
+    article = newsArticleRepository.save(NewsArticle.builder()
+        .source(ArticleSource.NAVER)
+        .originalLink("https://test.com/article/1")
+        .title("테스트 뉴스")
+        .publishedAt(Instant.now())
+        .summary("테스트 요약")
+        .build());
+  }
+
+  @Test
+  @DisplayName("댓글 등록 시 201 상태코드와 생성된 댓글 정보를 반환한다")
+  void createComment_Returns201_WhenValidRequest() {
+    // given
+    CommentRegisterRequest request = new CommentRegisterRequest(
+        article.getId(), user.getId(), "테스트 댓글입니다.");
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    HttpEntity<CommentRegisterRequest> entity = new HttpEntity<>(request, headers);
+
+    // when, restTemplate으로 실제 요청을 보냄
+    ResponseEntity<CommentDto> response = restTemplate.postForEntity(
+        "/api/comments", entity, CommentDto.class);
+
+    // then
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    assertThat(response.getBody()).isNotNull();
+    assertThat(response.getBody().content()).isEqualTo("테스트 댓글입니다.");
+    assertThat(response.getBody().articleId()).isEqualTo(article.getId());
+    assertThat(response.getBody().userId()).isEqualTo(user.getId());
+  }
+
+  @Test
+  @DisplayName("댓글 수정 시 200 상태코드와 수정된 댓글 정보를 반환한다")
+  void updateComment_Returns200_WhenValidRequest() {
+    // given
+    // 수정 대상 댓글 사전 생성
+    Comment comment = commentRepository.save(new Comment(user, article, "원본 댓글"));
+    CommentUpdateRequest request = new CommentUpdateRequest("수정된 댓글입니다.");
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    headers.set("Monew-Request-User-ID", user.getId().toString());
+    HttpEntity<CommentUpdateRequest> entity = new HttpEntity<>(request, headers);
+
+    // when
+    ResponseEntity<CommentDto> response = restTemplate.exchange(
+        "/api/comments/" + comment.getId(),
+        HttpMethod.PATCH, entity, CommentDto.class);
+
+    // then
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isNotNull();
+    assertThat(response.getBody().userId()).isEqualTo(user.getId());
+    assertThat(response.getBody().articleId()).isEqualTo(article.getId());
+    assertThat(response.getBody().content()).isEqualTo("수정된 댓글입니다.");
+  }
+
+  @Test
+  @DisplayName("댓글 논리 삭제 시 204 상태코드를 반환하고 isDeleted가 true가 된다")
+  void softDeleteComment_Returns204_WhenValidRequest() {
+    // given
+    Comment comment = commentRepository.save(new Comment(user, article, "삭제할 댓글"));
+
+    // when
+    ResponseEntity<Void> response = restTemplate.exchange(
+        "/api/comments/" + comment.getId(),
+        HttpMethod.DELETE, HttpEntity.EMPTY, Void.class);
+
+    // then
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+    // DB에서 실제로 논리 삭제되었는지 검증
+    Comment deleted = commentRepository.findById(comment.getId()).orElseThrow();
+    assertThat(deleted.isDeleted()).isTrue();
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 댓글 수정 시 404 상태코드를 반환한다")
+  void updateComment_Returns404_WhenCommentNotFound() {
+    // given
+    UUID nonExistId = UUID.randomUUID();
+    CommentUpdateRequest request = new CommentUpdateRequest("수정 시도");
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    headers.set("Monew-Request-User-ID", user.getId().toString());
+    HttpEntity<CommentUpdateRequest> entity = new HttpEntity<>(request, headers);
+
+    // when
+    ResponseEntity<ErrorResponse> response = restTemplate.exchange(
+        "/api/comments/" + nonExistId,
+        HttpMethod.PATCH, entity, ErrorResponse.class);
+
+    // then
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    assertThat(response.getBody()).isNotNull();
+    assertThat(response.getBody().getCode()).isEqualTo("CM01");
+    assertThat(response.getBody().getMessage()).isEqualTo("댓글을 찾을 수 없습니다.");
+  }
+
+  @Test
+  @DisplayName("댓글 등록 시 사용자 활동 내역에 댓글이 추가된다")
+  void createComment_AddsCommentToUserActivity_WhenValidRequest() {
+    // given
+    CommentRegisterRequest request = new CommentRegisterRequest(
+        article.getId(), user.getId(), "활동 내역 테스트 댓글");
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    HttpEntity<CommentRegisterRequest> entity = new HttpEntity<>(request, headers);
+
+    // when
+    // 실제 HTTP 요청으로 댓글 생성 → 서비스 내부에서 CommentCreatedEvent 발행
+    restTemplate.postForEntity("/api/comments", entity, CommentDto.class);
+
+    // then
+    // @TransactionalEventListener(AFTER_COMMIT)으로 처리되므로 트랜잭션 커밋 이후 MongoDB에 반영 ?
+    UserActivityDocument activity = userActivityRepository.findById(user.getId()).orElseThrow();
+    assertThat(activity.getComments()).hasSize(1);
+    assertThat(activity.getComments().get(0).content()).isEqualTo("활동 내역 테스트 댓글");
+    assertThat(activity.getComments().get(0).articleId()).isEqualTo(article.getId());
+  }
+
+  @Test
+  @DisplayName("댓글 물리 삭제 시 204 상태코드를 반환하고 DB에서 완전히 삭제된다")
+  void hardDeleteComment_Returns204_WhenValidRequest() {
+    // given
+    Comment comment = commentRepository.save(new Comment(user, article, "물리 삭제할 댓글"));
+
+    // when
+    ResponseEntity<Void> response = restTemplate.exchange(
+        "/api/comments/" + comment.getId() + "/hard",
+        HttpMethod.DELETE, HttpEntity.EMPTY, Void.class);
+
+    // then
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+    // DB에서 사라졌는지 검증
+    assertThat(commentRepository.findById(comment.getId())).isEmpty();
+  }
+}

--- a/src/test/java/com/springboot/monew/comment/integration/CommentLikeIntegrationTest.java
+++ b/src/test/java/com/springboot/monew/comment/integration/CommentLikeIntegrationTest.java
@@ -1,0 +1,136 @@
+package com.springboot.monew.comment.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.springboot.monew.comment.dto.CommentLikeDto;
+import com.springboot.monew.comment.entity.Comment;
+import com.springboot.monew.comment.repository.CommentLikeRepository;
+import com.springboot.monew.comment.repository.CommentRepository;
+import com.springboot.monew.common.integration.BaseIntegrationsTest;
+import com.springboot.monew.newsarticles.entity.NewsArticle;
+import com.springboot.monew.newsarticles.enums.ArticleSource;
+import com.springboot.monew.newsarticles.repository.NewsArticleRepository;
+import com.springboot.monew.notification.repository.NotificationRepository;
+import com.springboot.monew.user.entity.User;
+import com.springboot.monew.user.repository.UserRepository;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+public class CommentLikeIntegrationTest extends BaseIntegrationsTest {
+
+  @Autowired
+  private TestRestTemplate restTemplate;
+
+  @Autowired
+  private NotificationRepository notificationRepository;
+
+  @Autowired
+  private CommentRepository commentRepository;
+
+  @Autowired
+  private CommentLikeRepository commentLikeRepository;
+
+  @Autowired
+  private UserRepository userRepository;
+
+  @Autowired
+  private NewsArticleRepository newsArticleRepository;
+
+  private User user;
+  private Comment comment;
+
+  @BeforeEach
+  void setUp() {
+    notificationRepository.deleteAll();
+    commentLikeRepository.deleteAll();
+    commentRepository.deleteAll();
+    newsArticleRepository.deleteAll();
+    userRepository.deleteAll();
+
+    // 테스트용 유저, 뉴스기사, 댓글 생성
+    user = userRepository.save(new User("test@test.com", "tester", "password1234!"));
+    NewsArticle article = newsArticleRepository.save(NewsArticle.builder()
+        .source(ArticleSource.NAVER)
+        .originalLink("https://test.com/article/1")
+        .title("테스트 뉴스")
+        .publishedAt(Instant.now())
+        .summary("테스트 요약")
+        .build());
+    comment = commentRepository.save(new Comment(user, article, "좋아요 테스트 댓글"));
+  }
+
+  @Test
+  @DisplayName("댓글 좋아요 시 201 상태코드와 좋아요 정보를 반환한다")
+  void likeComment_Returns201_WhenValidRequest() {
+    // given
+    HttpHeaders headers = new HttpHeaders();
+    headers.set("Monew-Request-User-ID", user.getId().toString());
+    HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+    // when
+    ResponseEntity<CommentLikeDto> response = restTemplate.exchange(
+        "/api/comments/" + comment.getId() + "/comment-likes",
+        HttpMethod.POST, entity, CommentLikeDto.class);
+
+    // then
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    assertThat(response.getBody()).isNotNull();
+    assertThat(response.getBody().commentId()).isEqualTo(comment.getId());
+    assertThat(response.getBody().likeBy()).isEqualTo(user.getId());
+    assertThat(response.getBody().commentLikeCount()).isEqualTo(1L);
+  }
+
+  @Test
+  @DisplayName("댓글 좋아요 취소 시 200 상태코드를 반환하고 좋아요가 삭제된다")
+  void unlikeComment_Returns200_WhenLikeExists() {
+    // given
+    // 사전에 좋아요 등록
+    HttpHeaders headers = new HttpHeaders();
+    headers.set("Monew-Request-User-ID", user.getId().toString());
+    HttpEntity<Void> entity = new HttpEntity<>(headers);
+    restTemplate.exchange(
+        "/api/comments/" + comment.getId() + "/comment-likes",
+        HttpMethod.POST, entity, CommentLikeDto.class);
+
+    // when
+    ResponseEntity<Void> response = restTemplate.exchange(
+        "/api/comments/" + comment.getId() + "/comment-likes",
+        HttpMethod.DELETE, entity, Void.class);
+
+    // then
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    // DB에서 좋아요 레코드가 삭제되었는지 검증
+    assertThat(commentLikeRepository.findAll()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("이미 좋아요한 댓글에 다시 좋아요 시 409 상태코드를 반환한다")
+  void likeComment_Returns409_WhenAlreadyLiked() {
+    // given
+    // 첫 번째 좋아요
+    HttpHeaders headers = new HttpHeaders();
+    headers.set("Monew-Request-User-ID", user.getId().toString());
+    HttpEntity<Void> entity = new HttpEntity<>(headers);
+    restTemplate.exchange(
+        "/api/comments/" + comment.getId() + "/comment-likes",
+        HttpMethod.POST, entity, CommentLikeDto.class);
+
+    // when
+    // 두 번째 좋아요 시도
+    ResponseEntity<Void> response = restTemplate.exchange(
+        "/api/comments/" + comment.getId() + "/comment-likes",
+        HttpMethod.POST, entity, Void.class);
+
+    // then
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+  }
+}

--- a/src/test/java/com/springboot/monew/common/integration/BaseIntegrationsTest.java
+++ b/src/test/java/com/springboot/monew/common/integration/BaseIntegrationsTest.java
@@ -1,0 +1,44 @@
+package com.springboot.monew.common.integration;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.junit.jupiter.Container;
+
+// 모든 통합 테스트의 공통 설정
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@Testcontainers // @Container 어노테이션을 인식하고 컨테이너 생명주기를 관리
+public abstract class BaseIntegrationsTest {
+
+  // 클래스 단위 공유
+  // Spring은 컨텍스트 캐싱을 해서, 컨테이너를 재사용하기도 한다네요
+  @Container
+  static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16");
+
+  @Container
+  static MongoDBContainer mongo = new MongoDBContainer("mongo:8.0");
+
+  // 컨테이너가 기동된 후 실제 할당된 URL/포트를 Spring 컨텍스트에 동적으로 주입
+  @DynamicPropertySource
+  static void overrideProperties(DynamicPropertyRegistry registry) {
+    // test.yml의 H2 URL → 컨테이너 실제 PostgreSQL URL로 교체
+    registry.add("spring.datasource.url", postgres::getJdbcUrl);
+    registry.add("spring.datasource.username", postgres::getUsername);
+    registry.add("spring.datasource.password", postgres::getPassword);
+    // test.yml의 H2 드라이버 → PostgreSQL 드라이버로 교체
+    registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+    // test.yml의 H2Dialect → PostgreSQLDialect로 교체
+    registry.add("spring.jpa.properties.hibernate.dialect",
+        () -> "org.hibernate.dialect.PostgreSQLDialect");
+    // PostgreSQL은 비임베디드 DB라 기본값이 never → always로 강제해서 schema.sql 실행
+    registry.add("spring.sql.init.mode", () -> "always");
+    // schema.sql로 테이블 생성 후 Hibernate가 엔티티와 스키마 일치 여부만 검증
+    registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+    // test.yml의 고정 MongoDB URI → 컨테이너 실제 URI로 교체
+    registry.add("spring.data.mongodb.uri", mongo::getReplicaSetUrl);
+  }
+}

--- a/src/test/java/com/springboot/monew/common/integration/BaseIntegrationsTest.java
+++ b/src/test/java/com/springboot/monew/common/integration/BaseIntegrationsTest.java
@@ -6,21 +6,20 @@ import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.junit.jupiter.Container;
 
 // 모든 통합 테스트의 공통 설정
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-@Testcontainers // @Container 어노테이션을 인식하고 컨테이너 생명주기를 관리
 public abstract class BaseIntegrationsTest {
 
-  // 클래스 단위 공유
-  // Spring은 컨텍스트 캐싱을 해서, 컨테이너를 재사용하기도 한다네요
-  @Container
-  static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16");
+  // @Testcontainers + @Container 대신 static 블록으로 수동 기동
+  // → 컨테이너가 JVM당 딱 한 번만 시작되어 Spring 컨텍스트 캐싱과 충돌하지 않음
+  static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16");
+  static final MongoDBContainer mongo = new MongoDBContainer("mongo:8.0");
 
-  @Container
-  static MongoDBContainer mongo = new MongoDBContainer("mongo:8.0");
+  static {
+    postgres.start();
+    mongo.start();
+  }
 
   // 컨테이너가 기동된 후 실제 할당된 URL/포트를 Spring 컨텍스트에 동적으로 주입
   @DynamicPropertySource


### PR DESCRIPTION
## 📌 작업 내용
- 댓글(Comment) 및 댓글 좋아요(CommentLike) API 통합 테스트 작성

## 🔧 변경 사항
  - BaseIntegrationsTest 추가: Testcontainers(PostgreSQL, MongoDB) 기반 통합 테스트 공통 설정
  - CommentIntegrationTest 추가: 댓글 등록/수정/논리삭제/물리삭제/사용자 활동 반영 검증 (6케이스)
  - CommentLikeIntegrationTest 추가: 좋아요 등록/취소/중복 좋아요 검증 (3케이스)
  - BaseIntegrationsTest 컨테이너 수명 관리 방식 수정: @Testcontainers + @Container → static 블록
  수동 기동으로 변경 (Spring 컨텍스트 캐싱과 컨테이너 수명 충돌 수정)

## 반영 브랜치
`feature/` -> `dev`

## 💬 기타 참고 사항
- 여러 통합 테스트 클래스를 순차 실행 시 이전 클래스 종료 후 컨테이너가 내려가는데, Spring이 이전 컨텍스트를 캐싱해 재사용하면서 DB 연결 실패가 발생하는 문제를 수정함


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * 컨테이너화된 PostgreSQL/MongoDB 기반 통합 테스트 인프라 추가
  * 댓글 API에 대한 통합 테스트 추가(생성, 수정, 소프트 삭제, 하드 삭제, 존재하지 않는 댓글 처리, 사용자 활동 반영 검증)
  * 댓글 좋아요 기능에 대한 통합 테스트 추가(좋아요 등록/취소, 중복 좋아요 충돌 처리)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->