### PR TITLE
[Fix]네이버 뉴스기사 수집 API 429 ERROR 해결

### DIFF
--- a/src/main/java/com/springboot/monew/newsarticle/exception/NewsArticleErrorCode.java
+++ b/src/main/java/com/springboot/monew/newsarticle/exception/NewsArticleErrorCode.java
@@ -11,7 +11,8 @@ public enum NewsArticleErrorCode implements ErrorCode {
   NEWS_ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "NA01", "뉴스기사를 찾을 수 없습니다."),
   NEWS_ARTICLE_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "NA02", "이미 삭제된 뉴스기사입니다."),
   NEWS_ARTICLE_ALREADY_VIEWED(HttpStatus.BAD_REQUEST, "NA03", "이미 조회된 뉴스기사입니다."),
-  NAVER_API_REQUEST_FAILED(HttpStatus.BAD_GATEWAY, "NA04", "네이버 뉴스 API 호출에 실패했습니다.");
+  NAVER_API_REQUEST_FAILED(HttpStatus.BAD_GATEWAY, "NA04", "네이버 뉴스 API 호출에 실패했습니다."),
+  NAVER_API_RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "NA05", "네이버 뉴스 API 호출 제한을 초과했습니다.");
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/src/main/java/com/springboot/monew/newsarticle/service/NaverNewsApiClient.java
+++ b/src/main/java/com/springboot/monew/newsarticle/service/NaverNewsApiClient.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
 
@@ -59,9 +60,24 @@ public class NaverNewsApiClient {
 
       return response == null || response.articles() == null ? List.of() : response.articles();
 
+    } catch (HttpClientErrorException.TooManyRequests ex) {
+      log.warn("네이버 API 속도 제한 발생 - query={}", query, ex);
+
+      throw new ArticleException(
+          NewsArticleErrorCode.NAVER_API_RATE_LIMIT_EXCEEDED,
+          Map.of("query", query)
+      );
+
     } catch (RestClientException ex) {
-      log.warn("Naver API 호출 실패. query={}", query, ex);
-      throw new ArticleException(NewsArticleErrorCode.NAVER_API_REQUEST_FAILED, Map.of("query", query, "ex", ex));
+      log.warn("네이버 API 호출 실패 - query={}", query, ex);
+
+      throw new ArticleException(
+          NewsArticleErrorCode.NAVER_API_REQUEST_FAILED,
+          Map.of(
+              "query", query,
+              "message", ex.getMessage()
+          )
+      );
     }
   }
 }

--- a/src/main/java/com/springboot/monew/newsarticle/service/collector/NaverArticleCollector.java
+++ b/src/main/java/com/springboot/monew/newsarticle/service/collector/NaverArticleCollector.java
@@ -3,11 +3,13 @@ package com.springboot.monew.newsarticle.service.collector;
 import com.springboot.monew.newsarticle.dto.NaverNewsItem;
 import com.springboot.monew.newsarticle.dto.response.CollectedArticle;
 import com.springboot.monew.newsarticle.enums.ArticleSource;
+import com.springboot.monew.newsarticle.exception.ArticleException;
 import com.springboot.monew.newsarticle.service.NaverNewsApiClient;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import lombok.RequiredArgsConstructor;
@@ -31,33 +33,64 @@ public class NaverArticleCollector implements ArticleCollector {
 
     log.info("네이버 뉴스 수집 시작 - keywords={}", keywords);
 
-    List<CollectedArticle> result = keywords.stream()
-        .flatMap(keyword -> naverNewsApiClient.searchNews(keyword).stream())
-        .map(this::toCollectedArticle)
-        .filter(article -> {
-          boolean valid = article.publishedAt() != null;
-          if (!valid) {
-            log.warn("publishedAt 없음으로 기사 제외 - originallink={}", article.originalLink());
-          }
-          return valid;
-        })
-        .distinct()
-        .toList();
+    //최종 수집 결과 저장 리스트
+    List<CollectedArticle> result = new ArrayList<>();
 
-    log.info("네이버 뉴스 수집 종료 - 수집된 기사 수={}", result.size());
+    //키워드별 뉴스 수집 수행
+    //stream 대신 for문을 사용해서 특정 키워드 실패시 전체 배치 중단되지 않도록 처리
+    for (String keyword : keywords) {
+      try {
 
-    return result;
+        //네이버 뉴스 API 호출
+        List<NaverNewsItem> items = naverNewsApiClient.searchNews(keyword);
+
+        // 수집한 뉴스 데이터를 내부 CollectedArticle 형태로 변환
+        result.addAll(
+            items.stream()
+                .map(this::toCollectedArticle)
+                .filter(article -> {
+                  boolean valid = article.publishedAt() != null;
+
+                  if (!valid) {
+
+                    log.warn("publishedAt 없음으로 기사 제외 - originallink={}", article.originalLink());
+                  }
+                  return valid;
+                })
+                .toList()
+        );
+        // 네이버 API 속도 제한 방지
+        // 네이버 API 속도제한(429 Too Many Requests) 방지용 sleep
+        Thread.sleep(200);
+
+      } catch (ArticleException e) {
+        log.warn("키워드 뉴스 수집 실패 - keyword={}", keyword, e);
+
+      } catch (InterruptedException e) {
+
+        // sleep 중 interrupt 발생 시 현재 스레드 interrupt 상태 복구
+        Thread.currentThread().interrupt();
+        log.warn("뉴스 수집 sleep 중 interrupt 발생");
+
+        // 배치 중단
+        break;
+      }
+    }
+    // 동일 기사 중복 제거
+    List<CollectedArticle> distinctResult = result.stream()
+            .distinct()
+            .toList();
+
+    log.info("네이버 뉴스 수집 종료 - 수집된 기사 수={}", distinctResult.size());
+
+    return distinctResult;
   }
 
   private CollectedArticle toCollectedArticle(NaverNewsItem item) {
     Instant publishedAt = parsePublishedAt(item.pubDate());
 
     if (publishedAt == null) {
-      log.warn(
-          "pubDate 파싱 실패 - originallink={}, pubDate={}",
-          item.originallink(),
-          item.pubDate()
-      );
+      log.warn("pubDate 파싱 실패 - originallink={}, pubDate={}", item.originallink(), item.pubDate());
     }
 
     return new CollectedArticle(

--- a/src/main/java/com/springboot/monew/newsarticle/service/collector/NaverArticleCollector.java
+++ b/src/main/java/com/springboot/monew/newsarticle/service/collector/NaverArticleCollector.java
@@ -75,6 +75,7 @@ public class NaverArticleCollector implements ArticleCollector {
           Thread.sleep(200);
         }catch (InterruptedException e) {
           log.warn("뉴스 수집 sleep 중 interrupt 발생");
+          Thread.currentThread().interrupt(); // 인터럽트 상태 복원
           interrupted = true;
         }
       }

--- a/src/main/java/com/springboot/monew/newsarticle/service/collector/NaverArticleCollector.java
+++ b/src/main/java/com/springboot/monew/newsarticle/service/collector/NaverArticleCollector.java
@@ -35,6 +35,7 @@ public class NaverArticleCollector implements ArticleCollector {
 
     //최종 수집 결과 저장 리스트
     List<CollectedArticle> result = new ArrayList<>();
+    Boolean interrupted = false;
 
     //키워드별 뉴스 수집 수행
     //stream 대신 for문을 사용해서 특정 키워드 실패시 전체 배치 중단되지 않도록 처리
@@ -59,20 +60,26 @@ public class NaverArticleCollector implements ArticleCollector {
                 })
                 .toList()
         );
-        // 네이버 API 속도 제한 방지
-        // 네이버 API 속도제한(429 Too Many Requests) 방지용 sleep
-        Thread.sleep(200);
+
 
       } catch (ArticleException e) {
         log.warn("키워드 뉴스 수집 실패 - keyword={}", keyword, e);
 
-      } catch (InterruptedException e) {
+      } finally {
 
-        // sleep 중 interrupt 발생 시 현재 스레드 interrupt 상태 복구
-        Thread.currentThread().interrupt();
-        log.warn("뉴스 수집 sleep 중 interrupt 발생");
+        //성공, 실패 여부와 관계없이 요청간 간격을 둔다.
+        try {
 
-        // 배치 중단
+          // 네이버 API 속도 제한 방지
+          // 네이버 API 속도제한(429 Too Many Requests) 방지용 sleep
+          Thread.sleep(200);
+        }catch (InterruptedException e) {
+          log.warn("뉴스 수집 sleep 중 interrupt 발생");
+          interrupted = true;
+        }
+      }
+      // finally 밖에서 loop 종료
+      if (interrupted) {
         break;
       }
     }


### PR DESCRIPTION
## 📌 작업 내용
- 네이버 뉴스 API 수집 안정성 개선
- 외부 API 속도 제한(429 Too Many Requests) 대응
- 키워드 단위 예외 처리 구조 적용

## 🔧 변경 사항
- NaverArticleCollector
Stream 기반 수집 구조를 for-loop 기반으로 변경
키워드별 예외 처리 적용
특정 키워드 실패 시 전체 배치가 중단되지 않도록 수정
요청 간 Thread.sleep(200) 추가하여 네이버 API 속도 제한 대응
동일 기사 중복 제거 로직 유지
- NaverNewsApiClient
HttpClientErrorException.TooManyRequests 예외 분리 처리
네이버 API 속도 제한 전용 에러 코드 추가
API 실패 로그 개선
- NewsArticleErrorCode
NAVER_API_RATE_LIMIT_EXCEEDED 추가

## 반영 브랜치
`feature/#356/navercollector` -> `dev`

## 💬 기타 참고 사항
- 기존 Stream 기반 구조에서는 특정 키워드 API 호출 실패 시 전체 뉴스 수집 배치가 중단되는 문제가 있었음
- 네이버 뉴스 API의 429 응답 발생 시 이후 키워드 수집까지 실패하는 현상 확인
- 부분 실패 허용 구조로 변경하여 배치 안정성을 개선함


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 뉴스 API 요청 제한 오류를 명확하게 구분하여 처리
  * API 요청 간 지연을 추가하여 요청 제한 발생 가능성 감소
  * 개별 검색어별 예외 처리로 일부 실패 시에도 수집 계속 진행
  * 오류 메시지에 더 자세한 정보 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->