### PR TITLE
[Fix]Swagger List<Enum> Query Parameter 바인딩 오류 해결

### DIFF
--- a/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleApiDocs.java
+++ b/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleApiDocs.java
@@ -181,16 +181,6 @@ public interface NewsArticleApiDocs {
           example = "550e8400-e29b-41d4-a716-446655440000",
           schema = @Schema(type = "string", format = "uuid")
       ),
-//      @Parameter(
-//          name = "sourceIn",
-//          description = """
-//              출처 필터 (선택, 복수 선택 가능)
-//              - `NAVER` : 네이버
-//              - `HANKYUNG` : 한국경제
-//              - `CHOSUN` : 조선일보
-//              - `YEONHAP` : 연합뉴스"""
-//          schema = @Schema(type = "array", allowableValues = {"NAVER", "HANKYUNG", "CHOSUN", "YEONHAP"})
-//      ),
       @Parameter(
           name = "publishDateFrom",
           description = "발행일 범위 시작 (선택, ISO 8601 형식)",
@@ -223,10 +213,31 @@ public interface NewsArticleApiDocs {
       @Parameter(
           name = "cursor",
           description = """
-              이전 페이지의 마지막 커서 값 (첫 페이지 조회 시 생략)
-              - orderBy=`publishDate` 형식: `2024-01-15T10:30:00.000000000Z`
-              - orderBy=`commentCount` / `viewCount` 형식: `100|2024-01-15T10:30:00.000000000Z`""",
-          example = "2024-01-15T10:30:00.000000000Z"
+        이전 페이지의 마지막 커서 값 (첫 페이지 조회 시 생략)
+
+        서버 응답의 `nextCursor` 값을 그대로 전달합니다.
+
+        커서 형식:
+        - publishDate 정렬:
+          `publishDate|createdAt`
+
+        - commentCount / viewCount 정렬:
+          `count|createdAt`
+
+        예시:
+        - publishDate:
+          `2024-01-15T10:30:00.000000000Z|2024-01-15T10:30:04.621481Z`
+
+        - commentCount:
+          `100|2024-01-15T10:30:04.621481Z`
+
+        - viewCount:
+          `1500|2024-01-15T10:30:04.621481Z`
+
+        cursor 내부에 after(createdAt) 값이 포함되어 있으므로
+        별도의 after 파라미터는 사용하지 않습니다.
+        """,
+          example = "2024-01-15T10:30:00.000000000Z|2024-01-15T10:30:04.621481Z"
       ),
       @Parameter(
           name = "after",

--- a/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleApiDocs.java
+++ b/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleApiDocs.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import java.util.List;
 import java.util.UUID;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -180,16 +181,16 @@ public interface NewsArticleApiDocs {
           example = "550e8400-e29b-41d4-a716-446655440000",
           schema = @Schema(type = "string", format = "uuid")
       ),
-      @Parameter(
-          name = "sourceIn",
-          description = """
-              출처 필터 (선택, 복수 선택 가능)
-              - `NAVER` : 네이버
-              - `HANKYUNG` : 한국경제
-              - `CHOSUN` : 조선일보
-              - `YEONHAP` : 연합뉴스""",
-          schema = @Schema(type = "array", allowableValues = {"NAVER", "HANKYUNG", "CHOSUN", "YEONHAP"})
-      ),
+//      @Parameter(
+//          name = "sourceIn",
+//          description = """
+//              출처 필터 (선택, 복수 선택 가능)
+//              - `NAVER` : 네이버
+//              - `HANKYUNG` : 한국경제
+//              - `CHOSUN` : 조선일보
+//              - `YEONHAP` : 연합뉴스"""
+//          schema = @Schema(type = "array", allowableValues = {"NAVER", "HANKYUNG", "CHOSUN", "YEONHAP"})
+//      ),
       @Parameter(
           name = "publishDateFrom",
           description = "발행일 범위 시작 (선택, ISO 8601 형식)",
@@ -331,7 +332,8 @@ public interface NewsArticleApiDocs {
       )
   })
   CursorPageResponseNewsArticleDto list(
-      @Valid NewsArticlePageRequest request,
+      //@ParameterObject: 이 객체를 RequesstBody가 아니라 Query Parameter 묶음으로 해석해라.
+      @Valid @ParameterObject NewsArticlePageRequest request,
       @Parameter(description = "요청자 ID") @RequestHeader("Monew-Request-User-ID") UUID userId
   );
 

--- a/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleController.java
+++ b/src/main/java/com/springboot/monew/newsarticles/controller/NewsArticleController.java
@@ -18,6 +18,7 @@ import java.util.UUID;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -61,7 +62,7 @@ public class NewsArticleController implements NewsArticleApiDocs {
 
   //뉴스기사 목록 조회
   @GetMapping
-  public CursorPageResponseNewsArticleDto list(@Valid NewsArticlePageRequest request,
+  public CursorPageResponseNewsArticleDto list(@Valid @ParameterObject NewsArticlePageRequest request,
       @RequestHeader("Monew-Request-User-ID") UUID userId){
     return newsArticleService.list(request, userId);
 

--- a/src/main/java/com/springboot/monew/newsarticles/dto/request/NewsArticlePageRequest.java
+++ b/src/main/java/com/springboot/monew/newsarticles/dto/request/NewsArticlePageRequest.java
@@ -3,6 +3,8 @@ package com.springboot.monew.newsarticles.dto.request;
 import com.springboot.monew.newsarticles.enums.ArticleSource;
 import com.springboot.monew.newsarticles.enums.NewsArticleDirection;
 import com.springboot.monew.newsarticles.enums.NewsArticleOrderBy;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
@@ -19,6 +21,8 @@ public record NewsArticlePageRequest(
     UUID interestId,
 
     //출처 필터
+    //sourceIn이 배열/리스트 타입이고, 각 요소는 ArticleSource enum이다.(swagger 어노테이션)
+    @ArraySchema( schema = @Schema(implementation = ArticleSource.class) )
     List<ArticleSource> sourceIn,
 
     //날짜 범위


### PR DESCRIPTION
## 📌 작업 내용
- 뉴스 기사 목록 조회 API Swagger 문서화 개선
- sourceIn Query Parameter 바인딩 오류 해결

## 🔧 변경 사항
- NewsArticlePageRequest를 Swagger에서 Query Parameter 객체로 인식하도록 @ParameterObject 적용
- sourceIn 수동 @Parameter 문서화 제거
- Swagger의 List<ArticleSource> 직렬화 오류 수정
- cursor 파라미터 설명을 cursor|after 구조 기준으로 수정

## 반영 브랜치
`fix/#340/newsartilce-swagger` -> `dev`

## 💬 기타 참고 사항
- 기존 Swagger 설정에서 sourceIn=["NAVER"] 형태로 요청이 생성되어 Spring MVC List<ArticleSource> 바인딩 실패 발생
- @ParameterObject 및 DTO 기반 문서화 방식으로 변경 후 정상 Query Parameter 형태로 개선
- 실제 API는 Query Parameter 기반 GET 요청이며 RequestBody 방식이 아님
