### PR TITLE
[QA] 사용자 활동내역 관심사 구독 목록 10개 제한 제거 및 전체 목록 반환으로 수정

### DIFF
--- a/src/main/java/com/springboot/monew/user/document/UserActivityDocument.java
+++ b/src/main/java/com/springboot/monew/user/document/UserActivityDocument.java
@@ -31,7 +31,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @Document(collection = "user_activities")
 public class UserActivityDocument {
 
-  // 최근 활동 목록은 최대 10개까지만 유지한다.
+  // 최근 활동 목록은 최대 10개까지만 유지한다.(관심사 제외)
   private static final int RECENT_ACTIVITY_LIMIT = 10;
 
   @Id
@@ -65,11 +65,8 @@ public class UserActivityDocument {
 
   // 관심사 구독 성공 시 subscriptions에 추가한다.
   public void addSubscription(SubscriptionItem item) {
-    addRecentItem(
-        subscriptions,
-        item,
-        subscription -> subscription.interestId().equals(item.interestId())
-    );
+    subscriptions.removeIf(subscription -> subscription.interestId().equals(item.interestId()));
+    subscriptions.add(0, item);
   }
 
   // 관심사 구독 취소 시 subscriptions에서 제거한다.

--- a/src/test/java/com/springboot/monew/user/document/UserActivityDocumentTest.java
+++ b/src/test/java/com/springboot/monew/user/document/UserActivityDocumentTest.java
@@ -394,4 +394,47 @@ public class UserActivityDocumentTest {
         .doesNotContain(firstCommentId);
   }
 
+  @Test
+  @DisplayName("관심사 구독은 10개를 초과해도 잘리지 않고 사용자 활동내역 문서에 전체 목록이 최신순으로 유지된다")
+  void addSubscription_KeepsAllSubscriptions() {
+    // given
+    // 사용자 활동내역 문서를 생성한다.
+    UserActivityDocument document = new UserActivityDocument(
+        UUID.randomUUID(),
+        "test@example.com",
+        "tester",
+        Instant.now()
+    );
+
+    // 첫 번째로 구독한 관심사와 마지막으로 구독한 관심사의 id를 따로 보관해서
+    // 잘림 없이 전체가 유지되는지와 최신순 정렬이 유지되는지를 함께 검증한다.
+    UUID firstInterestId = UUID.randomUUID();
+    UUID lastInterestId = UUID.randomUUID();
+
+    // when
+    // 관심사 구독을 11개 추가한다.
+    // 기존 구현은 subscriptions도 최근 10개 제한을 적용받았기 때문에
+    // 이 테스트는 11개 모두 남아 있어야 한다는 요구사항을 검증한다.
+    for (int i = 0; i < 11; i++) {
+      UUID interestId = (i == 0) ? firstInterestId : (i == 10 ? lastInterestId : UUID.randomUUID());
+
+      document.addSubscription(new SubscriptionItem(
+          UUID.randomUUID(),
+          interestId,
+          "interest-" + i,
+          List.of("keyword-" + i),
+          Instant.now().plusSeconds(i)
+      ));
+    }
+
+    // then
+    assertThat(document.getSubscriptions()).hasSize(11);
+    // 가장 마지막에 추가한 관심사가 최신 구독으로 맨 앞에 위치해야 한다.
+    assertThat(document.getSubscriptions().get(0).interestId()).isEqualTo(lastInterestId);
+    // 가장 먼저 추가한 관심사도 삭제되지 않고 목록 안에 남아 있어야 한다.
+    assertThat(document.getSubscriptions().stream()
+        .map(SubscriptionItem::interestId))
+        .contains(firstInterestId);
+  }
+
 }

--- a/src/test/java/com/springboot/monew/user/integration/activity/UserActivityInterestIntegrationTest.java
+++ b/src/test/java/com/springboot/monew/user/integration/activity/UserActivityInterestIntegrationTest.java
@@ -24,7 +24,9 @@ import com.springboot.monew.user.repository.UserActivityOutboxRepository;
 import com.springboot.monew.user.repository.UserActivityRepository;
 import com.springboot.monew.user.repository.UserRepository;
 import com.springboot.monew.user.service.UserService;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -196,5 +198,38 @@ class UserActivityInterestIntegrationTest extends BaseIntegrationsTest {
   private InterestDto createInterest(String name, List<String> keywords) {
     // 관심사 흐름 테스트에서 공통으로 사용할 관심사를 실제 생성 서비스로 준비한다.
     return interestService.create(new InterestRegisterRequest(name, keywords));
+  }
+
+  @Test
+  @DisplayName("관심사 구독이 10개를 넘어도 사용자 활동내역 문서에는 전체 구독 목록이 유지된다")
+  void subscribe_keepsAllSubscriptionsInUserActivity() {
+    // given
+    List<InterestDto> createdInterests = new ArrayList<>();
+
+    // when
+    // 서로 유사한 이름으로 판정되지 않도록 UUID를 섞어서 관심사를 생성하고 바로 구독한다.
+    for (int i = 0; i < 11; i++) {
+      InterestDto interest = createInterest(
+          "관심사-" + UUID.randomUUID(),
+          List.of("keyword-" + i)
+      );
+      createdInterests.add(interest);
+      subscriptionService.subscribe(interest.id(), user.id());
+    }
+
+    // then
+    // 사용자 활동내역 Mongo 문서를 조회한다.
+    UserActivityDocument activity = userActivityRepository.findById(user.id()).orElseThrow();
+
+    // subscriptions는 더 이상 10개로 잘리지 않고 전체 11개가 유지되어야 한다.
+    assertThat(activity.getSubscriptions()).hasSize(11);
+
+    // 가장 마지막에 구독한 관심사가 맨 앞에 있어야 한다.
+    assertThat(activity.getSubscriptions().get(0).interestId())
+        .isEqualTo(createdInterests.get(10).id());
+
+    // 가장 먼저 구독한 관심사는 맨 뒤에 있어야 한다.
+    assertThat(activity.getSubscriptions().get(10).interestId())
+        .isEqualTo(createdInterests.get(0).id());
   }
 }


### PR DESCRIPTION
## 📌 해당 이슈카드

Closes #339

## 📌 작업 내용

- 사용자 활동내역 문서에서 관심사 구독 목록이 최근 10개로 잘리지 않도록 수정했습니다.
- 관심사 구독이 10개를 초과해도 전체 목록이 최신순으로 유지되는지 테스트를 추가했습니다.

## 🔧 변경 사항

- UserActivityDocument.addSubscription()이 공용 최근 활동 제한 로직을 사용하지 않도록 변경했습니다.
- 동일한 관심사 항목이 있을 경우 기존 항목을 제거한 뒤 최신 항목을 맨 앞에 추가하도록 처리했습니다.
- UserActivityDocumentTest에 관심사 구독 목록이 10개를 넘어도 전체가 유지되는 테스트를 추가했습니다.
- UserActivityInterestIntegrationTest에 실제 구독 흐름에서 전체 구독 목록이 유지되는 통합 테스트를 추가했습니다.

## 반영 브랜치
`hotfix/#339/user-activity-qa` -> `dev`

## 💬 기타 참고 사항
- comments, commentLikes, articleViews는 기존과 동일하게 최근 10개 제한을 유지합니다.
- 이번 수정은 subscriptions만 전체 목록을 유지하도록 변경한 것입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 사용자가 관심사를 구독할 때 모든 구독이 최신 순서대로 보관되도록 개선. 기존에는 일부 구독이 제한에 의해 제거될 수 있었던 문제 해결

* **테스트**
  * 다중 관심사 구독 시나리오에 대한 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->