### PR TITLE
[Fix] InterestNotificationEvent 단건 발행으로 변경 및 Listener 구조 수정

### DIFF
--- a/src/main/java/com/springboot/monew/newsarticles/service/NewsArticleService.java
+++ b/src/main/java/com/springboot/monew/newsarticles/service/NewsArticleService.java
@@ -182,7 +182,18 @@ public class NewsArticleService {
 
     if (!newArticleInterests.isEmpty()) {
       articleInterestRepository.saveAll(newArticleInterests);
-      eventPublisher.publishEvent(InterestNotificationEvent.from(newArticleInterests));
+
+      List<InterestNotificationEvent> events =
+          InterestNotificationEvent.from(newArticleInterests);
+
+      events.forEach(event -> {
+        log.info("[관심사 알림 이벤트 발행] interestId={}, resourceType={}",
+            event.getInterestId(),
+            event.getResourceType()
+        );
+
+        eventPublisher.publishEvent(event);
+      });
     }
 
     log.info("뉴스기사 저장 완료 - 신규 기사 수: {}, 신규 기사-관심사 연결 수: {}",

--- a/src/main/java/com/springboot/monew/notification/event/listener/NotificationEventListener.java
+++ b/src/main/java/com/springboot/monew/notification/event/listener/NotificationEventListener.java
@@ -20,14 +20,15 @@ public class NotificationEventListener {
 
   @Async("notificationCreationPool")
   @TransactionalEventListener
-  public void handleInterestNotificationCreation(List<InterestNotificationEvent> events) {
-    for (InterestNotificationEvent event : events) {
-      try {
-        notificationService.create(event);
-      } catch (MonewException exception) {
-        log.error("[관심사 알림 생성 실패] interestId: {}, resourceType: {}, message: {}",
-            event.getInterestId(), event.getResourceType(), exception.getDetails());
-      }
+  public void handleInterestNotificationCreation(InterestNotificationEvent event) {
+    try {
+      notificationService.create(event);
+    } catch (MonewException exception) {
+      log.error("[관심사 알림 생성 실패] interestId: {}, resourceType: {}, message: {}",
+          event.getInterestId(),
+          event.getResourceType(),
+          exception.getDetails()
+      );
     }
   }
 

--- a/src/test/java/com/springboot/monew/newsarticles/service/NewsArticleServiceTest.java
+++ b/src/test/java/com/springboot/monew/newsarticles/service/NewsArticleServiceTest.java
@@ -35,6 +35,7 @@ import com.springboot.monew.newsarticles.mapper.NewsArticleViewMapper;
 import com.springboot.monew.newsarticles.repository.ArticleInterestRepository;
 import com.springboot.monew.newsarticles.repository.ArticleViewRepository;
 import com.springboot.monew.newsarticles.repository.NewsArticleRepository;
+import com.springboot.monew.notification.event.InterestNotificationEvent;
 import com.springboot.monew.user.document.UserActivityDocument.ArticleViewItem;
 import com.springboot.monew.user.entity.User;
 import com.springboot.monew.user.event.articleView.ArticleViewedEvent;
@@ -167,7 +168,7 @@ class NewsArticleServiceTest {
     verify(articleInterestRepository).saveAll(anyList());
 
     // 관심사 알림 이벤트가 발행되어야 한다
-    verify(eventPublisher).publishEvent(any(List.class));
+    verify(eventPublisher).publishEvent(any(InterestNotificationEvent.class));
   }
 
   @Test
@@ -291,7 +292,7 @@ class NewsArticleServiceTest {
 
     // 이벤트가 발행되어야 한다
     // List<InterestNotificationEvent> 타입 객체
-    verify(eventPublisher).publishEvent(any(List.class));
+    verify(eventPublisher).publishEvent(any(InterestNotificationEvent.class));
 
   }
 

--- a/src/test/java/com/springboot/monew/newsarticles/service/NewsArticleServiceTest.java
+++ b/src/test/java/com/springboot/monew/newsarticles/service/NewsArticleServiceTest.java
@@ -292,7 +292,7 @@ class NewsArticleServiceTest {
 
     // 이벤트가 발행되어야 한다
     // List<InterestNotificationEvent> 타입 객체
-    verify(eventPublisher).publishEvent(any(InterestNotificationEvent.class));
+    verify(eventPublisher, times(2)).publishEvent(any(InterestNotificationEvent.class));
 
   }
 


### PR DESCRIPTION
## 📌 작업 내용
- InterestNotificationEvent 단건 발행으로 변경 및 Listener 구조 수정

## 🔧 변경 사항
- NewsService
List<InterestNotificationEvent> 일괄 발행 → 단건 이벤트 순차 발행 방식으로 변경
ArticleInterest 저장 이후 이벤트 생성 및 발행하도록 순서 수정
- NotificationEventListener
List<InterestNotificationEvent> 수신 → 단일 InterestNotificationEvent 수신으로 변경
이벤트 단위별 알림 생성 처리로 구조 개선
이벤트 처리 구조 개선
이벤트 단위를 ArticleInterest 1건 = 이벤트 1건으로 정렬
이벤트 발행/수신 타입 불일치로 인한 알림 미생성 문제 해결

## 반영 브랜치
`fix/#335/newsarticleInterest-notification` -> `dev`

## 💬 기타 참고 사항
- 기존에는 List 자체를 이벤트로 발행하여 Spring 이벤트 시스템에서 개별 이벤트로 처리되지 않는 문제가 있었음
@TransactionalEventListener는 발행된 이벤트 타입과 동일한 타입만 수신하므로, 단건 이벤트 발행 구조로 변경하여 정상 동작하도록 수정함


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 알림 이벤트 처리 로직이 최적화되었습니다.
  * 관심사 기반 알림 생성 프로세스가 개선되어 더 효율적으로 작동합니다.
  * 시스템 로깅 및 예외 처리가 강화되어 더 나은 모니터링과 디버깅이 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->