### PR TITLE
[Fix] 뉴스기사 날짜 범위 조회 오류 수정

### DIFF
--- a/src/main/java/com/springboot/monew/newsarticle/controller/NewsArticleApiDocs.java
+++ b/src/main/java/com/springboot/monew/newsarticle/controller/NewsArticleApiDocs.java
@@ -184,12 +184,12 @@ public interface NewsArticleApiDocs {
       @Parameter(
           name = "publishDateFrom",
           description = "발행일 범위 시작 (선택, ISO 8601 형식)",
-          example = "2024-01-01T00:00:00.000Z"
+          example = "2024-01-01T00:00:00"
       ),
       @Parameter(
           name = "publishDateTo",
           description = "발행일 범위 종료 (선택, ISO 8601 형식)",
-          example = "2024-01-31T23:59:59.000Z"
+          example = "2024-01-31T23:59:59"
       ),
       @Parameter(
           name = "orderBy",

--- a/src/main/java/com/springboot/monew/newsarticle/dto/request/NewsArticlePageRequest.java
+++ b/src/main/java/com/springboot/monew/newsarticle/dto/request/NewsArticlePageRequest.java
@@ -8,7 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
-import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -26,8 +26,8 @@ public record NewsArticlePageRequest(
     List<ArticleSource> sourceIn,
 
     //날짜 범위
-    Instant publishDateFrom,
-    Instant publishDateTo,
+    LocalDateTime publishDateFrom,
+    LocalDateTime publishDateTo,
 
     //정렬
     @NotNull NewsArticleOrderBy orderBy,

--- a/src/main/java/com/springboot/monew/newsarticle/repository/qdsl/NewsArticleQDSLRepositoryImpl.java
+++ b/src/main/java/com/springboot/monew/newsarticle/repository/qdsl/NewsArticleQDSLRepositoryImpl.java
@@ -18,17 +18,22 @@ import com.springboot.monew.newsarticle.dto.request.NewsArticlePageRequest;
 import com.springboot.monew.newsarticle.dto.response.NewsArticleCursorRow;
 import com.springboot.monew.newsarticle.enums.NewsArticleDirection;
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 
+@Slf4j
 @Repository
 @RequiredArgsConstructor
 public class NewsArticleQDSLRepositoryImpl implements NewsArticleQDSLRepository {
 
   private final JPAQueryFactory queryFactory;
+  private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
   @Override
   public List<NewsArticleCursorRow> findNewsArticles(NewsArticlePageRequest request, UUID userId) {
@@ -175,21 +180,23 @@ public class NewsArticleQDSLRepositoryImpl implements NewsArticleQDSLRepository 
   }
 
   // 날짜 시작 범위 조건
-  private BooleanExpression publishDateGoe(Instant publishDateFrom) {
+  private BooleanExpression publishDateGoe(LocalDateTime publishDateFrom) {
     if (publishDateFrom == null) {
       return null;
     }
-
-    return newsArticle.publishedAt.goe(publishDateFrom);
+    return newsArticle.publishedAt.goe(
+        publishDateFrom.atZone(KST).toInstant()
+    );
   }
 
   // 날짜 끝 범위 조건
-  private BooleanExpression publishDateLoe(Instant publishDateTo) {
+  private BooleanExpression publishDateLoe(LocalDateTime publishDateTo) {
     if (publishDateTo == null) {
       return null;
     }
-
-    return newsArticle.publishedAt.loe(publishDateTo);
+    return newsArticle.publishedAt.loe(
+        publishDateTo.atZone(KST).toInstant()
+    );
   }
 
   // 정렬 기준에 따른 커서 조건 생성

--- a/src/test/java/com/springboot/monew/newsarticle/repository/NewsArticleRepositoryTest.java
+++ b/src/test/java/com/springboot/monew/newsarticle/repository/NewsArticleRepositoryTest.java
@@ -16,6 +16,7 @@ import com.springboot.monew.user.entity.User;
 import com.springboot.monew.user.repository.UserRepository;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.UUID;
@@ -70,9 +71,9 @@ public class NewsArticleRepositoryTest extends BaseRepositoryTest {
   void findNewsArticles_ReturnsArticles_WhenPublishDateRangeApplied() {
     // given
 
-    NewsArticle before = createArticle("before", Instant.parse("2026-04-30T00:00:00Z").minusSeconds(1));
-    NewsArticle inRange = createArticle("in-range", Instant.parse("2026-04-30T00:00:00Z").plusSeconds(3600));
-    NewsArticle after = createArticle("after", Instant.parse("2026-04-30T00:00:00Z").plusSeconds(86400));
+    NewsArticle before = createArticle("before", Instant.parse("2026-04-29T14:59:59Z"));
+    NewsArticle inRange = createArticle("in-range", Instant.parse("2026-04-29T16:00:00Z"));
+    NewsArticle after = createArticle("after", Instant.parse("2026-04-30T15:00:00Z"));
 
     newsArticleRepository.saveAll(List.of(before, inRange, after));
     flushAndClear();
@@ -81,8 +82,8 @@ public class NewsArticleRepositoryTest extends BaseRepositoryTest {
         null,
         null,
         null,
-        Instant.parse("2026-04-30T00:00:00Z"),
-        Instant.parse("2026-04-30T00:00:00Z").plusSeconds(86399),
+        LocalDateTime.of(2026, 4, 30, 0, 0, 0),
+        LocalDateTime.of(2026, 4, 30, 23, 59, 59),
         NewsArticleOrderBy.publishDate,
         NewsArticleDirection.DESC,
         null,


### PR DESCRIPTION
## 📌 작업 내용
- 뉴스기사 날짜 범위 조회 오류 수정

## 🔧 변경 사항
- 뉴스기사 조회 요청 DTO의 날짜 타입을 `Instant` → `LocalDateTime`으로 변경
- QueryDSL 날짜 조건 비교 시 `Asia/Seoul` 기준으로 `Instant` 변환 후 비교하도록 수정
- 날짜 범위 조회 요청 시 발생하던 바인딩 오류 해결
- PostgreSQL `TIMESTAMP WITH TIME ZONE`(UTC) 저장 구조에 맞춰 날짜 비교 로직 수정

## 반영 브랜치
`feature/#345/newsarticle-list` -> `dev`

## 💬 기타 참고 사항
- 프론트에서 전달하는 날짜 형식(`2026-05-01T00:00:00`)을 그대로 사용할 수 있도록 백엔드에서 처리하도록 수정했습니다.
- 프론트에서는 LocalDateTime으로 요청을 보내고 DB에 저장된 날짜는 UTC 시간의 PostgreSQL TIMSTAMP 형식이라 비교가 불가능해서 조회에 오류가 있었습니다.
- LocalDateTime으로 들어오는 요청을 그대로 받고 백쪽에서 날짜변환을 해서 DB 값과 비교도록 수정했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 뉴스 기사 날짜 필터링 처리 개선으로 타임존 인식 기능이 추가되었습니다.
  * 날짜 범위 필터링의 정확성이 향상되었습니다.

* **API 변경**
  * 뉴스 기사 페이지 요청 API의 날짜 필터 파라미터 형식이 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->