### PR TITLE
[Test]NewsArticle Service 테스트커버리지 올림

### DIFF
--- a/src/test/java/com/springboot/monew/newsarticles/service/NaverNewsApiClientTest.java
+++ b/src/test/java/com/springboot/monew/newsarticles/service/NaverNewsApiClientTest.java
@@ -1,0 +1,178 @@
+package com.springboot.monew.newsarticles.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+import com.springboot.monew.newsarticles.dto.NaverNewsItem;
+import com.springboot.monew.newsarticles.dto.response.NaverNewsResponse;
+import com.springboot.monew.newsarticles.exception.ArticleException;
+import java.util.List;
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+@ExtendWith(MockitoExtension.class)
+class NaverNewsApiClientTest {
+
+  @Mock
+  private RestClient restClient;
+
+  @Mock
+  private RestClient.ResponseSpec responseSpec;
+
+  private NaverNewsApiClient naverNewsApiClient;
+
+  private final String clientId = "test-client-id";
+  private final String clientSecret = "test-client-secret";
+
+  @BeforeEach
+  void setUp() {
+    // @Value로 주입되는 값은 테스트에서 직접 생성자에 넣어준다.
+    naverNewsApiClient = new NaverNewsApiClient(clientId, clientSecret, restClient);
+  }
+
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  @Test
+  @DisplayName("네이버 뉴스 검색 - API 응답이 정상일 경우 기사 목록을 반환한다")
+  void searchNews_ReturnsArticles_WhenApiResponseIsValid() {
+
+    // given
+    // RestClient의 fluent API 체인을 모킹하기 위한 객체들
+    RestClient.RequestHeadersUriSpec uriSpec = mockRequestHeadersUriSpec();
+    RestClient.RequestHeadersSpec headersSpec = mockRequestHeadersSpec();
+
+    NaverNewsItem item = org.mockito.Mockito.mock(NaverNewsItem.class);
+    List<NaverNewsItem> articles = List.of(item);
+
+    NaverNewsResponse response = new NaverNewsResponse(articles);
+
+    // restClient.get() 호출 시 URI 설정 단계 객체를 반환한다.
+    given(restClient.get()).willReturn(uriSpec);
+
+    // uri(...) 호출 후 header 설정 단계 객체를 반환한다.
+    given(uriSpec.uri(any(Function.class))).willReturn(headersSpec);
+
+    // 첫 번째 header 설정 후 같은 headersSpec을 반환하여 다음 header를 이어서 호출할 수 있게 한다.
+    given(headersSpec.header(eq("X-Naver-Client-Id"), eq(clientId)))
+        .willReturn(headersSpec);
+
+    // 두 번째 header 설정 후 같은 headersSpec을 반환한다.
+    given(headersSpec.header(eq("X-Naver-Client-Secret"), eq(clientSecret)))
+        .willReturn(headersSpec);
+
+    // retrieve() 호출 시 응답 처리 객체를 반환한다.
+    given(headersSpec.retrieve()).willReturn(responseSpec);
+
+    // body(...) 호출 시 네이버 API 응답 DTO를 반환한다.
+    given(responseSpec.body(NaverNewsResponse.class)).willReturn(response);
+
+    // when
+    List<NaverNewsItem> result = naverNewsApiClient.searchNews("AI");
+
+    // then
+    // API 응답에 들어있던 기사 목록이 그대로 반환되어야 한다.
+    assertThat(result).hasSize(1);
+    assertThat(result).isEqualTo(articles);
+  }
+
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  @Test
+  @DisplayName("네이버 뉴스 검색 - API 응답이 null이면 빈 리스트를 반환한다")
+  void searchNews_ReturnsEmptyList_WhenResponseIsNull() {
+
+    // given
+    RestClient.RequestHeadersUriSpec uriSpec = mockRequestHeadersUriSpec();
+    RestClient.RequestHeadersSpec headersSpec = mockRequestHeadersSpec();
+
+    given(restClient.get()).willReturn(uriSpec);
+    given(uriSpec.uri(any(Function.class))).willReturn(headersSpec);
+    given(headersSpec.header(eq("X-Naver-Client-Id"), eq(clientId)))
+        .willReturn(headersSpec);
+    given(headersSpec.header(eq("X-Naver-Client-Secret"), eq(clientSecret)))
+        .willReturn(headersSpec);
+    given(headersSpec.retrieve()).willReturn(responseSpec);
+
+    // 네이버 API 응답 body가 null인 상황
+    given(responseSpec.body(NaverNewsResponse.class)).willReturn(null);
+
+    // when
+    List<NaverNewsItem> result = naverNewsApiClient.searchNews("AI");
+
+    // then
+    // null 응답은 예외가 아니라 빈 리스트로 처리한다.
+    assertThat(result).isEmpty();
+  }
+
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  @Test
+  @DisplayName("네이버 뉴스 검색 - 응답의 articles가 null이면 빈 리스트를 반환한다")
+  void searchNews_ReturnsEmptyList_WhenArticlesIsNull() {
+
+    // given
+    RestClient.RequestHeadersUriSpec uriSpec = mockRequestHeadersUriSpec();
+    RestClient.RequestHeadersSpec headersSpec = mockRequestHeadersSpec();
+
+    NaverNewsResponse response = new NaverNewsResponse(null);
+
+    given(restClient.get()).willReturn(uriSpec);
+    given(uriSpec.uri(any(Function.class))).willReturn(headersSpec);
+    given(headersSpec.header(eq("X-Naver-Client-Id"), eq(clientId)))
+        .willReturn(headersSpec);
+    given(headersSpec.header(eq("X-Naver-Client-Secret"), eq(clientSecret)))
+        .willReturn(headersSpec);
+    given(headersSpec.retrieve()).willReturn(responseSpec);
+    given(responseSpec.body(NaverNewsResponse.class)).willReturn(response);
+
+    // when
+    List<NaverNewsItem> result = naverNewsApiClient.searchNews("AI");
+
+    // then
+    // articles 필드가 null이어도 빈 리스트로 안전하게 처리한다.
+    assertThat(result).isEmpty();
+  }
+
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  @Test
+  @DisplayName("네이버 뉴스 검색 - RestClientException 발생 시 ArticleException으로 변환한다")
+  void searchNews_ThrowsArticleException_WhenRestClientExceptionOccurs() {
+
+    // given
+    RestClient.RequestHeadersUriSpec uriSpec = mockRequestHeadersUriSpec();
+    RestClient.RequestHeadersSpec headersSpec = mockRequestHeadersSpec();
+
+    given(restClient.get()).willReturn(uriSpec);
+    given(uriSpec.uri(any(Function.class))).willReturn(headersSpec);
+    given(headersSpec.header(eq("X-Naver-Client-Id"), eq(clientId)))
+        .willReturn(headersSpec);
+    given(headersSpec.header(eq("X-Naver-Client-Secret"), eq(clientSecret)))
+        .willReturn(headersSpec);
+
+    // 외부 API 호출 중 RestClientException이 발생하는 상황
+    given(headersSpec.retrieve())
+        .willThrow(new RestClientException("Naver API request failed"));
+
+    // when & then
+    // 외부 API 예외는 ArticleException으로 변환되어야 한다.
+    assertThatThrownBy(() -> naverNewsApiClient.searchNews("AI"))
+        .isInstanceOf(ArticleException.class);
+  }
+
+  @SuppressWarnings("rawtypes")
+  private RestClient.RequestHeadersUriSpec mockRequestHeadersUriSpec() {
+    return org.mockito.Mockito.mock(RestClient.RequestHeadersUriSpec.class);
+  }
+
+  @SuppressWarnings("rawtypes")
+  private RestClient.RequestHeadersSpec mockRequestHeadersSpec() {
+    return org.mockito.Mockito.mock(RestClient.RequestHeadersSpec.class);
+  }
+}

--- a/src/test/java/com/springboot/monew/newsarticles/service/NewsArticleCollectServiceTest.java
+++ b/src/test/java/com/springboot/monew/newsarticles/service/NewsArticleCollectServiceTest.java
@@ -1,0 +1,187 @@
+package com.springboot.monew.newsarticles.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.springboot.monew.interest.dto.response.InterestKeywordInfo;
+import com.springboot.monew.interest.repository.InterestKeywordRepository;
+import com.springboot.monew.newsarticles.dto.CollectedArticleWithInterest;
+import com.springboot.monew.newsarticles.dto.response.CollectedArticle;
+import com.springboot.monew.newsarticles.enums.ArticleSource;
+import com.springboot.monew.newsarticles.metric.result.NewsArticleCollectResult;
+import com.springboot.monew.newsarticles.metric.result.NewsArticleSaveResult;
+import com.springboot.monew.newsarticles.service.collector.ArticleCollector;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class NewsArticleCollectServiceTest {
+
+  @Mock
+  private ArticleCollector collector;
+
+  @Mock
+  private NewsArticleService newsArticleService;
+
+  @Mock
+  private InterestKeywordRepository interestKeywordRepository;
+
+  private NewsArticleCollectService newsArticleCollectService;
+
+  @BeforeEach
+  void setUp() {
+    newsArticleCollectService = new NewsArticleCollectService(
+        List.of(collector),
+        newsArticleService,
+        interestKeywordRepository
+    );
+  }
+
+  @Test
+  @DisplayName("전체 뉴스 수집 - 키워드와 매칭된 기사만 저장한다")
+  void collectAll_SavesOnlyMatchedArticles_WhenArticlesCollected() {
+
+    // given
+    UUID interestId = UUID.randomUUID();
+
+    given(interestKeywordRepository.findAllInterestKeywordInfos())
+        .willReturn(List.of(
+            new InterestKeywordInfo(interestId, "AI")
+        ));
+
+    given(collector.getSource()).willReturn(ArticleSource.NAVER);
+
+    CollectedArticle matchedArticle = new CollectedArticle(
+        ArticleSource.NAVER,
+        "https://news.com/1",
+        "AI 기술 발전",
+        Instant.now(),
+        "인공지능 관련 기사 요약"
+    );
+
+    CollectedArticle unmatchedArticle = new CollectedArticle(
+        ArticleSource.NAVER,
+        "https://news.com/2",
+        "스포츠 뉴스",
+        Instant.now(),
+        "축구 경기 결과"
+    );
+
+    given(collector.collect(List.of("ai")))
+        .willReturn(List.of(matchedArticle, unmatchedArticle));
+
+    given(newsArticleService.saveAll(anyList()))
+        .willReturn(new NewsArticleSaveResult(
+            2, // 요청 기사 수
+            2, // distinct
+            0, // 기존 없음
+            1, // 저장된 기사
+            1  // 관심사 연결
+        ));
+
+    // when
+    NewsArticleCollectResult result = newsArticleCollectService.collectAll();
+
+    // then
+    assertThat(result.keywordCount()).isEqualTo(1);
+    assertThat(result.sourceResults()).hasSize(1);
+
+    ArgumentCaptor<List<CollectedArticleWithInterest>> captor =
+        ArgumentCaptor.forClass(List.class);
+
+    verify(newsArticleService).saveAll(captor.capture());
+
+    List<CollectedArticleWithInterest> savedArticles = captor.getValue();
+
+    // 핵심 검증: 매칭된 기사만 저장됨
+    assertThat(savedArticles).hasSize(1);
+    assertThat(savedArticles.get(0).article()).isEqualTo(matchedArticle);
+    assertThat(savedArticles.get(0).interestIds()).containsExactly(interestId);
+  }
+
+  @Test
+  @DisplayName("전체 뉴스 수집 - 키워드가 없으면 저장 대상 없이 수집을 수행한다")
+  void collectAll_DoesNotSaveMatchedArticles_WhenKeywordIsEmpty() {
+
+    // given
+    // 관심사 키워드가 하나도 없는 상황
+    given(interestKeywordRepository.findAllInterestKeywordInfos())
+        .willReturn(List.of());
+
+    given(collector.getSource()).willReturn(ArticleSource.NAVER);
+
+    // 키워드가 없으므로 collector에는 빈 키워드 리스트가 전달된다.
+    given(collector.collect(List.of()))
+        .willReturn(List.of(
+            new CollectedArticle(
+                ArticleSource.NAVER,
+                "https://news.com/1",
+                "AI 뉴스",
+                Instant.now(),
+                "요약"
+            )
+        ));
+
+    // 키워드가 없어 매칭된 기사가 없으므로 저장 결과는 empty로 처리
+    given(newsArticleService.saveAll(anyList()))
+        .willReturn(NewsArticleSaveResult.empty());
+
+    // when
+    NewsArticleCollectResult result = newsArticleCollectService.collectAll();
+
+    // then
+    assertThat(result.keywordCount()).isEqualTo(0);
+    assertThat(result.sourceResults()).hasSize(1);
+
+    // saveAll에 전달된 저장 대상 목록을 캡처
+    ArgumentCaptor<List<CollectedArticleWithInterest>> captor =
+        ArgumentCaptor.forClass(List.class);
+
+    verify(newsArticleService).saveAll(captor.capture());
+
+    // 키워드가 없으면 어떤 기사도 관심사와 매칭되지 않으므로 빈 리스트가 저장 요청된다.
+    assertThat(captor.getValue()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("전체 뉴스 수집 - collector에서 예외가 발생하면 실패 결과를 반환하고 저장하지 않는다")
+  void collectAll_ReturnsFailureResult_WhenCollectorThrowsException() {
+
+    // given
+    UUID interestId = UUID.randomUUID();
+
+    // 관심사 키워드가 존재하는 상황
+    given(interestKeywordRepository.findAllInterestKeywordInfos())
+        .willReturn(List.of(
+            new InterestKeywordInfo(interestId, "AI")
+        ));
+
+    given(collector.getSource()).willReturn(ArticleSource.NAVER);
+
+    // 외부 수집기 호출 중 예외가 발생하는 상황
+    given(collector.collect(List.of("ai")))
+        .willThrow(new RuntimeException("수집 실패"));
+
+    // when
+    NewsArticleCollectResult result = newsArticleCollectService.collectAll();
+
+    // then
+    assertThat(result.keywordCount()).isEqualTo(1);
+    assertThat(result.sourceResults()).hasSize(1);
+
+    // collector 단계에서 실패했으므로 saveAll은 호출되지 않아야 한다.
+    verify(newsArticleService, never()).saveAll(anyList());
+  }
+
+}

--- a/src/test/java/com/springboot/monew/newsarticles/service/RssClientTest.java
+++ b/src/test/java/com/springboot/monew/newsarticles/service/RssClientTest.java
@@ -1,0 +1,130 @@
+package com.springboot.monew.newsarticles.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import com.springboot.monew.newsarticles.dto.RssItem;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+import org.jsoup.Connection;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.parser.Parser;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+class RssClientTest {
+
+  private final RssClient rssClient = new RssClient();
+
+  @Test
+  @DisplayName("RSS XML 파싱에 성공하면 RssItem 목록을 반환한다")
+  void read_ReturnsRssItems_WhenRssXmlIsValid() throws Exception {
+
+    // given
+    String url = "https://example.com/rss";
+
+    String rssXml = """
+        <rss>
+          <channel>
+            <item>
+              <title>테스트 기사 제목</title>
+              <link>https://example.com/news/1</link>
+              <description>테스트 기사 요약</description>
+              <pubDate>Fri, 17 Apr 2026 11:12:07 +0900</pubDate>
+            </item>
+          </channel>
+        </rss>
+        """;
+
+    Document document = Jsoup.parse(rssXml, "", Parser.xmlParser());
+    Connection connection = mock(Connection.class);
+
+    try (MockedStatic<Jsoup> jsoupMock = mockStatic(Jsoup.class)) {
+
+      // 실제 외부 RSS URL 호출을 막고, Mock Connection을 반환하도록 설정
+      jsoupMock.when(() -> Jsoup.connect(url)).thenReturn(connection);
+
+      // connection.get() 호출 시 미리 만든 XML Document 반환
+      when(connection.get()).thenReturn(document);
+
+      // when
+      List<RssItem> result = rssClient.read(url);
+
+      // then
+      assertThat(result).hasSize(1);
+
+      RssItem item = result.get(0);
+      assertThat(item.title()).isEqualTo("테스트 기사 제목");
+      assertThat(item.link()).isEqualTo("https://example.com/news/1");
+      assertThat(item.description()).isEqualTo("테스트 기사 요약");
+      assertThat(item.publishedAt()).isEqualTo(Instant.parse("2026-04-17T02:12:07Z"));
+    }
+  }
+
+  @Test
+  @DisplayName("description 태그가 없으면 빈 문자열로 반환한다")
+  void read_ReturnsEmptyDescription_WhenDescriptionMissing() throws Exception {
+
+    // given
+    String url = "https://example.com/rss";
+
+    String rssXml = """
+        <rss>
+          <channel>
+            <item>
+              <title>제목</title>
+              <link>https://example.com/news/1</link>
+              <pubDate>Fri, 17 Apr 2026 11:12:07 +0900</pubDate>
+            </item>
+          </channel>
+        </rss>
+        """;
+
+    Document document = Jsoup.parse(rssXml, "", Parser.xmlParser());
+    Connection connection = mock(Connection.class);
+
+    try (MockedStatic<Jsoup> jsoupMock = mockStatic(Jsoup.class)) {
+
+      jsoupMock.when(() -> Jsoup.connect(url)).thenReturn(connection);
+      when(connection.get()).thenReturn(document);
+
+      // when
+      List<RssItem> result = rssClient.read(url);
+
+      // then
+      assertThat(result).hasSize(1);
+      assertThat(result.get(0).description()).isEqualTo("");
+    }
+  }
+
+  @Test
+  @DisplayName("RSS 연결 또는 파싱 중 예외 발생 시 RuntimeException을 던진다")
+  void read_ThrowsRuntimeException_WhenJsoupFails() throws Exception {
+
+    // given
+    String url = "https://example.com/rss";
+
+    Connection connection = mock(Connection.class);
+
+    try (MockedStatic<Jsoup> jsoupMock = mockStatic(Jsoup.class)) {
+
+      jsoupMock.when(() -> Jsoup.connect(url)).thenReturn(connection);
+      when(connection.get()).thenThrow(new IOException("연결 실패"));
+
+      // when & then
+      assertThatThrownBy(() -> rssClient.read(url))
+          .isInstanceOf(RuntimeException.class)
+          .hasMessage("RSS 파싱 실패")
+          .hasCauseInstanceOf(IOException.class);
+    }
+  }
+
+
+}


### PR DESCRIPTION
## 📌 작업 내용
- NaverNewsApiClient 단위 테스트 작성
- 뉴스 기사 수집/외부 연동 관련 Service 계층 단위 테스트 추가
- 

## 🔧 변경 사항
- NaverNewsApiClientTest
- NewsArticleCollectServiceTest
- RssClientTest

## 반영 브랜치
`feature/#331/newsarticle-service-test` -> `dev`

## 💬 기타 참고 사항
- 외부 의존성(API, RSS)은 모두 Mock 처리하여 테스트 실행 시 네트워크 의존성 제거
- 테스트 커버리지 90%
<img width="575" height="226" alt="image" src="https://github.com/user-attachments/assets/cb06901a-2d52-4ba6-aa93-c11134e8d099" />

