### PR TITLE
[Refactor] OOM으로 인한 메모리 조정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN mkdir -p /app/.logs \
 
 
 # JVM 실행 옵션 (기본값: 빈 문자열)
-ENV JAVA_TOOL_OPTIONS=""
+ENV JAVA_TOOL_OPTIONS="-Xms256m -Xmx512m"
 
 # builder 단계에서 만든 jar를 runtime 이미지로 복사
 #COPY할때 바로 소유자 지정

--- a/ecs-task-def.json
+++ b/ecs-task-def.json
@@ -10,8 +10,8 @@
       "name": "monew-app",
       "image": "${REPO_URI}:${IMAGE_TAG}",
       "cpu": 256,
-      "memory": 384,
-      "memoryReservation": 256,
+      "memory": 1024,
+      "memoryReservation": 768,
       "portMappings": [
         {
           "containerPort": 8080,


### PR DESCRIPTION
## 📌 작업 내용
- Dockerfile과 테스트정의에 메모리 설정

## 🔧 변경 사항
- JAVA_TOOL_OPTIONS="-Xms256m -Xmx512m"
```
"memory": 1024,
"memoryReservation": 768,
```

## 반영 브랜치
`feature/#351/newsarticle` -> `dev`

## 💬 기타 참고 사항
- ECS에서 OOM 발생이 잦습니다. (뉴스수집이나, 연속된 댓글작성)
-  task-def.json과 Dockerfile내 memory 설정하였습니다.
